### PR TITLE
Fix issue #394

### DIFF
--- a/UndertaleModTool/Editors/UndertaleExtensionEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleExtensionEditor.xaml
@@ -61,7 +61,7 @@
                 <DataGridTemplateColumn Header="Files" Width="*">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <local:UndertaleObjectReference Margin="23,3,3,3" ObjectReference="{Binding Path=., Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ObjectType="{x:Type undertale:UndertaleExtensionFile}"/>
+                            <local:UndertaleObjectReference Margin="23,3,3,3" ObjectReference="{Binding Path=., Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ObjectType="{x:Type undertale:UndertaleExtensionFile}" CanRemove="False"/>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>


### PR DESCRIPTION
The title.
Same thing is done in many modtool editors, just prevent setting object reference to null :/
But hey, it works.

cc @Grossley 