### PR TITLE
Add support for GMS2.3+ weird dup variants

### DIFF
--- a/UndertaleModLib/Decompiler/Decompiler.cs
+++ b/UndertaleModLib/Decompiler/Decompiler.cs
@@ -1480,6 +1480,32 @@ namespace UndertaleModLib.Decompiler
             }
         }
 
+        static int GetTypeSize(UndertaleInstruction.DataType type)
+        {
+            switch (type)
+            {
+                case UndertaleInstruction.DataType.Int16:
+                case UndertaleInstruction.DataType.Int32:
+                    return 4;
+                case UndertaleInstruction.DataType.Variable:
+                    return 16;
+                default:
+                    throw new NotImplementedException("Unknown size for data type " + type);
+            }
+        }
+        static int GetTypeSize(Expression e)
+        {
+            if (e is ExpressionVar || e is ExpressionTempVar)
+                return GetTypeSize(UndertaleInstruction.DataType.Variable);
+            if (e is ExpressionCast)
+                return GetTypeSize(e.Type); // TODO: I don't think we even store a cast to variable, which could break somewhere...?
+            if (e is ExpressionConstant)
+                return GetTypeSize(e.Type);
+            if (e is ExpressionTwo)
+                return GetTypeSize(((ExpressionTwo)e).Type2); // for add.i.v, the output is a var
+            throw new NotImplementedException("No idea what to do with " + e.GetType().ToString());
+        }
+
         // The core function to decompile a specific block.
         internal static void DecompileFromBlock(DecompileContext context, Block block, List<TempVarReference> tempvars, Stack<Tuple<Block, List<TempVarReference>>> workQueue)
         {
@@ -1529,41 +1555,65 @@ namespace UndertaleModLib.Decompiler
                     case UndertaleInstruction.Opcode.Dup:
                         if (instr.ComparisonKind != 0)
                         {
-                            // This is a special instruction for moving around an instance on the stack in GMS2.3
+                            // This is the GMS 2.3+ stack move / swap instruction
 
-                            int weirdLength = (byte)instr.ComparisonKind & 0x7F;
-                            if (weirdLength != 8)
-                                throw new Exception("I have no idea where this shows up but it does, need to have an example first"); // TODO
-
-                            Stack<Expression> args = new Stack<Expression>();
-                            for (int j = 0; j < instr.Extra; j++)
-                                args.Push(stack.Pop());
-                            Expression instance = stack.Pop();
-                            for (int j = 0; j < args.Count; j++)
+                            int bytesToTake = instr.Extra * 4;
+                            Stack<Expression> taken = new Stack<Expression>();
+                            while (bytesToTake > 0)
                             {
-                                Expression e = args.Pop();
-                                e.WasDuplicated = true;
-                                stack.Push(e);
+                                Expression e = stack.Pop();
+                                taken.Push(e);
+                                bytesToTake -= GetTypeSize(e);
+                                if (bytesToTake < 0)
+                                    throw new InvalidOperationException("The stack got misaligned?");
                             }
-                            instance.WasDuplicated = true;
-                            stack.Push(instance);
+
+                            int b2 = (byte)instr.ComparisonKind & 0x7F;
+                            if ((b2 & 0b111) != 0)
+                                throw new InvalidOperationException("Don't know what to do with this");
+                            int bytesToMove = (b2 >> 3) * 4;
+                            Stack<Expression> moved = new Stack<Expression>();
+                            while (bytesToMove > 0)
+                            {
+                                Expression e = stack.Pop();
+                                moved.Push(e);
+                                bytesToMove -= GetTypeSize(e);
+                                if (bytesToMove < 0)
+                                    throw new InvalidOperationException("The stack got misaligned?");
+                            }
+
+                            while (taken.Count > 0)
+                                stack.Push(taken.Pop());
+                            while (moved.Count > 0)
+                                stack.Push(moved.Pop());
 
                             break;
                         }
 
+                        if (instr.Type1 == UndertaleInstruction.DataType.Variable)
+                        {
+                            // This is the GMS2.3+ var duplication instruction
+                            // It creates a new temp var whose initial value is the same as the variable on top of the stack
+
+                            Expression item = stack.Peek();
+
+                            TempVar var = context.NewTempVar();
+                            var.Type = item.Type;
+                            TempVarReference varref = new TempVarReference(var);
+                            statements.Add(new TempVarAssigmentStatement(varref, item));
+
+                            stack.Push(new ExpressionTempVar(varref, var.Type));
+                            break;
+                        }
+
+                        // Normal dup instruction
+
                         List<Expression> topExpressions1 = new List<Expression>();
                         List<Expression> topExpressions2 = new List<Expression>();
-                        // This "count" is necessary because sometimes dup.i 1 is replaced with dup.l 0...
-                        // Seemingly have equivalent behavior, so treat it that way.
-                        int count = ((instr.Extra + 1) * (instr.Type1 == UndertaleInstruction.DataType.Int64 ? 2 : 1));
-                        for (int j = 0; j < count; j++)
+                        int bytesToDuplicate = (instr.Extra + 1) * GetTypeSize(instr.Type1);
+                        while (bytesToDuplicate > 0)
                         {
-                            if ((j % 2) > 0 && stack.Count == 0)
-                                continue;
-
                             var item = stack.Pop();
-                            //if ((j % 2) == 0 && item.Type != UndertaleInstruction.DataType.Int64 && instr.Type1 == UndertaleInstruction.DataType.Int64)
-                            //    j++; // Skip the next iteration in the case on dup.l 0 replacing dup.i 1
 
                             if (item.IsDuplicationSafe())
                             {
@@ -1581,6 +1631,10 @@ namespace UndertaleModLib.Decompiler
                                 topExpressions1.Add(new ExpressionTempVar(varref, varref.Var.Type) { WasDuplicated = true });
                                 topExpressions2.Add(new ExpressionTempVar(varref, instr.Type1) { WasDuplicated = true });
                             }
+
+                            bytesToDuplicate -= GetTypeSize(item);
+                            if (bytesToDuplicate < 0)
+                                throw new InvalidOperationException("The stack got misaligned?");
                         }
                         topExpressions1.Reverse();
                         topExpressions2.Reverse();
@@ -1756,7 +1810,7 @@ namespace UndertaleModLib.Decompiler
                         {
                             ExpressionVar pushTarget = new ExpressionVar((instr.Value as UndertaleInstruction.Reference<UndertaleVariable>).Target, new ExpressionConstant(UndertaleInstruction.DataType.Int16, instr.TypeInst), (instr.Value as UndertaleInstruction.Reference<UndertaleVariable>).Type);
                             pushTarget.Opcode = instr.Kind;
-                            if (instr.TypeInst == UndertaleInstruction.InstanceType.Builtin)
+                            /*if (instr.TypeInst == UndertaleInstruction.InstanceType.Builtin)
                             {
                                 pushTarget.InstType = stack.Pop();
                                 if (pushTarget.InstType is FunctionCall fc)
@@ -1769,7 +1823,7 @@ namespace UndertaleModLib.Decompiler
                                         pushTarget.InstType = new ExpressionConstant(UndertaleInstruction.DataType.Int16, (short)-5) { AssetType = AssetIDType.GameObject };
                                 }
                             }
-                            else if (instr.TypeInst == UndertaleInstruction.InstanceType.Stacktop)
+                            else*/ if (instr.TypeInst == UndertaleInstruction.InstanceType.Stacktop)
                             {
                                 pushTarget.InstType = stack.Pop();
                             }

--- a/UndertaleModLib/Decompiler/Decompiler.cs
+++ b/UndertaleModLib/Decompiler/Decompiler.cs
@@ -1810,7 +1810,8 @@ namespace UndertaleModLib.Decompiler
                         {
                             ExpressionVar pushTarget = new ExpressionVar((instr.Value as UndertaleInstruction.Reference<UndertaleVariable>).Target, new ExpressionConstant(UndertaleInstruction.DataType.Int16, instr.TypeInst), (instr.Value as UndertaleInstruction.Reference<UndertaleVariable>).Type);
                             pushTarget.Opcode = instr.Kind;
-                            /*if (instr.TypeInst == UndertaleInstruction.InstanceType.Builtin)
+                            /* TODO: This is wrong and breaks a lot of things - "pushbltn.v builtin.room" does not take anything from the stack
+                            if (instr.TypeInst == UndertaleInstruction.InstanceType.Builtin)
                             {
                                 pushTarget.InstType = stack.Pop();
                                 if (pushTarget.InstType is FunctionCall fc)

--- a/UndertaleModLib/Models/UndertaleCode.cs
+++ b/UndertaleModLib/Models/UndertaleCode.cs
@@ -815,6 +815,7 @@ namespace UndertaleModLib.Models
                                 // Special dup instruction with extra parameters
                                 sb.Append(' ');
                                 sb.Append((byte)ComparisonKind & 0x7F);
+                                sb.Append(" ; this is a weird GMS2.3+ swap instruction");
                             }
                         }
                     }
@@ -855,6 +856,7 @@ namespace UndertaleModLib.Models
                         // Special scenario - the swap instruction
                         // TODO: Figure out the proper syntax, see #129
                         sb.Append(SwapExtra.ToString());
+                        sb.Append(" ; this is a weird swap instruction, see #129");
                     }
                     else
                     {


### PR DESCRIPTION
This PR adds support for the weird GMS2.3+ dup variants:

* The two-argument `dup` is actually a weird stack swap thing that takes stack locations in bytes as arguments
* The `dup.v` instruction is a special case for variable duplication
* The old base `dup` code was rewritten to properly take stack element sizes into account

I also commented out some code that was causing a lot of decompilation in DR Chapter 2 to fail... not sure what it was supposed to do because I haven't seen that much GMS2.3 assembly yet

This brings the count of scripts that fail to decompile from 931 to 531