### PR TITLE
Fix Bytecode 15 code editing

### DIFF
--- a/UndertaleModLib/UndertaleData.cs
+++ b/UndertaleModLib/UndertaleData.cs
@@ -257,14 +257,15 @@ namespace UndertaleModLib
                 if (!bytecode14)
                 {
                     if (data.InstanceVarCount == data.InstanceVarCountAgain)
-                    { // Example games that use this mode: Undertale v1.08, Undertale v1.11.
+                    { // Bytecode 16+.
                         data.InstanceVarCount++;
                         data.InstanceVarCountAgain++;
                     }
                     else
-                    { // Example Games which use this mode: Undertale v1.001.
-                        if (inst == UndertaleInstruction.InstanceType.Self)
+                    { // Bytecode 15.
+                        if (inst == UndertaleInstruction.InstanceType.Self && !isBuiltin)
                         {
+			    oldId = data.InstanceVarCountAgain;
                             data.InstanceVarCountAgain++;
                         }
                         else if (inst == UndertaleInstruction.InstanceType.Global)


### PR DESCRIPTION
Fixes the variable re-assigning issue in which adding more than 1 new variable in the code editor would make the new vars be duplicates of the last assigned one in bytecode 15 games.