### PR TITLE
Add basic support for the swap variant of pop instruction

### DIFF
--- a/UndertaleModLib/Decompiler/Assembler.cs
+++ b/UndertaleModLib/Decompiler/Assembler.cs
@@ -88,7 +88,12 @@ namespace UndertaleModLib.Decompiler
 
                 case UndertaleInstruction.InstructionType.PopInstruction:
                     UndertaleInstruction.InstanceType inst = instr.TypeInst;
-                    instr.Destination = ParseVariableReference(line, vars, localvars, ref inst, instr, lookOnStack);
+                    if (instr.Type1 == UndertaleInstruction.DataType.Int16 && instr.Type2 == UndertaleInstruction.DataType.Variable)
+                    {
+                        // Special scenario?
+                        inst = (UndertaleInstruction.InstanceType)Int32.Parse(line);
+                    } else
+                        instr.Destination = ParseVariableReference(line, vars, localvars, ref inst, instr, lookOnStack);
                     instr.TypeInst = inst;
                     line = "";
                     break;

--- a/UndertaleModLib/Decompiler/Decompiler.cs
+++ b/UndertaleModLib/Decompiler/Decompiler.cs
@@ -830,6 +830,8 @@ namespace UndertaleModLib.Decompiler
                         break;
 
                     case UndertaleInstruction.Opcode.Pop:
+                        if (instr.Destination == null)
+                            throw new Exception("Unsupported pop.e.v, this is a bug seemingly with incrementing/decrementing in expressions");
                         ExpressionVar target = new ExpressionVar(instr.Destination.Target, new ExpressionConstant(UndertaleInstruction.DataType.Int16, instr.TypeInst), instr.Destination.Type);
                         Expression val = null;
                         if (instr.Type1 != UndertaleInstruction.DataType.Int32 && instr.Type1 != UndertaleInstruction.DataType.Variable)

--- a/UndertaleModLib/Models/UndertaleCode.cs
+++ b/UndertaleModLib/Models/UndertaleCode.cs
@@ -427,7 +427,8 @@ namespace UndertaleModLib.Models
                         byte TypePair = (byte)((byte)Type2 << 4 | (byte)Type1);
                         writer.Write(TypePair);
                         writer.Write((byte)Kind);
-                        writer.WriteUndertaleObject(Destination);
+                        if (Destination != null)
+                            writer.WriteUndertaleObject(Destination);
                     }
                     break;
 
@@ -562,7 +563,11 @@ namespace UndertaleModLib.Models
                         Type1 = (DataType)(TypePair & 0xf);
                         Type2 = (DataType)(TypePair >> 4);
                         if(reader.ReadByte() != (byte)Kind) throw new Exception("really shouldn't happen");
-                        Destination = reader.ReadUndertaleObject<Reference<UndertaleVariable>>();
+                        if (Type1 == DataType.Int16 && Type2 == DataType.Variable)
+                        {
+                            // Special scenario?
+                        } else
+                            Destination = reader.ReadUndertaleObject<Reference<UndertaleVariable>>();
                     }
                     break;
 
@@ -678,7 +683,10 @@ namespace UndertaleModLib.Models
                         sb.Append(TypeInst.ToString().ToLower());
                         sb.Append(".");
                     }
-                    sb.Append(Destination.ToString());
+                    if (Destination != null)
+                        sb.Append(Destination.ToString());
+                    else
+                        sb.Append(TypeInst.ToString());
                     break;
 
                 case InstructionType.PushInstruction:

--- a/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
@@ -149,12 +149,19 @@ namespace UndertaleModTool
                                 par.Inlines.Add(new Run(instr.TypeInst.ToString().ToLower()) { Foreground = typeBrush });
                                 par.Inlines.Add(new Run("."));
                             }
-                            Run runDest = new Run(instr.Destination.ToString()) { Foreground = argBrush, Cursor = Cursors.Hand };
-                            runDest.MouseDown += (sender, e) =>
+                            if (instr.Destination != null)
                             {
-                                (Application.Current.MainWindow as MainWindow).ChangeSelection(instr.Destination);
-                            };
-                            par.Inlines.Add(runDest);
+                                Run runDest = new Run(instr.Destination.ToString()) { Foreground = argBrush, Cursor = Cursors.Hand };
+                                runDest.MouseDown += (sender, e) =>
+                                {
+                                    (Application.Current.MainWindow as MainWindow).ChangeSelection(instr.Destination);
+                                };
+                                par.Inlines.Add(runDest);
+                            } else
+                            {
+                                Run runType = new Run(instr.TypeInst.ToString().ToLower()) { Foreground = argBrush, Cursor = Cursors.Arrow };
+                                par.Inlines.Add(runType);
+                            }
                             break;
 
                         case UndertaleInstruction.InstructionType.PushInstruction:


### PR DESCRIPTION
There is a seemingly undiscovered variant of the pop instruction I just noticed while writing more of the compiler. It seems, from all I've found so far, used for incrementing/decrementing chain/stacktop variable references inside of expressions. All cases I've seen are exactly in the form `pop.e.v 5` according to the GM:S 1.4 debugger, though the number may vary (it's just in TypeInst apparently). I added support for assembly/disassembly, and a temporary exception for when the instruction is encountered in the decompiler in case anyone gets errors.

Since I can't really explain it well, here's some GML:
```gml
a++;
a.b.c++;
show_message(a++);
show_message(++a);
show_message(a.b.c++); // uses the instruction
show_message(++a.b.c); // uses the instruction
```

This now disassembles to this (previously it would fail to recognize the missing 4 bytes at the end of this instruction and fail to load the file):
```
00000: push.v self.a
00002: push.e 1
00003: add.i.v
00004: pop.v.v self.a

00006: push.v self.a
00008: conv.v.i
00009: push.v [stacktop]b
00011: conv.v.i
00012: dup.i 0
00013: push.v [stacktop]c
00015: push.e 1
00016: add.i.v
00017: pop.i.v [stacktop]c

00019: push.v self.a
00021: dup.v 0
00022: push.e 1
00023: add.i.v
00024: pop.v.v self.a
00026: call.i show_message(argc=1)
00028: popz.v

00029: push.v self.a
00031: push.e 1
00032: add.i.v
00033: dup.v 0
00034: pop.v.v self.a
00036: call.i show_message(argc=1)
00038: popz.v

00039: push.v self.a
00041: conv.v.i
00042: push.v [stacktop]b
00044: conv.v.i
00045: dup.i 0
00046: push.v [stacktop]c
00048: dup.v 0
00049: pop.e.v 5
00050: push.e 1
00051: add.i.v
00052: pop.i.v [stacktop]c
00054: call.i show_message(argc=1)
00056: popz.v

00057: push.v self.a
00059: conv.v.i
00060: push.v [stacktop]b
00062: conv.v.i
00063: dup.i 0
00064: push.v [stacktop]c
00066: push.e 1
00067: add.i.v
00068: dup.v 0
00069: pop.e.v 5
00070: pop.i.v [stacktop]c
00072: call.i show_message(argc=1)
00074: popz.v
```

There are other decompilation issues with this, though I'll put that in a separate issue.