### PR TITLE
Direct Padding

### DIFF
--- a/UndertaleModLib/Models/UndertaleEmbeddedAudio.cs
+++ b/UndertaleModLib/Models/UndertaleEmbeddedAudio.cs
@@ -25,8 +25,7 @@ namespace UndertaleModLib.Models
 
         public void SerializePadding(UndertaleWriter writer)
         {
-            while (writer.Position % 4 != 0)
-                writer.Write((byte)0);
+            writer.Position += (4 - (writer.Position % 4)) % 4;
         }
 
         public void Unserialize(UndertaleReader reader)

--- a/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
+++ b/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
@@ -39,17 +39,16 @@ namespace UndertaleModLib.Models
         public void SerializeBlob(UndertaleWriter writer)
         {
             // padding
-            while (writer.Position % 0x80 != 0)
-                writer.Write((byte)0);
+            writer.Position += (0x80 - (writer.Position % 0x80)) % 0x80;
 
             writer.WriteUndertaleObject(TextureData);
         }
 
         public void UnserializeBlob(UndertaleReader reader)
         {
-            while (reader.Position % 0x80 != 0)
-                if (reader.ReadByte() != 0)
-                    throw new IOException("Padding error!");
+            reader.Position += (0x80 - (reader.Position % 0x80)) % 0x80 - 1;
+            if (reader.ReadByte() != 0)
+                throw new IOException("Padding error!");
 
             reader.ReadUndertaleObject(TextureData);
         }

--- a/UndertaleModLib/Models/UndertaleSequence.cs
+++ b/UndertaleModLib/Models/UndertaleSequence.cs
@@ -321,15 +321,14 @@ namespace UndertaleModLib.Models
         {
             public virtual void Serialize(UndertaleWriter writer)
             {
-                while (writer.Position % 4 != 0)
-                    writer.Write((byte)0);
+                writer.Position += (4 - (writer.Position % 4)) % 4;
             }
 
             public virtual void Unserialize(UndertaleReader reader)
             {
                 while (reader.Position % 4 != 0)
                     if (reader.ReadByte() != 0)
-                        throw new IOException("Padding error!");
+                    throw new IOException("Padding error!");
             }
         }
 

--- a/UndertaleModLib/Models/UndertaleSprite.cs
+++ b/UndertaleModLib/Models/UndertaleSprite.cs
@@ -212,11 +212,9 @@ namespace UndertaleModLib.Models
             }
             if (SVersion != 2)
             {
-                while (total % 4 != 0)
-                {
-                    writer.Write((byte)0);
-                    total++;
-                }
+                uint PaddingFix = (4 - (total % 4)) % 4;
+                writer.Position += PaddingFix;
+                total += PaddingFix;
                 Debug.Assert(total == CalculateMaskDataSize(Width, Height, (uint)CollisionMasks.Count));
             }
         }

--- a/UndertaleModLib/UndertaleChunks.cs
+++ b/UndertaleModLib/UndertaleChunks.cs
@@ -417,8 +417,7 @@ namespace UndertaleModLib
             base.SerializeChunk(writer);
 
             // padding
-            while (writer.Position % 0x80 != 0)
-                writer.Write((byte)0);
+            writer.Position += (0x80 - (writer.Position % 0x80)) % 0x80;
         }
 
         internal override void UnserializeChunk(UndertaleReader reader)
@@ -426,8 +425,8 @@ namespace UndertaleModLib
             base.UnserializeChunk(reader);
 
             // padding
-            while (reader.Position % 0x80 != 0)
-                if (reader.ReadByte() != 0)
+            reader.Position += (0x80 - (reader.Position % 0x80)) % 0x80 - 1;
+            if (reader.ReadByte() != 0)
                     throw new IOException("Padding error in STRG");
         }
     }
@@ -446,8 +445,7 @@ namespace UndertaleModLib
 
             // padding
             // TODO: Maybe the padding is more global and every chunk is padded to 4 byte boundaries?
-            while (writer.Position % 4 != 0)
-                writer.Write((byte)0);
+            writer.Position += (4 - (writer.Position % 4)) % 4;
         }
 
         internal override void UnserializeChunk(UndertaleReader reader)
@@ -459,9 +457,9 @@ namespace UndertaleModLib
                 obj.UnserializeBlob(reader);
 
             // padding
-            while (reader.Position % 4 != 0)
-                if (reader.ReadByte() != 0)
-                    throw new IOException("Padding error!");
+            reader.Position += (4 - (reader.Position % 4)) % 4 - 1;
+            if (reader.ReadByte() != 0)
+                throw new IOException("Padding error!");
         }
     }
 
@@ -558,8 +556,7 @@ namespace UndertaleModLib
             if (writer.undertaleData.GeneralInfo.Major < 2)
                 throw new InvalidOperationException();
 
-            while (writer.Position % 4 != 0)
-                writer.Write((byte)0);
+            writer.Position += (4 - (writer.Position % 4)) % 4;
 
             writer.Write((uint)1); // Version
 
@@ -572,9 +569,9 @@ namespace UndertaleModLib
                 throw new InvalidOperationException();
 
             // Padding
-            while (reader.Position % 4 != 0)
-                if (reader.ReadByte() != 0)
-                    throw new IOException("Padding error!");
+            reader.Position += (4 - (reader.Position % 4)) % 4 - 1;
+            if (reader.ReadByte() != 0)
+                throw new IOException("Padding error!");
 
             if (reader.ReadUInt32() != 1)
                 throw new IOException("Expected ACRV version 1");
@@ -593,8 +590,7 @@ namespace UndertaleModLib
             if (writer.undertaleData.GeneralInfo.Major < 2)
                 throw new InvalidOperationException();
 
-            while (writer.Position % 4 != 0)
-                writer.Write((byte)0);
+            writer.Position += (4 - (writer.Position % 4)) % 4;
 
             writer.Write((uint)1); // Version
 
@@ -607,9 +603,9 @@ namespace UndertaleModLib
                 throw new InvalidOperationException();
 
             // Padding
-            while (reader.Position % 4 != 0)
-                if (reader.ReadByte() != 0)
-                    throw new IOException("Padding error!");
+            reader.Position += (4 - (reader.Position % 4)) % 4 - 1;
+            if (reader.ReadByte() != 0)
+                throw new IOException("Padding error!");
 
             if (reader.ReadUInt32() != 1)
                 throw new IOException("Expected SEQN version 1");
@@ -628,8 +624,7 @@ namespace UndertaleModLib
             if (writer.undertaleData.GeneralInfo.Major < 2)
                 throw new InvalidOperationException();
 
-            while (writer.Position % 4 != 0)
-                writer.Write((byte)0);
+            writer.Position += (4 - (writer.Position % 4)) % 4;
 
             writer.Write((uint)1); // Version
 
@@ -642,9 +637,9 @@ namespace UndertaleModLib
                 throw new InvalidOperationException();
 
             // Padding
-            while (reader.Position % 4 != 0)
-                if (reader.ReadByte() != 0)
-                    throw new IOException("Padding error!");
+            reader.Position += (4 - (reader.Position % 4)) % 4 - 1;
+            if (reader.ReadByte() != 0)
+                throw new IOException("Padding error!");
 
             if (reader.ReadUInt32() != 1)
                 throw new IOException("Expected TAGS version 1");


### PR DESCRIPTION
Jumps straight to desired address without looping through the file while loading or saving. By default, jumping to a higher address on a new file will zero the previous bytes, so there is no need to constantly write zeros. This may increase performance...