### PR TITLE
Add a safety check to remove null layers

### DIFF
--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -196,11 +196,8 @@ namespace UndertaleModLib.Models
 
         public void SetupRoom()
         {
-            foreach (UndertaleRoom.Layer layer in Layers.ToList())
-            {
-                if (layer != null)
-                    layer.ParentRoom = this;
-            }
+            foreach (UndertaleRoom.Layer layer in Layers)
+                layer?.ParentRoom = this;
             foreach (UndertaleRoom.Background bgnd in Backgrounds)
                 bgnd.ParentRoom = this;
         }

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -197,7 +197,10 @@ namespace UndertaleModLib.Models
         public void SetupRoom()
         {
             foreach (UndertaleRoom.Layer layer in Layers)
-                layer?.ParentRoom = this;
+            {
+                if (layer != null)
+                    layer.ParentRoom = this;
+            }
             foreach (UndertaleRoom.Background bgnd in Backgrounds)
                 bgnd.ParentRoom = this;
         }

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -80,13 +80,9 @@ namespace UndertaleModLib.Models
         {
             if (writer.undertaleData.GeneralInfo.Major >= 2)
             {
-                foreach (var layer in Layers.ToList())
+                foreach (var layer in Layers)
                 {
-                    if (layer == null)
-                    {
-                        Layers.Remove(layer);
-                    }
-                    else if (layer.InstancesData != null)
+                    if (layer.InstancesData != null)
                     {
                         foreach (var inst in layer.InstancesData.Instances)
                         {
@@ -204,10 +200,7 @@ namespace UndertaleModLib.Models
             {
                 if (layer != null)
                     layer.ParentRoom = this;
-                else
-                    Layers.Remove(layer);
             }
-
             foreach (UndertaleRoom.Background bgnd in Backgrounds)
                 bgnd.ParentRoom = this;
         }

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -80,9 +80,13 @@ namespace UndertaleModLib.Models
         {
             if (writer.undertaleData.GeneralInfo.Major >= 2)
             {
-                foreach (var layer in Layers)
+                foreach (var layer in Layers.ToList())
                 {
-                    if (layer.InstancesData != null)
+                    if (layer == null)
+                    {
+                        Layers.Remove(layer);
+                    }
+                    else if (layer.InstancesData != null)
                     {
                         foreach (var inst in layer.InstancesData.Instances)
                         {

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -196,8 +196,13 @@ namespace UndertaleModLib.Models
 
         public void SetupRoom()
         {
-            foreach (UndertaleRoom.Layer layer in Layers)
-                layer.ParentRoom = this;
+            foreach (UndertaleRoom.Layer layer in Layers.ToList())
+            {
+                if (layer != null)
+                    layer.ParentRoom = this;
+                else
+                    Layers.Remove(layer);
+            }
 
             foreach (UndertaleRoom.Background bgnd in Backgrounds)
                 bgnd.ParentRoom = this;

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Win32;
+using Microsoft.Win32;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -661,8 +661,10 @@ namespace UndertaleModTool
         {
             CompositeCollection collection = new CompositeCollection();
             IList<UndertaleRoom.Layer> layers = value as IList<UndertaleRoom.Layer>;
-            foreach (var layer in layers.OrderByDescending((x) => x.LayerDepth))
+            foreach (var layer in layers.OrderByDescending((x) => x?.LayerDepth ?? 0))
             {
+                if (layer == null)
+                    continue;
                 switch (layer.LayerType)
                 {
                     case UndertaleRoom.LayerType.Background:


### PR DESCRIPTION
Prevent crashes of UndertaleModTool when opening a room with a null layer by removing the null layer