### PR TITLE
Add convenience EventHandlerFor functions

### DIFF
--- a/UndertaleModLib/Models/UndertaleGameObject.cs
+++ b/UndertaleModLib/Models/UndertaleGameObject.cs
@@ -175,9 +175,24 @@ namespace UndertaleModLib.Models
             return code;
         }
 
+        public UndertaleCode EventHandlerFor(EventType type, UndertaleData data)
+        {
+            return EventHandlerFor(type, data.Strings, data.Code, data.CodeLocals);
+        }
+
+        public UndertaleCode EventHandlerFor(EventType type, uint subtype, UndertaleData data)
+        {
+            return EventHandlerFor(type, subtype, data.Strings, data.Code, data.CodeLocals);
+        }
+
         public UndertaleCode EventHandlerFor(EventType type, IList<UndertaleString> strg, IList<UndertaleCode> codelist, IList<UndertaleCodeLocals> localslist)
         {
             return EventHandlerFor(type, 0u, strg, codelist, localslist);
+        }
+
+        public UndertaleCode EventHandlerFor(EventType type, EventSubtypeKey subtype, UndertaleData data)
+        {
+            return EventHandlerFor(type, subtype, data.Strings, data.Code, data.CodeLocals);
         }
 
         public UndertaleCode EventHandlerFor(EventType type, EventSubtypeKey subtype, IList<UndertaleString> strg, IList<UndertaleCode> codelist, IList<UndertaleCodeLocals> localslist)
@@ -187,11 +202,21 @@ namespace UndertaleModLib.Models
             return EventHandlerFor(type, (uint)subtype, strg, codelist, localslist);
         }
 
+        public UndertaleCode EventHandlerFor(EventType type, EventSubtypeStep subtype, UndertaleData data)
+        {
+            return EventHandlerFor(type, subtype, data.Strings, data.Code, data.CodeLocals);
+        }
+
         public UndertaleCode EventHandlerFor(EventType type, EventSubtypeStep subtype, IList<UndertaleString> strg, IList<UndertaleCode> codelist, IList<UndertaleCodeLocals> localslist)
         {
             if (type != EventType.Step)
                 throw new InvalidOperationException();
             return EventHandlerFor(type, (uint)subtype, strg, codelist, localslist);
+        }
+
+        public UndertaleCode EventHandlerFor(EventType type, EventSubtypeMouse subtype, UndertaleData data)
+        {
+            return EventHandlerFor(type, subtype, data.Strings, data.Code, data.CodeLocals);
         }
 
         public UndertaleCode EventHandlerFor(EventType type, EventSubtypeMouse subtype, IList<UndertaleString> strg, IList<UndertaleCode> codelist, IList<UndertaleCodeLocals> localslist)
@@ -200,14 +225,24 @@ namespace UndertaleModLib.Models
                 throw new InvalidOperationException();
             return EventHandlerFor(type, (uint)subtype, strg, codelist, localslist);
         }
-		
-		public UndertaleCode EventHandlerFor(EventType type, EventSubtypeOther subtype, IList<UndertaleString> strg, IList<UndertaleCode> codelist, IList<UndertaleCodeLocals> localslist)
+
+        public UndertaleCode EventHandlerFor(EventType type, EventSubtypeOther subtype, UndertaleData data)
+        {
+            return EventHandlerFor(type, subtype, data.Strings, data.Code, data.CodeLocals);
+        }
+
+        public UndertaleCode EventHandlerFor(EventType type, EventSubtypeOther subtype, IList<UndertaleString> strg, IList<UndertaleCode> codelist, IList<UndertaleCodeLocals> localslist)
         {
             if (type != EventType.Other)
                 throw new InvalidOperationException();
             return EventHandlerFor(type, (uint)subtype, strg, codelist, localslist);
         }
-        
+
+        public UndertaleCode EventHandlerFor(EventType type, EventSubtypeDraw subtype, UndertaleData data)
+        {
+            return EventHandlerFor(type, subtype, data.Strings, data.Code, data.CodeLocals);
+        }
+
         public UndertaleCode EventHandlerFor(EventType type, EventSubtypeDraw subtype, IList<UndertaleString> strg, IList<UndertaleCode> codelist, IList<UndertaleCodeLocals> localslist)
         {
             if (type != EventType.Draw)

--- a/UndertaleModLib/UndertaleChunks.cs
+++ b/UndertaleModLib/UndertaleChunks.cs
@@ -639,13 +639,18 @@ namespace UndertaleModLib
             if (reader.undertaleData.GeneralInfo.Major < 2)
                 throw new InvalidOperationException();
 
+            // Apparently SEQN can be empty
+            if (Length == 0)
+                return;
+
             // Padding
             while (reader.Position % 4 != 0)
                 if (reader.ReadByte() != 0)
                     throw new IOException("Padding error!");
 
-            if (reader.ReadUInt32() != 1)
-                throw new IOException("Expected SEQN version 1");
+            uint version = reader.ReadUInt32();
+            if (version != 1)
+                throw new IOException("Expected SEQN version 1, got " + version.ToString());
 
             base.UnserializeChunk(reader);
         }


### PR DESCRIPTION
This gives the option to pass an instance of UndertaleData instead of passing in Data.Strings, Data.Code, and Data.CodeLocals explicitly.