### PR TITLE
A workaround for GMS2.3+ games with fonts.

### DIFF
--- a/UndertaleModLib/Models/UndertaleFont.cs
+++ b/UndertaleModLib/Models/UndertaleFont.cs
@@ -141,9 +141,10 @@ namespace UndertaleModLib.Models
             DisplayName = reader.ReadUndertaleString();
             EmSize = reader.ReadUInt32();
             EmSizeIsFloat = false;
-            if (EmSize > 100)
+
+            // since the float is always written negated, it has the first bit set.
+            if ((EmSize & (1 << 31)) != 0)
             {
-                // absurd! GM:S 1.4's IDE doesn't even let you set the size >100! not sure about GMS 2, but still weird and wrong.
                 float fsize = -BitConverter.ToSingle(BitConverter.GetBytes(EmSize), 0);
                 EmSize = (uint)fsize;
                 EmSizeIsFloat = true;


### PR DESCRIPTION
Kinda ported over from DogScepter.
Since in ModTool the size is read as an unsigned integer, we just need to check if it's higher than 100.
Why would anyone even use fonts that are bigger than 100? That's the limit in GM:S 1.4 IDE, not sure about GMS 2.