### PR TITLE
Document shader types and fix stuff in UndertaleRoom.

### DIFF
--- a/UndertaleModLib/Decompiler/AssetTypeResolver.cs
+++ b/UndertaleModLib/Decompiler/AssetTypeResolver.cs
@@ -54,7 +54,7 @@ namespace UndertaleModLib.Decompiler
 
     public enum OSType : int
     {
-        os_windows = 0,
+        os_windows = 0, // legacy constant os_win32 is equal to os_windows
         os_macosx = 1,
         os_psp = 2,
         os_ios = 3,
@@ -73,7 +73,7 @@ namespace UndertaleModLib.Decompiler
         os_ps3 = 16,
         os_xbox360 = 17,
         os_uwp = 18,
-        // constant number 19 is missing... no idea why it was skipped...
+        os_amazon = 19, // the same as android but... different?
         os_switch_beta = 20, // this one was used while switch support was in beta and changed later? In newer runtimes 20 is now os_tvos...
         os_switch = 21,
         os_unknown = -1

--- a/UndertaleModLib/Decompiler/AssetTypeResolver.cs
+++ b/UndertaleModLib/Decompiler/AssetTypeResolver.cs
@@ -55,26 +55,28 @@ namespace UndertaleModLib.Decompiler
     public enum OSType : int
     {
         os_windows = 0,
-        os_uwp = 18,
-        os_linux = 6,
         os_macosx = 1,
+        os_psp = 2,
         os_ios = 3,
         os_android = 4,
-        os_ps3 = 16,
-        os_ps4 = 14,
-        os_psvita = 12,
-        os_xboxone = 15,
-        os_unknown = -1,
-        os_3ds = 11,
-        os_bb10 = 13,
-        os_psp = 2,
         os_symbian = 5,
+        os_linux = 6,
+        os_winphone = 7,
         os_tizen = 8,
-        os_wiiu = 10,
         os_win8native = 9,
+        os_wiiu = 10,
+        os_3ds = 11,
+        os_psvita = 12,
+        os_bb10 = 13,
+        os_ps4 = 14,
+        os_xboxone = 15,
+        os_ps3 = 16,
         os_xbox360 = 17,
-        os_switch_beta = 20, // this one was used while switch support was in beta and changed later?
+        os_uwp = 18,
+        // constant number 19 is missing... no idea why it was skipped...
+        os_switch_beta = 20, // this one was used while switch support was in beta and changed later? In newer runtimes 20 is now os_tvos...
         os_switch = 21,
+        os_unknown = -1
     }
 
     public enum GamepadButton : int

--- a/UndertaleModLib/Decompiler/AssetTypeResolver.cs
+++ b/UndertaleModLib/Decompiler/AssetTypeResolver.cs
@@ -620,6 +620,7 @@ namespace UndertaleModLib.Decompiler
                 { "gamepad_button_check", new AssetIDType[] { AssetIDType.Other, AssetIDType.Enum_GamepadButton } },
                 { "gamepad_button_check_pressed", new AssetIDType[] { AssetIDType.Other, AssetIDType.Enum_GamepadButton } },
                 { "gamepad_button_check_released", new AssetIDType[] { AssetIDType.Other, AssetIDType.Enum_GamepadButton } },
+                { "gamepad_axis_value", new AssetIDType[] { AssetIDType.Other, AssetIDType.Enum_GamepadButton } },
 
                 { "buffer_create", new AssetIDType[] { AssetIDType.Other, AssetIDType.Enum_BufferKind, AssetIDType.Other } },
                 { "buffer_create_from_vertex_buffer", new AssetIDType[] { AssetIDType.Other, AssetIDType.Enum_BufferKind, AssetIDType.Other } },

--- a/UndertaleModLib/Decompiler/Decompiler.cs
+++ b/UndertaleModLib/Decompiler/Decompiler.cs
@@ -304,7 +304,7 @@ namespace UndertaleModLib.Decompiler
                     int vint = Convert.ToInt32(Value);
                     if (vint < 0) // negative value.
                         return vint.ToString();
-                    else // guaranteed be an unsigned int.
+                    else // guaranteed to be an unsigned int.
                     {
                         uint vuint = (uint)vint;
                         if (DecompileContext.ColorDictionary.ContainsKey(vuint))

--- a/UndertaleModLib/Decompiler/Decompiler.cs
+++ b/UndertaleModLib/Decompiler/Decompiler.cs
@@ -17,6 +17,30 @@ namespace UndertaleModLib.Decompiler
         public UndertaleData Data;
         public UndertaleCode TargetCode;
 
+        // Color dictionary for resolving.
+        public static Dictionary<uint, string> ColorDictionary = new Dictionary<uint, string>
+        {
+            [16776960] = "c_aqua",
+            [0] = "c_black",
+            [16711680] = "c_blue",
+            [4210752] = "c_dkgray",
+            [16711935] = "c_fuchsia",
+            [8421504] = "c_gray",
+            [32768] = "c_green",
+            [65280] = "c_lime",
+            [12632256] = "c_ltgray",
+            [128] = "c_maroon",
+            [8388608] = "c_navy",
+            [32896] = "c_olive",
+            [8388736] = "c_purple",
+            [255] = "c_red",
+            [12632256] = "c_silver",
+            [8421376] = "c_teal",
+            [16777215] = "c_white", // maximum color value
+            [65535] = "c_yellow",
+            [4235519] = "c_orange"
+        };
+
         // Settings
         public bool EnableStringLabels;
 
@@ -276,7 +300,20 @@ namespace UndertaleModLib.Decompiler
                     return ConvertToEnumStr<Boolean>(Value);
 
                 else if (AssetType == AssetIDType.Color && Value is IFormattable && !(Value is float) && !(Value is double) && !(Value is decimal))
-                    return (context.isGameMaker2 ? "0x" : "$") + ((IFormattable)Value).ToString("X8", CultureInfo.InvariantCulture);
+                {
+                    int vint = Convert.ToInt32(Value);
+                    if (vint < 0) // negative value.
+                        return vint.ToString();
+                    else // might be an unsigned int.
+                    {
+                        uint vuint = Convert.ToUInt32(Value);
+                        string dict = DecompileContext.ColorDictionary[vuint];
+                        if (dict != null)
+                            return dict;
+                        else
+                            return (context.isGameMaker2 ? "0x" : "$") + ((IFormattable)Value).ToString("X6", CultureInfo.InvariantCulture); // not a known color and not negative.
+                    }
+                }
 
                 else if (AssetType == AssetIDType.KeyboardKey)
                 {

--- a/UndertaleModLib/Decompiler/Decompiler.cs
+++ b/UndertaleModLib/Decompiler/Decompiler.cs
@@ -304,9 +304,9 @@ namespace UndertaleModLib.Decompiler
                     int vint = Convert.ToInt32(Value);
                     if (vint < 0) // negative value.
                         return vint.ToString();
-                    else // might be an unsigned int.
+                    else // guaranteed be an unsigned int.
                     {
-                        uint vuint = Convert.ToUInt32(Value);
+                        uint vuint = (uint)vint;
                         if (DecompileContext.ColorDictionary.ContainsKey(vuint))
                             return DecompileContext.ColorDictionary[vuint];
                         else

--- a/UndertaleModLib/Decompiler/Decompiler.cs
+++ b/UndertaleModLib/Decompiler/Decompiler.cs
@@ -307,9 +307,8 @@ namespace UndertaleModLib.Decompiler
                     else // might be an unsigned int.
                     {
                         uint vuint = Convert.ToUInt32(Value);
-                        string dict = DecompileContext.ColorDictionary[vuint];
-                        if (dict != null)
-                            return dict;
+                        if (DecompileContext.ColorDictionary.ContainsKey(vuint))
+                            return DecompileContext.ColorDictionary[vuint];
                         else
                             return (context.isGameMaker2 ? "0x" : "$") + ((IFormattable)Value).ToString("X6", CultureInfo.InvariantCulture); // not a known color and not negative.
                     }

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -30,7 +30,7 @@ namespace UndertaleModLib.Models
         private bool _DrawBackgroundColor = true;
         private UndertaleResourceById<UndertaleCode, UndertaleChunkCODE> _CreationCodeId = new UndertaleResourceById<UndertaleCode, UndertaleChunkCODE>();
         private RoomEntryFlags _Flags = RoomEntryFlags.EnableViews;
-        private uint _World = 0;
+        private bool _World = false;
         private uint _Top = 0;
         private uint _Left = 0;
         private uint _Right = 1024;
@@ -49,7 +49,7 @@ namespace UndertaleModLib.Models
         public bool DrawBackgroundColor { get => _DrawBackgroundColor; set { _DrawBackgroundColor = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("DrawBackgroundColor")); } }
         public UndertaleCode CreationCodeId { get => _CreationCodeId.Resource; set { _CreationCodeId.Resource = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("CreationCodeId")); } }
         public RoomEntryFlags Flags { get => _Flags; set { _Flags = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Flags")); } }
-        public uint World { get => _World; set { _World = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("World")); } }
+        public bool World { get => _World; set { _World = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("World")); } }
         public uint Top { get => _Top; set { _Top = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Top")); } }
         public uint Left { get => _Left; set { _Left = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Left")); } }
         public uint Right { get => _Right; set { _Right = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Right")); } }
@@ -140,7 +140,7 @@ namespace UndertaleModLib.Models
             GameObjects = reader.ReadUndertaleObjectPointer<UndertalePointerListLenCheck<GameObject>>();
             uint tilePtr = reader.ReadUInt32();
             Tiles = reader.GetUndertaleObjectAtAddress<UndertalePointerList<Tile>>(tilePtr);
-            World = reader.ReadUInt32();
+            World = reader.ReadBoolean();
             Top = reader.ReadUInt32();
             Left = reader.ReadUInt32();
             Right = reader.ReadUInt32();
@@ -205,8 +205,8 @@ namespace UndertaleModLib.Models
             private UndertaleResourceById<UndertaleBackground, UndertaleChunkBGND> _BackgroundDefinition = new UndertaleResourceById<UndertaleBackground, UndertaleChunkBGND>();
             private int _X = 0;
             private int _Y = 0;
-            private uint _TileX = 1;
-            private uint _TileY = 1;
+            private int _TileX = 1;
+            private int _TileY = 1;
             private int _SpeedX = 0;
             private int _SpeedY = 0;
             private bool _Stretch = false;
@@ -220,8 +220,8 @@ namespace UndertaleModLib.Models
             public UndertaleBackground BackgroundDefinition { get => _BackgroundDefinition.Resource; set { _BackgroundDefinition.Resource = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("BackgroundDefinition")); } }
             public int X { get => _X; set { _X = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("X")); UpdateStretch(); } }
             public int Y { get => _Y; set { _Y = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Y")); UpdateStretch(); } }
-            public uint TileX { get => _TileX; set { _TileX = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("TileX")); } }
-            public uint TileY { get => _TileY; set { _TileY = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("TileY")); } }
+            public int TileX { get => _TileX; set { _TileX = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("TileX")); } }
+            public int TileY { get => _TileY; set { _TileY = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("TileY")); } }
             public int SpeedX { get => _SpeedX; set { _SpeedX = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("SpeedX")); } }
             public int SpeedY { get => _SpeedY; set { _SpeedY = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("SpeedY")); } }
             public bool Stretch { get => _Stretch; set { _Stretch = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Stretch")); UpdateStretch(); } }
@@ -265,8 +265,8 @@ namespace UndertaleModLib.Models
                 _BackgroundDefinition = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleBackground, UndertaleChunkBGND>>();
                 X = reader.ReadInt32();
                 Y = reader.ReadInt32();
-                TileX = reader.ReadUInt32();
-                TileY = reader.ReadUInt32();
+                TileX = reader.ReadInt32();
+                TileY = reader.ReadInt32();
                 SpeedX = reader.ReadInt32();
                 SpeedY = reader.ReadInt32();
                 Stretch = reader.ReadBoolean();

--- a/UndertaleModLib/Models/UndertaleShader.cs
+++ b/UndertaleModLib/Models/UndertaleShader.cs
@@ -54,8 +54,8 @@ namespace UndertaleModLib.Models
         public UndertaleRawShaderData HLSL11_PixelData;
         public UndertaleRawShaderData PSSL_VertexData;
         public UndertaleRawShaderData PSSL_PixelData;
-        public UndertaleRawShaderData Cg_VertexData;
-        public UndertaleRawShaderData Cg_PixelData;
+        public UndertaleRawShaderData Cg_PSVita_VertexData;
+        public UndertaleRawShaderData Cg_PSVita_PixelData;
         public UndertaleRawShaderData Cg_PS3_VertexData;
         public UndertaleRawShaderData Cg_PS3_PixelData;
 
@@ -69,8 +69,8 @@ namespace UndertaleModLib.Models
             HLSL11_PixelData = new UndertaleRawShaderData();
             PSSL_VertexData = new UndertaleRawShaderData();
             PSSL_PixelData = new UndertaleRawShaderData();
-            Cg_VertexData = new UndertaleRawShaderData();
-            Cg_PixelData = new UndertaleRawShaderData();
+            Cg_PSVita_VertexData = new UndertaleRawShaderData();
+            Cg_PSVita_PixelData = new UndertaleRawShaderData();
             Cg_PS3_VertexData = new UndertaleRawShaderData();
             Cg_PS3_PixelData = new UndertaleRawShaderData();
         }
@@ -118,8 +118,8 @@ namespace UndertaleModLib.Models
 
             PSSL_VertexData.Serialize(writer);
             PSSL_PixelData.Serialize(writer);
-            Cg_VertexData.Serialize(writer);
-            Cg_PixelData.Serialize(writer);
+            Cg_PSVita_VertexData.Serialize(writer);
+            Cg_PSVita_PixelData.Serialize(writer);
             Cg_PS3_VertexData.Serialize(writer);
             Cg_PS3_PixelData.Serialize(writer);
 
@@ -149,17 +149,17 @@ namespace UndertaleModLib.Models
                 PSSL_PixelData.WriteData(writer);
             }
 
-            if (!Cg_VertexData.IsNull)
+            if (!Cg_PSVita_VertexData.IsNull)
             {
                 WritePadding(writer, 7);
 
-                Cg_VertexData.WriteData(writer);
+                Cg_PSVita_VertexData.WriteData(writer);
             }
-            if (!Cg_PixelData.IsNull)
+            if (!Cg_PSVita_PixelData.IsNull)
             {
                 WritePadding(writer, 7);
 
-                Cg_PixelData.WriteData(writer);
+                Cg_PSVita_PixelData.WriteData(writer);
             }
 
             if (!Cg_PS3_VertexData.IsNull)
@@ -198,8 +198,8 @@ namespace UndertaleModLib.Models
 
             PSSL_VertexData.Unserialize(reader);
             PSSL_PixelData.Unserialize(reader);
-            Cg_VertexData.Unserialize(reader);
-            Cg_PixelData.Unserialize(reader);
+            Cg_PSVita_VertexData.Unserialize(reader);
+            Cg_PSVita_PixelData.Unserialize(reader);
             Cg_PS3_VertexData.Unserialize(reader);
             Cg_PS3_PixelData.Unserialize(reader);
 
@@ -249,28 +249,28 @@ namespace UndertaleModLib.Models
 
                 // Calculate length of data
                 uint next = 0;
-                if (!Cg_VertexData.IsNull)
-                    next = Cg_VertexData._Position;
+                if (!Cg_PSVita_VertexData.IsNull)
+                    next = Cg_PSVita_VertexData._Position;
                 else
                     next = _EntryEnd;
                 int length = (int)(next - reader.Position);
                 PSSL_PixelData.ReadData(reader, length);
             }
 
-            if (!Cg_VertexData.IsNull)
+            if (!Cg_PSVita_VertexData.IsNull)
             {
                 ReadPadding(reader, 7);
 
                 // Calculate length of data
                 uint next = 0;
-                if (!Cg_PixelData.IsNull)
-                    next = Cg_PixelData._Position;
+                if (!Cg_PSVita_PixelData.IsNull)
+                    next = Cg_PSVita_PixelData._Position;
                 else
                     next = _EntryEnd;
                 int length = (int)(next - reader.Position);
-                Cg_VertexData.ReadData(reader, length);
+                Cg_PSVita_VertexData.ReadData(reader, length);
             }
-            if (!Cg_PixelData.IsNull)
+            if (!Cg_PSVita_PixelData.IsNull)
             {
                 ReadPadding(reader, 7);
 
@@ -281,7 +281,7 @@ namespace UndertaleModLib.Models
                 else
                     next = _EntryEnd;
                 int length = (int)(next - reader.Position);
-                Cg_PixelData.ReadData(reader, length);
+                Cg_PSVita_PixelData.ReadData(reader, length);
             }
 
             if (!Cg_PS3_VertexData.IsNull)
@@ -308,18 +308,18 @@ namespace UndertaleModLib.Models
             }
         }
 
-        // The "unknown" types are actually known, but what they correspond to is unknown.
-        // They are PSSL (PlayStation Shader Language), Cg, and Cg_PS3 (for PS3 seemingly)
-        // This enum is not the direct value in the file
+        // PSSL is a shading language used only in PS4, based on HLSL11.
+        // Cg stands for "C for graphics" made by NVIDIA and used in PSVita and PS3 (they have their own variants of Cg), based on HLSL9.
+        // All console shaders (and HLSL11?) are compiled using confidential SDK tools when GMAssetCompiler builds the game (for PSVita it's psp2cgc shader compiler).
         public enum ShaderType : uint
         {
             GLSL_ES = 1,
             GLSL = 2,
             HLSL9 = 3,
             HLSL11 = 4,
-            Unknown2 = 5,
-            Unknown3 = 6,
-            Unknown4 = 7
+            PSSL = 5,
+            Cg_PSVita = 6,
+            Cg_PS3 = 7
         }
 
         public class UndertaleRawShaderData


### PR DESCRIPTION
in UndertaleRoom "World" is just a boolean indicating "Is this room a physics world or not?" it can't be anything other than 0 or 1.

also TileX and TileY can be set to negative numbers in IDE.

and added some more info about shaders.

upd: added `gamepad_axis_value` to AssetTypeResolver
upd1: added `os_winphone` constant to OSType enum and sorted it a little bit so it'll look nicer.
upd2: improved color decompilation.
upd3: did some minor corrections, ready to merge!

Have a nice day!