### PR TITLE
IPC with AUMI

### DIFF
--- a/UndertaleModLib/AumiIPC.cs
+++ b/UndertaleModLib/AumiIPC.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UndertaleModLib
+{
+    public struct IpcMessage_t
+    {
+        public short FuncID;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 510)]
+        public byte[] Buffer;
+
+        public byte[] RawBytes()
+        {
+            var stream = new MemoryStream();
+            var writer = new BinaryWriter(stream);
+
+            writer.Write(this.FuncID);
+
+            if (this.Buffer != null)
+                writer.Write(this.Buffer, 0, 510);
+
+            return stream.ToArray();
+        }
+    };
+
+    public struct IpcReply_t
+    {
+        public int AUMIResult; //Always contains a value.
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 124)]
+        public byte[] Buffer;
+
+        public static IpcReply_t FromBytes(byte[] bytes)
+        {
+            var reader = new BinaryReader(new MemoryStream(bytes));
+
+            var s = default(IpcReply_t);
+
+            s.AUMIResult = reader.ReadInt32();
+            s.Buffer = reader.ReadBytes(124);
+
+            return s;
+        }
+    };
+}

--- a/UndertaleModLib/AumiIPC.cs
+++ b/UndertaleModLib/AumiIPC.cs
@@ -30,7 +30,7 @@ namespace UndertaleModLib
 
     public struct IpcReply_t
     {
-        public int AUMIResult; //Always contains a value.
+        public int AUMIResult; // Always contains a value.
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = 128)]
         public byte[] Buffer;
 

--- a/UndertaleModLib/AumiIPC.cs
+++ b/UndertaleModLib/AumiIPC.cs
@@ -11,18 +11,18 @@ namespace UndertaleModLib
     public struct IpcMessage_t
     {
         public short FuncID;
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 510)]
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 512)]
         public byte[] Buffer;
 
         public byte[] RawBytes()
         {
-            var stream = new MemoryStream();
-            var writer = new BinaryWriter(stream);
+            using var stream = new MemoryStream();
+            using var writer = new BinaryWriter(stream);
 
             writer.Write(this.FuncID);
 
             if (this.Buffer != null)
-                writer.Write(this.Buffer, 0, 510);
+                writer.Write(this.Buffer, 0, 512);
 
             return stream.ToArray();
         }
@@ -31,17 +31,18 @@ namespace UndertaleModLib
     public struct IpcReply_t
     {
         public int AUMIResult; //Always contains a value.
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 124)]
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 128)]
         public byte[] Buffer;
 
         public static IpcReply_t FromBytes(byte[] bytes)
         {
-            var reader = new BinaryReader(new MemoryStream(bytes));
+            using var stream = new MemoryStream(bytes);
+            using var reader = new BinaryReader(stream);
 
             var s = default(IpcReply_t);
 
             s.AUMIResult = reader.ReadInt32();
-            s.Buffer = reader.ReadBytes(124);
+            s.Buffer = reader.ReadBytes(128);
 
             return s;
         }

--- a/UndertaleModLib/Scripting/IScriptInterface.cs
+++ b/UndertaleModLib/Scripting/IScriptInterface.cs
@@ -30,6 +30,7 @@ namespace UndertaleModLib.Scripting
         bool ScriptQuestion(string message);
         void ScriptError(string error, string title = "Error", bool SetConsoleText = true);
         void ScriptOpenURL(string url);
+        bool SendAUMIMessage(IpcMessage_t ipMessage, ref IpcReply_t outReply);
         bool RunUMTScript(string path);
         bool LintUMTScript(string path);
         void ReapplyProfileCode();

--- a/UndertaleModTests/GameScriptTests.cs
+++ b/UndertaleModTests/GameScriptTests.cs
@@ -74,7 +74,10 @@ namespace UndertaleModTests
             Console.WriteLine(message);
             return true;
         }
-
+        public bool SendAUMIMessage(IpcMessage_t ipMessage, ref IpcReply_t outReply)
+        {
+            return true;
+        }
         public void ScriptOpenURL(string url)
         {
             Console.WriteLine("Open: " + url);

--- a/UndertaleModTool/ScriptingFunctions.cs
+++ b/UndertaleModTool/ScriptingFunctions.cs
@@ -26,11 +26,11 @@ namespace UndertaleModTool
             // By Archie
             const int ReplySize = 132;
 
-            //Create the pipe
+            // Create the pipe
             using var pPipeServer = new NamedPipeServerStream("AUMI-IPC", PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
 
-            //Wait 1/8th of a second for AUMI to connect.
-            //If it doesn't connect in time (which it should), just return false to avoid a deadlock.
+            // Wait 1/8th of a second for AUMI to connect.
+            // If it doesn't connect in time (which it should), just return false to avoid a deadlock.
             if (!pPipeServer.IsConnected)
             {
                 pPipeServer.WaitForConnectionAsync();
@@ -48,14 +48,14 @@ namespace UndertaleModTool
                 pPipeServer.Write(ipMessage.RawBytes());
                 pPipeServer.Flush();
             }
-            catch (IOException)
+            catch (Exception e)
             {
-                //Catch any errors that might arise if the connection is broken
-                ScriptError("Could not write data to the pipe!");
+                // Catch any errors that might arise if the connection is broken
+                ScriptError("Could not write data to the pipe!\nError: " + e.Message);
                 return false;
             }
 
-            //Read the reply, the length of which is always a pre-set amount of bytes.
+            // Read the reply, the length of which is always a pre-set amount of bytes.
             byte[] bBuffer = new byte[ReplySize];
             pPipeServer.Read(bBuffer, 0, ReplySize);
 
@@ -100,7 +100,7 @@ namespace UndertaleModTool
             }
             catch (Exception)
             {
-                //Using the 100 MS timer it can time out before successfully running, compilation errors are fast enough to get through.
+                // Using the 100 MS timer it can time out before successfully running, compilation errors are fast enough to get through.
                 ScriptExecutionSuccess = true;
                 ScriptErrorMessage = "";
                 ScriptErrorType = "";

--- a/UndertaleModTool/ScriptingFunctions.cs
+++ b/UndertaleModTool/ScriptingFunctions.cs
@@ -14,12 +14,59 @@ using System.Reflection;
 using Newtonsoft.Json;
 using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.CodeAnalysis.Scripting;
+using System.IO.Pipes;
 
 namespace UndertaleModTool
 {
     // Adding misc. scripting functions here
     public partial class MainWindow : Window, INotifyPropertyChanged, IScriptInterface
     {
+        public bool SendAUMIMessage(IpcMessage_t ipMessage, ref IpcReply_t outReply)
+        {
+            // By Archie
+            const int ReplySize = 128;
+
+            //Create the pipe
+            var pPipeServer = new NamedPipeServerStream("AUMI-IPC", PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+
+            //Wait 1/8th of a second for AUMI to connect.
+            //If it doesn't connect in time (which it should), just return false to avoid a deadlock.
+            if (!pPipeServer.IsConnected)
+            {
+                pPipeServer.WaitForConnectionAsync();
+                Thread.Sleep(125);
+                if (!pPipeServer.IsConnected)
+                {
+                    pPipeServer.DisposeAsync();
+                    return false;
+                }
+            }
+
+            try
+            {
+                //Send the message
+                pPipeServer.Write(ipMessage.RawBytes());
+                pPipeServer.Flush();
+            }
+            catch (InvalidOperationException)
+            {
+                //Catch any errors that might arise if the connection is broken
+                ScriptError("Could not write data to the pipe!");
+                pPipeServer.Disconnect();
+                pPipeServer.Dispose();
+                return false;
+            }
+
+            //Read the reply, the length of which is always a pre-set amount of bytes.
+            byte[] bBuffer = new byte[ReplySize];
+            pPipeServer.Read(bBuffer, 0, ReplySize);
+            pPipeServer.Disconnect();
+            pPipeServer.Dispose();
+
+            outReply = IpcReply_t.FromBytes(bBuffer);
+            return true;
+        }
+
         public bool RunUMTScript(string path)
         {
             // By Grossley

--- a/UndertaleModTool/TechnicalScripts/TestAUMIConnection.csx
+++ b/UndertaleModTool/TechnicalScripts/TestAUMIConnection.csx
@@ -1,0 +1,12 @@
+IpcMessage_t ipMessage;
+IpcReply_t ipReply;
+
+ipMessage.FuncID = 0x01;
+ipMessage.Buffer = null;
+
+SendAUMIMessage(ipMessage, ref ipReply);
+
+if (ipReply.Buffer != null)
+	ScriptMessage(System.Text.Encoding.ASCII.GetString(ipReply.Buffer));
+else
+	ScriptMessage("Didn't get a reply. Is AUMI not running?");

--- a/UndertaleModTool/UndertaleModTool.csproj
+++ b/UndertaleModTool/UndertaleModTool.csproj
@@ -3852,6 +3852,10 @@
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<ExcludeFromSingleFile>true</ExcludeFromSingleFile>
 		</None>
+    <None Update="TechnicalScripts\TestAUMIConnection.csx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+    </None>
 		<None Update="TechnicalScripts\ToggleAlignment.csx">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<ExcludeFromSingleFile>true</ExcludeFromSingleFile>


### PR DESCRIPTION
Fully implemented IPC with AUMI, which can be used by the script interface as well.

AUMI can now receive custom-made data such as bytecode to execute and send back a result, all without any Windows dependencies on UMT's side.

I tested this locally, ran without any errors or exceptions even when AUMI wasn't loaded (the new script TestAUMIConnection.csx can be used to verify if stuff works).

Link to AUMI: https://github.com/Archie-osu/AUMI