### PR TITLE
Add scripts to import and export all Tilesets/Backgrounds

### DIFF
--- a/UndertaleModTool/ExperimentalScripts/ImportAllTilesets.csx
+++ b/UndertaleModTool/ExperimentalScripts/ImportAllTilesets.csx
@@ -1,0 +1,41 @@
+// Adapted from original script by Grossley
+
+using System.Text;
+using System;
+using System.IO;
+using System.Drawing;
+using System.Threading;
+using System.Threading.Tasks;
+
+// Setup root export folder.
+string winFolder = GetFolder(FilePath); // The folder data.win is located in.
+
+string GetFolder(string path)
+{
+	return Path.GetDirectoryName(path) + Path.DirectorySeparatorChar;
+}
+
+// Folder Check One
+if (!Directory.Exists(winFolder + "Export_Tilesets\\"))
+{
+	ScriptError("There is no 'Export_Tilesets' folder to import.", "Error: Nothing to import.");
+	return;
+}
+
+string subPath = winFolder + "Export_Tilesets";
+int i = 0;
+foreach (var tileset in Data.Backgrounds) 
+{
+    UndertaleBackground target = tileset as UndertaleBackground;
+    try 
+    {
+        //byte[] data = File.ReadAllBytes(subPath + "\\" + i + ".png");
+        Bitmap img = new Bitmap(subPath + "\\" + tileset.Name.Content + ".png");
+        target.Texture.ReplaceTexture((Image)img);
+    }
+    catch (Exception ex) 
+    {
+	    ScriptMessage("Failed to import file number " + i + " due to: " + ex.Message);
+    }
+    i++;
+}

--- a/UndertaleModTool/ExperimentalScripts/ImportAllTilesets.csx
+++ b/UndertaleModTool/ExperimentalScripts/ImportAllTilesets.csx
@@ -10,6 +10,10 @@ using System.Threading.Tasks;
 // Setup root export folder.
 string winFolder = GetFolder(FilePath); // The folder data.win is located in.
 
+int progress = 0;
+string subPath = winFolder + "Export_Tilesets";
+int i = 0;
+
 string GetFolder(string path)
 {
 	return Path.GetDirectoryName(path) + Path.DirectorySeparatorChar;
@@ -22,20 +26,36 @@ if (!Directory.Exists(winFolder + "Export_Tilesets\\"))
 	return;
 }
 
-string subPath = winFolder + "Export_Tilesets";
-int i = 0;
-foreach (var tileset in Data.Backgrounds) 
+
+UpdateProgress();
+await ImportTilesets();
+HideProgressBar();
+ScriptMessage("Import Complete.");
+
+
+void UpdateProgress()
+{
+    UpdateProgressBar(null, "Tilesets", progress++, Data.Backgrounds.Count);
+}
+
+
+async Task ImportTilesets()
+{
+    await Task.Run(() => Parallel.ForEach(Data.Backgrounds, ImportTileset));
+}
+
+void ImportTileset(UndertaleBackground tileset)
 {
     UndertaleBackground target = tileset as UndertaleBackground;
-    try 
+    try
     {
-        //byte[] data = File.ReadAllBytes(subPath + "\\" + i + ".png");
         Bitmap img = new Bitmap(subPath + "\\" + tileset.Name.Content + ".png");
         target.Texture.ReplaceTexture((Image)img);
     }
-    catch (Exception ex) 
+    catch (Exception ex)
     {
-	    ScriptMessage("Failed to import file number " + i + " due to: " + ex.Message);
+        ScriptMessage("Failed to import file number " + i + " due to: " + ex.Message);
     }
     i++;
+    UpdateProgress();
 }

--- a/UndertaleModTool/SampleScripts/ExportAllTilesets.csx
+++ b/UndertaleModTool/SampleScripts/ExportAllTilesets.csx
@@ -1,0 +1,46 @@
+﻿using System.Text;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using UndertaleModLib.Util;
+
+int progress = 0;
+string texFolder = GetFolder(FilePath) + "Export_Tilesets" + Path.DirectorySeparatorChar;
+TextureWorker worker = new TextureWorker();
+
+if (Directory.Exists(texFolder))
+{
+    ScriptError("A texture export already exists. Please remove it.", "Error");
+    return;
+}
+
+Directory.CreateDirectory(texFolder);
+
+UpdateProgress();
+await DumpTilesets();
+worker.Cleanup();
+HideProgressBar();
+ScriptMessage("Export Complete.\n\nLocation: " + texFolder);
+
+void UpdateProgress()
+{
+    UpdateProgressBar(null, "Tilesets", progress++, Data.Backgrounds.Count);
+}
+
+string GetFolder(string path) 
+{
+    return Path.GetDirectoryName(path) + Path.DirectorySeparatorChar;
+}
+
+
+async Task DumpTilesets()
+{
+    await Task.Run(() => Parallel.ForEach(Data.Backgrounds, DumpTileset));
+}
+
+void DumpTileset(UndertaleBackground tileset) 
+{
+	worker.ExportAsPNG(tileset.Texture, texFolder + tileset.Name.Content + ".png");
+    UpdateProgress();
+}


### PR DESCRIPTION
 Added scripts that exports all tilesets/backgrounds in the current project as well as an experimental script to import all of those back in again.
 
 I followed the current structure, which is why the import script is in the experimental folder, where as the export script is in the sample folder.
 
I named the script after tilesets, as well as the variables inside the script, because the project I was working on used more Tilesets than Backgrounds there.
