### PR TITLE
Attempt to fix switch statement default failing to decompile if it branches at the start

### DIFF
--- a/UndertaleModLib/Decompiler/Decompiler.cs
+++ b/UndertaleModLib/Decompiler/Decompiler.cs
@@ -1453,6 +1453,23 @@ namespace UndertaleModLib.Decompiler
                         if (!caseEntries.ContainsKey(block.nextBlockTrue))
                             caseEntries.Add(block.nextBlockTrue, new List<Expression>());
                         caseEntries[block.nextBlockTrue].Add(caseExpr);
+                        if (!block.conditionalExit)
+                        {
+                            // Seems to be "default", and we simply want to go to the exit now.
+                            // This is a little hack, but it should fully work. The compiler always
+                            // emits "default" at the end it looks like. Also this navigates down the
+                            // "false" branching paths over others- this should lead to the correct
+                            // block. Without this, branching at the start of "default" will break
+                            // this switch detection.
+                            while (block.nextBlockTrue != meetPoint)
+                            {
+                                if (block.nextBlockFalse != null)
+                                    block = block.nextBlockFalse;
+                                else
+                                    block = block.nextBlockTrue;
+                            }
+                            break;
+                        }
                         block = block.nextBlockFalse;
                     }
 


### PR DESCRIPTION
Read the comments in the code.

I found evidence that the "default" statement is always put after the other conditions, which would make sense, and I made sure that it doesn't do anything weird by testing my own code.

Basically, the situation was something like this:
```gml
switch(variable)
{
    case 0:
        if (anothervariable == 0)
            somethingelse = 1;
        break;
    default:
        if (anothervariable == 0)
            somethingelse = -1;
        break;
}
```

The switch statement decompiler got all messed up once it got to `default`, because there is an immediate `if` statement there. I guess that it interpreted that as part of the switch cases... and then it interpreted the expression `anothervariable == 0` as one of the case expressions, which in the end resulted in the error `Malformed switch statement: bad condition var (self.anothervariable)`. I think there's some weird branching for `default`, and that may be why the problem didn't occur on other normal cases.

Let me know if there are any issues with this.