### PR TITLE
Update switch_controller_acceleration to have 3 vars

### DIFF
--- a/UndertaleModLib/Compiler/BuiltinList.cs
+++ b/UndertaleModLib/Compiler/BuiltinList.cs
@@ -2705,7 +2705,7 @@ namespace UndertaleModLib.Compiler
             Functions["switch_controller_get_supported_styles"] = new FunctionInfo(this, 0);
             Functions["switch_controller_vibration_permitted"] = new FunctionInfo(this, 0);
             Functions["switch_controller_vibrate_hd"] = new FunctionInfo(this, 6);
-            Functions["switch_controller_acceleration"] = new FunctionInfo(this, 2);
+            Functions["switch_controller_acceleration"] = new FunctionInfo(this, 3);
             Functions["switch_controller_angular_velocity"] = new FunctionInfo(this, 2);
             Functions["switch_controller_angle"] = new FunctionInfo(this, 2);
             Functions["switch_controller_direction"] = new FunctionInfo(this, 2);


### PR DESCRIPTION
Had a game with this function and 3 vars, so I guess it needs 3 ¯\\\_(ツ)_/¯