### PR TITLE
Add preliminary GMS2.3 method support

### DIFF
--- a/UndertaleModLib/Decompiler/AssetTypeResolver.cs
+++ b/UndertaleModLib/Decompiler/AssetTypeResolver.cs
@@ -1291,7 +1291,7 @@ namespace UndertaleModLib.Decompiler
                 builtin_funcs["gml_Script_draw_sprite_ext_centerscale"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Other };
                 builtin_funcs["gml_Script_draw_sprite_ext_flash"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Other };
                 builtin_funcs["gml_Script_draw_sprite_skew_ext_cute"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
-                builtin_funcs["gml_Script_draw_text_outline"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_draw_text_outline"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
                 builtin_funcs["gml_Script_i_ex"] = new AssetIDType[] { AssetIDType.GameObject };
                 builtin_funcs["gml_Script_instance_create_ch1"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.GameObject };
                 builtin_funcs["gml_Script_msgsetloc"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other };
@@ -1373,7 +1373,7 @@ namespace UndertaleModLib.Decompiler
                 builtin_funcs["draw_sprite_ext_centerscale"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Other };
                 builtin_funcs["draw_sprite_ext_flash"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Other };
                 builtin_funcs["draw_sprite_skew_ext_cute"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
-                builtin_funcs["draw_text_outline"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["draw_text_outline"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
                 builtin_funcs["i_ex"] = new AssetIDType[] { AssetIDType.GameObject };
                 builtin_funcs["instance_create_ch1"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.GameObject };
                 builtin_funcs["msgsetloc"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other };

--- a/UndertaleModLib/Decompiler/AssetTypeResolver.cs
+++ b/UndertaleModLib/Decompiler/AssetTypeResolver.cs
@@ -354,18 +354,10 @@ namespace UndertaleModLib.Decompiler
     {
         public static Dictionary<string, AssetIDType[]> builtin_funcs;
 
-        public static Dictionary<string, Dictionary<string, AssetIDType>> builtin_var_overrides;
-        public static Dictionary<string, AssetIDType> builtin_vars;
+        public static Dictionary<string, Dictionary<string, AssetIDType>> builtin_var_overrides; // keys are code block names or object names. In the resulting dictionary keys are variable names.
+        public static Dictionary<string, AssetIDType> builtin_vars; // keys are variable names
 
-        public static Dictionary<string, AssetIDType> return_types;
-
-        internal static string StripPrefix(string name)
-        {
-            if (name.StartsWith("gml_Script_") || name.StartsWith("gml_Object_"))
-                name = name.Substring(11);
-
-            return name;
-        }
+        public static Dictionary<string, AssetIDType> return_types; // keys are script names (< GMS2.3) or member function variable names (>= GMS2.3)
 
         internal static bool AnnotateTypesForFunctionCall(string function_name, AssetIDType[] arguments, DecompileContext context) 
         {
@@ -375,8 +367,6 @@ namespace UndertaleModLib.Decompiler
         internal static bool AnnotateTypesForFunctionCall(string function_name, AssetIDType[] arguments, DecompileContext context, Decompiler.FunctionCall function)
         {
             Dictionary<string, AssetIDType[]> scriptArgs = context.GlobalContext.ScriptArgsCache;
-
-            function_name = StripPrefix(function_name);
 
             bool overloaded = false;
             // Scripts overload builtins because in GMS2 some functions are just backwards-compatibility scripts
@@ -481,7 +471,7 @@ namespace UndertaleModLib.Decompiler
 
         internal static AssetIDType AnnotateTypeForVariable(DecompileContext context, string variable_name)
         {
-            var overrides = GetTypeOverridesFor(context.TargetNameStripped);
+            var overrides = GetTypeOverridesFor(context.TargetCode.Name.Content);
             if (overrides.ContainsKey(variable_name))
                 return overrides[variable_name];
 
@@ -507,7 +497,7 @@ namespace UndertaleModLib.Decompiler
 
         internal static Dictionary<string, AssetIDType> GetTypeOverridesFor(DecompileContext context)
         {
-            return GetTypeOverridesFor(context.TargetNameStripped);
+            return GetTypeOverridesFor(context.TargetCode.Name.Content);
         }
 
         internal static Dictionary<string, AssetIDType> GetTypeOverridesFor(string code_entry_name)
@@ -1015,7 +1005,7 @@ namespace UndertaleModLib.Decompiler
             if (data?.Code != null)
             {
                 foreach (var code in data.Code)
-                    builtin_var_overrides[StripPrefix(code.Name.Content)] = new Dictionary<string, AssetIDType>();
+                    builtin_var_overrides[code.Name.Content] = new Dictionary<string, AssetIDType>();
             }
 
             builtin_vars = new Dictionary<string, AssetIDType>()
@@ -1054,10 +1044,10 @@ namespace UndertaleModLib.Decompiler
             if (lowerName != null && (lowerName == "undertale"))
             {
 
-                //AddOverrideFor("obj_wizardorb_chaser_Alarm_0", "pop", AssetIDType.Script);
+                //AddOverrideFor("gml_Object_obj_wizardorb_chaser_Alarm_0", "pop", AssetIDType.Script);
 
-                AddOverrideFor("obj_fakeborderdraw_Draw_0", "op", AssetIDType.GameObject);
-                AddOverrideFor("obj_vertcroissant_Step_0", "op", AssetIDType.GameObject);
+                AddOverrideFor("gml_Object_obj_fakeborderdraw_Draw_0", "op", AssetIDType.GameObject);
+                AddOverrideFor("gml_Object_obj_vertcroissant_Step_0", "op", AssetIDType.GameObject);
 
                 return_types["scr_getmusindex"] = AssetIDType.Sound;
                 return_types["scr_getsprite"] = AssetIDType.Sprite;
@@ -1245,11 +1235,11 @@ namespace UndertaleModLib.Decompiler
             // Both UT and DR
             if (lowerName != null && (lowerName == "undertale" || lowerName == "survey_program" || lowerName.StartsWith("deltarune")))
             {
-                AddOverrideFor("scr_getbuttonsprite", "control", AssetIDType.Enum_GamepadButton);
-                AddOverrideFor("scr_getbuttonsprite", "button", AssetIDType.Enum_GamepadButton);
+                AddOverrideFor("gml_Script_scr_getbuttonsprite", "control", AssetIDType.Enum_GamepadButton);
+                AddOverrideFor("gml_Script_scr_getbuttonsprite", "button", AssetIDType.Enum_GamepadButton);
 
                 // Don't use this. It will not recompile.
-                // AddOverrideFor("obj_shop3_Draw_0", "mycolor", AssetIDType.Macro);
+                // AddOverrideFor("gml_Object_obj_shop3_Draw_0", "mycolor", AssetIDType.Macro);
 
                 return_types["scr_getbuttonsprite"] = AssetIDType.Sprite;
 
@@ -1257,7 +1247,7 @@ namespace UndertaleModLib.Decompiler
                 // Seems to be used a lot as a regular value between the values of around 0-20.
                 AddOverrideFor("obj_vulkinbody", "face", AssetIDType.Sprite);
 
-                AddOverrideFor("scr_setfont", "newfont", AssetIDType.Font);
+                AddOverrideFor("gml_Script_scr_setfont", "newfont", AssetIDType.Font);
 
                 //builtin_vars.Add("face", AssetIDType.Sprite);
 

--- a/UndertaleModLib/Decompiler/AssetTypeResolver.cs
+++ b/UndertaleModLib/Decompiler/AssetTypeResolver.cs
@@ -835,6 +835,7 @@ namespace UndertaleModLib.Decompiler
                 { "draw_roundrect_colour", new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Color, AssetIDType.Other } },
                 { "draw_roundrect_colour_ext", new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Color, AssetIDType.Other } },
                 { "draw_healthbar", new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Color, AssetIDType.Color, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other } },
+                { "draw_set_alpha", new AssetIDType[] { AssetIDType.Other } },
 
                 { "draw_set_blend_mode", new AssetIDType[] { AssetIDType.ContextDependent } },
                 { "draw_set_blend_mode_ext", new AssetIDType[] { AssetIDType.ContextDependent, AssetIDType.ContextDependent } },
@@ -844,6 +845,9 @@ namespace UndertaleModLib.Decompiler
                 { "d3d_set_fog", new AssetIDType[] { AssetIDType.Boolean, AssetIDType.Color, AssetIDType.Other, AssetIDType.Other } },
                 { "gpu_set_fog", new AssetIDType[] { AssetIDType.Boolean, AssetIDType.Color, AssetIDType.Other, AssetIDType.Other } },
 
+                { "layer_script_begin", new AssetIDType[] { AssetIDType.Other, AssetIDType.Script } },
+                { "gpu_set_blendenable", new AssetIDType[] { AssetIDType.Boolean } },
+                { "layer_script_end", new AssetIDType[] { AssetIDType.Other, AssetIDType.Script } },
                 { "draw_sprite", new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other } },
                 { "draw_sprite_ext", new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Other } },
                 { "draw_sprite_general", new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Color, AssetIDType.Color, AssetIDType.Color, AssetIDType.Other } },
@@ -1077,7 +1081,7 @@ namespace UndertaleModLib.Decompiler
             }
 
             // Just Deltarune
-            if (lowerName != null && (lowerName == "survey_program" || lowerName.StartsWith("deltarune")))
+            if (lowerName != null && (lowerName == "survey_program" || lowerName.StartsWith("deltarune") || lowerName == "deltarune chapter 1 & 2"))
             {
                 builtin_vars.Add("idlesprite", AssetIDType.Sprite);
                 builtin_vars.Add("actreadysprite", AssetIDType.Sprite);
@@ -1233,7 +1237,7 @@ namespace UndertaleModLib.Decompiler
             }
 
             // Both UT and DR
-            if (lowerName != null && (lowerName == "undertale" || lowerName == "survey_program" || lowerName.StartsWith("deltarune")))
+            if (lowerName != null && (lowerName == "undertale" || lowerName == "survey_program" || lowerName.StartsWith("deltarune") || lowerName == "deltarune chapter 1 & 2"))
             {
                 AddOverrideFor("gml_Script_scr_getbuttonsprite", "control", AssetIDType.Enum_GamepadButton);
                 AddOverrideFor("gml_Script_scr_getbuttonsprite", "button", AssetIDType.Enum_GamepadButton);
@@ -1252,9 +1256,217 @@ namespace UndertaleModLib.Decompiler
                 //builtin_vars.Add("face", AssetIDType.Sprite);
 
                 builtin_vars.Add("myfont", AssetIDType.Font);
+
                 // Hope this script works!
                 builtin_funcs["scr_bouncer"] = new AssetIDType[] { AssetIDType.GameObject, AssetIDType.Other, AssetIDType.Other };
 
+                // Deltarune Chapter 2 asset resolutions:
+                // Seems to be x, y, measure of distance (maybe)
+
+                builtin_funcs["gml_Script__background_set"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Sprite };
+                builtin_funcs["gml_Script_c_addxy"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color };
+                builtin_funcs["gml_Script_c_autowalk"] = new AssetIDType[] { AssetIDType.Boolean };
+                builtin_funcs["gml_Script_c_fadeout"] = new AssetIDType[] { AssetIDType.Other };
+                builtin_funcs["gml_Script_c_pan"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_c_pannable"] = new AssetIDType[] { AssetIDType.Boolean };
+                builtin_funcs["gml_Script_c_panobj"] = new AssetIDType[] { AssetIDType.GameObject, AssetIDType.Other };
+                builtin_funcs["gml_Script_c_panspeed"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_c_script_instance"] = new AssetIDType[] { AssetIDType.GameObject, AssetIDType.Script, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_c_script_instance_stop"] = new AssetIDType[] { AssetIDType.GameObject, AssetIDType.Script };
+                builtin_funcs["gml_Script_c_setxy"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_c_soundplay"] = new AssetIDType[] { AssetIDType.Sound };
+                builtin_funcs["gml_Script_c_soundplay_x"] = new AssetIDType[] { AssetIDType.Sound, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_c_sprite"] = new AssetIDType[] { AssetIDType.Sprite };
+                builtin_funcs["gml_Script_c_stickto"] = new AssetIDType[] { AssetIDType.GameObject, AssetIDType.Other };
+                builtin_funcs["gml_Script_c_wait"] = new AssetIDType[] { AssetIDType.Other };
+                builtin_funcs["gml_Script_c_walkdirect"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_c_walkdirect_wait"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_d3d_set_fog_ch1"] = new AssetIDType[] { AssetIDType.Boolean, AssetIDType.Color, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_draw_background_ext_ch1"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Other };
+                builtin_funcs["gml_Script_draw_background_part_ext_ch1"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Other };
+                builtin_funcs["gml_Script_draw_background_tiled_ext_ch1"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Other };
+                builtin_funcs["gml_Script_draw_enable_alphablend_ch1"] = new AssetIDType[] { AssetIDType.Boolean };
+                builtin_funcs["gml_Script_draw_monster_body_part"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_draw_monster_body_part_ext"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Other };
+                builtin_funcs["gml_Script_draw_sprite_ext_centerscale"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Other };
+                builtin_funcs["gml_Script_draw_sprite_ext_flash"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Other };
+                builtin_funcs["gml_Script_draw_sprite_skew_ext_cute"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_draw_text_outline"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_i_ex"] = new AssetIDType[] { AssetIDType.GameObject };
+                builtin_funcs["gml_Script_instance_create_ch1"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.GameObject };
+                builtin_funcs["gml_Script_msgsetloc"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_mus_loop"] = new AssetIDType[] { AssetIDType.Sound };
+                builtin_funcs["gml_Script_mus_loop_ext"] = new AssetIDType[] { AssetIDType.Sound, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_safe_delete"] = new AssetIDType[] { AssetIDType.GameObject };
+                builtin_funcs["gml_Script_scr_84_debug"] = new AssetIDType[] { AssetIDType.Boolean };
+                builtin_funcs["gml_Script_scr_act_charsprite"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Boolean };
+                builtin_funcs["gml_Script_scr_anim"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other };
+                builtin_funcs["gml_Script_scr_anim_ch1"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other };
+                builtin_funcs["gml_Script_scr_battle"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Boolean, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_scr_battle_marker"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Sprite };
+                builtin_funcs["gml_Script_scr_bullet_create"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.GameObject };
+                builtin_funcs["gml_Script_scr_bulletspawner"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.GameObject };
+                builtin_funcs["gml_Script_scr_caterpillar_facing_ch1"] = new AssetIDType[] { AssetIDType.Other };
+                builtin_funcs["gml_Script_scr_custom_afterimage"] = new AssetIDType[] { AssetIDType.Sprite };
+                builtin_funcs["gml_Script_scr_custom_afterimage_ext"] = new AssetIDType[] { AssetIDType.GameObject, AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_scr_dark_marker"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Sprite };
+                builtin_funcs["gml_Script_scr_dark_marker_ch1"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Sprite };
+                builtin_funcs["gml_Script_scr_dark_marker_depth"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Sprite };
+                builtin_funcs["gml_Script_scr_debug_keycheck"] = new AssetIDType[] { AssetIDType.KeyboardKey };
+                builtin_funcs["gml_Script_scr_draw_background_ps4_ch1"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_scr_draw_outline_ext"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_scr_draw_sprite_crop_ext"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_scr_ds_list_write"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_scr_enemyblcon"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_scr_following_afterimage"] = new AssetIDType[] { AssetIDType.GameObject, AssetIDType.GameObject };
+                builtin_funcs["gml_Script_scr_forcefield"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Boolean, AssetIDType.Boolean };
+                builtin_funcs["gml_Script_scr_fx_housesquare"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Color };
+                builtin_funcs["gml_Script_scr_guardpeek"] = new AssetIDType[] { AssetIDType.GameObject };
+                builtin_funcs["gml_Script_scr_marker"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Sprite };
+                builtin_funcs["gml_Script_scr_marker_ch1"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Sprite };
+                builtin_funcs["gml_Script_scr_mercyadd"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_scr_monster_add"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.GameObject };
+                builtin_funcs["gml_Script_scr_monster_change"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.GameObject };
+                builtin_funcs["gml_Script_scr_move_to_point_over_time"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_scr_pan_ch1"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_scr_pan_to_obj"] = new AssetIDType[] { AssetIDType.GameObject, AssetIDType.Other };
+                builtin_funcs["gml_Script_scr_pan_to_obj_ch1"] = new AssetIDType[] { AssetIDType.GameObject, AssetIDType.Other };
+                builtin_funcs["gml_Script_scr_script_delayed"] = new AssetIDType[] { AssetIDType.Script, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_scr_textsetup"] = new AssetIDType[] { AssetIDType.Font, AssetIDType.Color, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Sound, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_scr_textsetup_ch1"] = new AssetIDType[] { AssetIDType.Font, AssetIDType.Color, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Sound, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_snd_is_playing"] = new AssetIDType[] { AssetIDType.Sound };
+                builtin_funcs["gml_Script_snd_loop"] = new AssetIDType[] { AssetIDType.Sound };
+                builtin_funcs["gml_Script_snd_loop_ch1"] = new AssetIDType[] { AssetIDType.Sound };
+                builtin_funcs["gml_Script_snd_pitch"] = new AssetIDType[] { AssetIDType.Sound, AssetIDType.Other };
+                builtin_funcs["gml_Script_snd_play"] = new AssetIDType[] { AssetIDType.Sound };
+                builtin_funcs["gml_Script_snd_play_ch1"] = new AssetIDType[] { AssetIDType.Sound };
+                builtin_funcs["gml_Script_snd_play_pitch"] = new AssetIDType[] { AssetIDType.Sound, AssetIDType.Other };
+                builtin_funcs["gml_Script_snd_play_x"] = new AssetIDType[] { AssetIDType.Sound, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["gml_Script_snd_stop"] = new AssetIDType[] { AssetIDType.Sound };
+                builtin_funcs["gml_Script_snd_stop_ch1"] = new AssetIDType[] { AssetIDType.Sound };
+                builtin_funcs["gml_Script_snd_volume"] = new AssetIDType[] { AssetIDType.Sound, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["_background_set"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Sprite };
+                builtin_funcs["c_addxy"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color };
+                builtin_funcs["c_autowalk"] = new AssetIDType[] { AssetIDType.Boolean };
+                builtin_funcs["c_fadeout"] = new AssetIDType[] { AssetIDType.Other };
+                builtin_funcs["c_pan"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["c_pannable"] = new AssetIDType[] { AssetIDType.Boolean };
+                builtin_funcs["c_panobj"] = new AssetIDType[] { AssetIDType.GameObject, AssetIDType.Other };
+                builtin_funcs["c_panspeed"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["c_script_instance"] = new AssetIDType[] { AssetIDType.GameObject, AssetIDType.Script, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["c_script_instance_stop"] = new AssetIDType[] { AssetIDType.GameObject, AssetIDType.Script };
+                builtin_funcs["c_setxy"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["c_soundplay"] = new AssetIDType[] { AssetIDType.Sound };
+                builtin_funcs["c_soundplay_x"] = new AssetIDType[] { AssetIDType.Sound, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["c_sprite"] = new AssetIDType[] { AssetIDType.Sprite };
+                builtin_funcs["c_stickto"] = new AssetIDType[] { AssetIDType.GameObject, AssetIDType.Other };
+                builtin_funcs["c_wait"] = new AssetIDType[] { AssetIDType.Other };
+                builtin_funcs["c_walkdirect"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["c_walkdirect_wait"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["d3d_set_fog_ch1"] = new AssetIDType[] { AssetIDType.Boolean, AssetIDType.Color, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["draw_background_ext_ch1"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Other };
+                builtin_funcs["draw_background_part_ext_ch1"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Other };
+                builtin_funcs["draw_background_tiled_ext_ch1"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Other };
+                builtin_funcs["draw_enable_alphablend_ch1"] = new AssetIDType[] { AssetIDType.Boolean };
+                builtin_funcs["draw_monster_body_part"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["draw_monster_body_part_ext"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Other };
+                builtin_funcs["draw_sprite_ext_centerscale"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Other };
+                builtin_funcs["draw_sprite_ext_flash"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Other };
+                builtin_funcs["draw_sprite_skew_ext_cute"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["draw_text_outline"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["i_ex"] = new AssetIDType[] { AssetIDType.GameObject };
+                builtin_funcs["instance_create_ch1"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.GameObject };
+                builtin_funcs["msgsetloc"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["mus_loop"] = new AssetIDType[] { AssetIDType.Sound };
+                builtin_funcs["mus_loop_ext"] = new AssetIDType[] { AssetIDType.Sound, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["safe_delete"] = new AssetIDType[] { AssetIDType.GameObject };
+                builtin_funcs["scr_84_debug"] = new AssetIDType[] { AssetIDType.Boolean };
+                builtin_funcs["scr_act_charsprite"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Boolean };
+                builtin_funcs["scr_anim"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other };
+                builtin_funcs["scr_anim_ch1"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other };
+                builtin_funcs["scr_battle"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Boolean, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["scr_battle_marker"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Sprite };
+                builtin_funcs["scr_bullet_create"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.GameObject };
+                builtin_funcs["scr_bulletspawner"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.GameObject };
+                builtin_funcs["scr_caterpillar_facing_ch1"] = new AssetIDType[] { AssetIDType.Other };
+                builtin_funcs["scr_custom_afterimage"] = new AssetIDType[] { AssetIDType.Sprite };
+                builtin_funcs["scr_custom_afterimage_ext"] = new AssetIDType[] { AssetIDType.GameObject, AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["scr_dark_marker"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Sprite };
+                builtin_funcs["scr_dark_marker_ch1"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Sprite };
+                builtin_funcs["scr_dark_marker_depth"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Sprite };
+                builtin_funcs["scr_debug_keycheck"] = new AssetIDType[] { AssetIDType.KeyboardKey };
+                builtin_funcs["scr_draw_background_ps4_ch1"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["scr_draw_outline_ext"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Color, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["scr_draw_sprite_crop_ext"] = new AssetIDType[] { AssetIDType.Sprite, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["scr_ds_list_write"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["scr_enemyblcon"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["scr_following_afterimage"] = new AssetIDType[] { AssetIDType.GameObject, AssetIDType.GameObject };
+                builtin_funcs["scr_forcefield"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Boolean, AssetIDType.Boolean };
+                builtin_funcs["scr_fx_housesquare"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Color };
+                builtin_funcs["scr_guardpeek"] = new AssetIDType[] { AssetIDType.GameObject };
+                builtin_funcs["scr_marker"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Sprite };
+                builtin_funcs["scr_marker_ch1"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Sprite };
+                builtin_funcs["scr_mercyadd"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["scr_monster_add"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.GameObject };
+                builtin_funcs["scr_monster_change"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.GameObject };
+                builtin_funcs["scr_move_to_point_over_time"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["scr_pan_ch1"] = new AssetIDType[] { AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["scr_pan_to_obj"] = new AssetIDType[] { AssetIDType.GameObject, AssetIDType.Other };
+                builtin_funcs["scr_pan_to_obj_ch1"] = new AssetIDType[] { AssetIDType.GameObject, AssetIDType.Other };
+                builtin_funcs["scr_script_delayed"] = new AssetIDType[] { AssetIDType.Script, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["scr_textsetup"] = new AssetIDType[] { AssetIDType.Font, AssetIDType.Color, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Sound, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["scr_textsetup_ch1"] = new AssetIDType[] { AssetIDType.Font, AssetIDType.Color, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other, AssetIDType.Sound, AssetIDType.Other, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["snd_is_playing"] = new AssetIDType[] { AssetIDType.Sound };
+                builtin_funcs["snd_loop"] = new AssetIDType[] { AssetIDType.Sound };
+                builtin_funcs["snd_loop_ch1"] = new AssetIDType[] { AssetIDType.Sound };
+                builtin_funcs["snd_pitch"] = new AssetIDType[] { AssetIDType.Sound, AssetIDType.Other };
+                builtin_funcs["snd_play"] = new AssetIDType[] { AssetIDType.Sound };
+                builtin_funcs["snd_play_ch1"] = new AssetIDType[] { AssetIDType.Sound };
+                builtin_funcs["snd_play_pitch"] = new AssetIDType[] { AssetIDType.Sound, AssetIDType.Other };
+                builtin_funcs["snd_play_x"] = new AssetIDType[] { AssetIDType.Sound, AssetIDType.Other, AssetIDType.Other };
+                builtin_funcs["snd_stop"] = new AssetIDType[] { AssetIDType.Sound };
+                builtin_funcs["snd_stop_ch1"] = new AssetIDType[] { AssetIDType.Sound };
+                builtin_funcs["snd_volume"] = new AssetIDType[] { AssetIDType.Sound, AssetIDType.Other, AssetIDType.Other };
+                builtin_vars.Add("_headsprite", AssetIDType.Sprite);
+                builtin_vars.Add("ar", AssetIDType.Other);
+                builtin_vars.Add("as", AssetIDType.Other);
+                builtin_vars.Add("be", AssetIDType.Other);
+                builtin_vars.Add("canactnoe", AssetIDType.Boolean);
+                builtin_vars.Add("canactral", AssetIDType.Boolean);
+                builtin_vars.Add("canactsus", AssetIDType.Boolean);
+                builtin_vars.Add("char", AssetIDType.Other);
+                builtin_vars.Add("choice", AssetIDType.Other);
+                builtin_vars.Add("direction", AssetIDType.Other);
+                builtin_vars.Add("encounterno", AssetIDType.Other);
+                builtin_vars.Add("flag", AssetIDType.Other);
+                builtin_vars.Add("gi", AssetIDType.Other);
+                builtin_vars.Add("gold", AssetIDType.Other);
+                builtin_vars.Add("hg", AssetIDType.Other);
+                builtin_vars.Add("housecolor", AssetIDType.Color);
+                builtin_vars.Add("la", AssetIDType.Other);
+                builtin_vars.Add("lhp", AssetIDType.Other);
+                builtin_vars.Add("na", AssetIDType.Other);
+                builtin_vars.Add("nl", AssetIDType.Other);
+                builtin_vars.Add("no", AssetIDType.Other);
+                builtin_vars.Add("partblend", AssetIDType.Color);
+                builtin_vars.Add("partsprite", AssetIDType.Sprite);
+                builtin_vars.Add("plot", AssetIDType.Other);
+                builtin_vars.Add("qu", AssetIDType.Other);
+                builtin_vars.Add("sa", AssetIDType.Other);
+                builtin_vars.Add("sameattack", AssetIDType.Other);
+                builtin_vars.Add("sameattacker", AssetIDType.Other);
+                builtin_vars.Add("side", AssetIDType.Other);
+                builtin_vars.Add("skip", AssetIDType.Boolean);
+                builtin_vars.Add("st", AssetIDType.Other);
+                builtin_vars.Add("stats_amount", AssetIDType.Color);
+                builtin_vars.Add("stayVisible", AssetIDType.Boolean);
+                builtin_vars.Add("sw", AssetIDType.Other);
+                builtin_vars.Add("to", AssetIDType.Other);
+                builtin_vars.Add("un", AssetIDType.Other);
+                builtin_vars.Add("walkpoint", AssetIDType.Other);
+                builtin_vars.Add("xx", AssetIDType.Other);
+                builtin_vars.Add("yy", AssetIDType.Other);
+                
                 // Undertale 1.05+ and Deltarune console versions.
                 builtin_funcs["scr_draw_background_ps4"] = new AssetIDType[] { AssetIDType.Background, AssetIDType.Other, AssetIDType.Other };
                 builtin_vars.Add("room_id", AssetIDType.Room);

--- a/UndertaleModLib/Decompiler/AssetTypeResolver.cs
+++ b/UndertaleModLib/Decompiler/AssetTypeResolver.cs
@@ -374,7 +374,7 @@ namespace UndertaleModLib.Decompiler
 
         internal static bool AnnotateTypesForFunctionCall(string function_name, AssetIDType[] arguments, DecompileContext context, Decompiler.FunctionCall function)
         {
-            Dictionary<string, AssetIDType[]> scriptArgs = context.scriptArgs;
+            Dictionary<string, AssetIDType[]> scriptArgs = context.GlobalContext.ScriptArgsCache;
 
             function_name = StripPrefix(function_name);
 
@@ -389,7 +389,7 @@ namespace UndertaleModLib.Decompiler
 
             function_name = function_name.Replace("color", "colour"); // Just GameMaker things... both are valid :o
 
-            if(context.Data?.IsGameMaker2() ?? false)
+            if(context.GlobalContext.Data?.IsGameMaker2() ?? false)
             {
                 // Backgrounds don't exist in GMS2
                 for (int i = 0; i < arguments.Length; i++)
@@ -405,7 +405,7 @@ namespace UndertaleModLib.Decompiler
                 if (arguments.Length > func_types.Length)
                     throw new Exception("Bad call to " + function_name + " with " + arguments.Length + " arguments (instead of " + func_types.Length + ")");
 
-                if (context.Data?.IsGameMaker2() ?? false)
+                if (context.GlobalContext.Data?.IsGameMaker2() ?? false)
                 {
                     // Backgrounds don't exist in GMS2
                     for (int i = 0; i < func_types.Length; i++)
@@ -458,9 +458,9 @@ namespace UndertaleModLib.Decompiler
                         if ((firstArg is Decompiler.ExpressionConstant) && firstArg.Type == UndertaleInstruction.DataType.Int16) 
                         {
                             short script_id = (short) (firstArg as Decompiler.ExpressionConstant).Value;
-                            if (script_id >= 0 && script_id < context.Data.Scripts.Count)
+                            if (script_id >= 0 && script_id < context.GlobalContext.Data.Scripts.Count)
                             {
-                                var script = context.Data.Scripts[script_id];
+                                var script = context.GlobalContext.Data.Scripts[script_id];
                                 AssetIDType[] args = new AssetIDType[arguments.Length-1];
                                 AnnotateTypesForFunctionCall(script.Name.Content, args, context);
                                 Array.Copy(args, 0, arguments, 1, args.Length);

--- a/UndertaleModLib/Decompiler/Decompiler.cs
+++ b/UndertaleModLib/Decompiler/Decompiler.cs
@@ -1235,11 +1235,13 @@ namespace UndertaleModLib.Decompiler
         public class FunctionDefinition : Expression
         {
             public UndertaleFunction Function { get; private set; }
+            public UndertaleCode FunctionBodyCodeEntry { get; private set; }
             public Block FunctionBodyEntryBlock { get; private set; }
 
-            public FunctionDefinition(UndertaleFunction target, Block functionBodyEntryBlock)
+            public FunctionDefinition(UndertaleFunction target, UndertaleCode functionBodyCodeEntry, Block functionBodyEntryBlock)
             {
                 Function = target;
+                FunctionBodyCodeEntry = functionBodyCodeEntry;
                 FunctionBodyEntryBlock = functionBodyEntryBlock;
             }
 
@@ -1255,7 +1257,15 @@ namespace UndertaleModLib.Decompiler
                 {
                     sb.Append("function ");
                     sb.Append(Function.Name.Content);
-                    sb.Append("() {\n");
+                    sb.Append("(");
+                    for (int i = 0; i < FunctionBodyCodeEntry.ArgumentsCount; ++i)
+                    {
+                        if (i != 0)
+                            sb.Append(", ");
+                        sb.Append("argument");
+                        sb.Append(i);
+                    }
+                    sb.Append(") {\n");
                     context.IndentationLevel++;
                     foreach (Statement stmt in context.Statements[FunctionBodyEntryBlock.Address.Value])
                         sb.Append(context.Indentation + stmt.ToString(context) + "\n");
@@ -2072,7 +2082,7 @@ namespace UndertaleModLib.Decompiler
                                         // This function is somewhere inside this UndertaleCode block
                                         // inline the definition
                                         Block functionBodyEntryBlock = blocks[functionBody.Offset / 4];
-                                        stack.Push(new FunctionDefinition(argCodeFunc.Target, functionBodyEntryBlock));
+                                        stack.Push(new FunctionDefinition(argCodeFunc.Target, functionBody, functionBodyEntryBlock));
                                         workQueue.Push(new Tuple<Block, List<TempVarReference>>(functionBodyEntryBlock, new List<TempVarReference>()));
                                         break;
                                     }

--- a/UndertaleModLib/Decompiler/Decompiler.cs
+++ b/UndertaleModLib/Decompiler/Decompiler.cs
@@ -1419,6 +1419,18 @@ namespace UndertaleModLib.Decompiler
 
                 // NOTE: The "var" prefix is handled in Decompiler.Decompile. 
 
+                if (VarType == UndertaleInstruction.VariableType.Instance)
+                {
+                    if (InstType is ExpressionConstant c)
+                    {
+                        int? val = ExpressionConstant.ConvertToInt(c.Value);
+                        if (val == null)
+                            throw new InvalidOperationException("Unable to parse the instance ID to int");
+                        // TODO: This is a reference to an object instance in the room. Resolving these is non-trivial since you don't exactly have a reference to the room where this script is used when decompiling...
+                        return (val + 100000) + "." + name;
+                    }
+                    else throw new InvalidOperationException("Instance variable type used with non-const InstType"); // TODO: can this happen?
+                }
                 if (InstType is ExpressionConstant constant) // Only use "global." and "other.", not "self." or "local.". GMS doesn't recognize those.
                 {
                     string prefix = InstType.ToString(context) + ".";
@@ -1464,9 +1476,6 @@ namespace UndertaleModLib.Decompiler
                     context.assetTypes[Var] = current; // This is a messy fix to arrays messing up exported variable types.
                 return current;
             }
-
-            public bool NeedsArrayParameters => VarType == UndertaleInstruction.VariableType.Array;
-            public bool NeedsInstanceParameters => VarType == UndertaleInstruction.VariableType.StackTop;
         }
 
         // Represents a with statement beginning (pushing to the env stack).
@@ -1682,16 +1691,9 @@ namespace UndertaleModLib.Decompiler
                         break;
 
                     case UndertaleInstruction.Opcode.Popz:
-                        if (stack.Count > 0)
-                        {
-                            Expression popped = stack.Pop();
-                            if (!popped.IsDuplicationSafe()) // <- not duplication safe = has side effects and needs to be listed in the output
-                                statements.Add(popped);
-                        }
-                        else
-                        {
-                            statements.Add(new CommentStatement("WARNING: Popz'd an empty stack."));
-                        }
+                        Expression popped = stack.Pop();
+                        if (!popped.IsDuplicationSafe()) // <- not duplication safe = has side effects and needs to be listed in the output
+                            statements.Add(popped);
                         break;
 
                     case UndertaleInstruction.Opcode.Conv:
@@ -1776,30 +1778,32 @@ namespace UndertaleModLib.Decompiler
                                 throw new Exception("Unrecognized pop instruction, doesn't conform to pop.i.X, pop.v.X, or pop.e.v");
                             if (instr.Type1 == UndertaleInstruction.DataType.Int32)
                                 val = stack.Pop();
-                            if (target.NeedsInstanceParameters)
+                            switch (target.VarType)
                             {
-                                target.InstType = stack.Pop();
-                                if (target.InstType is ExpressionConstant c &&
-                                    c.Type == UndertaleInstruction.DataType.Int16 && (short)c.Value == -9)
+                                case UndertaleInstruction.VariableType.Normal:
+                                case UndertaleInstruction.VariableType.Instance:
+                                    break;
+                                case UndertaleInstruction.VariableType.StackTop:
                                     target.InstType = stack.Pop();
-                            }
-                            else if (target.NeedsArrayParameters)
-                            {
-                                Tuple<Expression, Expression> ind = ExpressionVar.Decompile2DArrayIndex(stack.Pop());
-                                target.ArrayIndices = new List<Expression> { ind.Item1 };
-                                if (ind.Item2 != null)
-                                    target.ArrayIndices.Add(ind.Item2);
-                                target.InstType = stack.Pop();
-                                if (target.InstType is ExpressionConstant c &&
-                                    c.Type == UndertaleInstruction.DataType.Int16 && (short)c.Value == -9)
+                                    break;
+                                case UndertaleInstruction.VariableType.Array:
+                                    Tuple<Expression, Expression> ind = ExpressionVar.Decompile2DArrayIndex(stack.Pop());
+                                    target.ArrayIndices = new List<Expression> { ind.Item1 };
+                                    if (ind.Item2 != null)
+                                        target.ArrayIndices.Add(ind.Item2);
                                     target.InstType = stack.Pop();
+                                    break;
+                                default:
+                                    throw new NotImplementedException("Don't know how to decompile variable type " + target.VarType);
                             }
-
+                            if (target.InstType is ExpressionConstant c &&
+                                c.Type == UndertaleInstruction.DataType.Int16 && (short)c.Value == -9)
+                                target.InstType = stack.Pop();
                             if (instr.Type1 == UndertaleInstruction.DataType.Variable)
                                 val = stack.Pop();
                             if (val != null)
                             {
-                                if ((target.NeedsInstanceParameters || target.NeedsArrayParameters) && target.InstType.WasDuplicated)
+                                if ((target.VarType == UndertaleInstruction.VariableType.StackTop || target.VarType == UndertaleInstruction.VariableType.Array) && target.InstType.WasDuplicated)
                                 {
                                     // Almost safe to assume that this is a +=, -=, etc.
                                     // Need to confirm a few things first. It's not certain, could be ++ even.
@@ -1846,30 +1850,32 @@ namespace UndertaleModLib.Decompiler
                         {
                             ExpressionVar pushTarget = new ExpressionVar((instr.Value as UndertaleInstruction.Reference<UndertaleVariable>).Target, new ExpressionConstant(UndertaleInstruction.DataType.Int16, instr.TypeInst), (instr.Value as UndertaleInstruction.Reference<UndertaleVariable>).Type);
                             pushTarget.Opcode = instr.Kind;
-                            if (pushTarget.NeedsInstanceParameters)
+                            switch(pushTarget.VarType)
                             {
-                                pushTarget.InstType = stack.Pop();
-                                if (pushTarget.InstType is ExpressionConstant c &&
-                                    c.Type == UndertaleInstruction.DataType.Int16 && (short)c.Value == -9)
+                                case UndertaleInstruction.VariableType.Normal:
+                                case UndertaleInstruction.VariableType.Instance:
+                                    break;
+                                case UndertaleInstruction.VariableType.StackTop:
                                     pushTarget.InstType = stack.Pop();
-                            }
-                            else if (pushTarget.NeedsArrayParameters)
-                            {
-                                Tuple<Expression, Expression> ind = ExpressionVar.Decompile2DArrayIndex(stack.Pop());
-                                pushTarget.ArrayIndices = new List<Expression>() { ind.Item1 };
-                                if (ind.Item2 != null)
-                                    pushTarget.ArrayIndices.Add(ind.Item2);
-                                pushTarget.InstType = stack.Pop();
-                                if (pushTarget.InstType is ExpressionConstant c &&
-                                    c.Type == UndertaleInstruction.DataType.Int16 && (short)c.Value == -9)
+                                    break;
+                                case UndertaleInstruction.VariableType.Array:
+                                    Tuple<Expression, Expression> ind = ExpressionVar.Decompile2DArrayIndex(stack.Pop());
+                                    pushTarget.ArrayIndices = new List<Expression>() { ind.Item1 };
+                                    if (ind.Item2 != null)
+                                        pushTarget.ArrayIndices.Add(ind.Item2);
                                     pushTarget.InstType = stack.Pop();
+                                    break;
+                                case UndertaleInstruction.VariableType.ArrayPopAF:
+                                case UndertaleInstruction.VariableType.ArrayPushAF:
+                                    pushTarget.ArrayIndices = new List<Expression>() { stack.Pop() };
+                                    pushTarget.InstType = stack.Pop();
+                                    break;
+                                default:
+                                    throw new NotImplementedException("Don't know how to decompile variable type " + pushTarget.VarType);
                             }
-                            else if (context.Data?.GMS2_3 == true && pushTarget.VarType != UndertaleInstruction.VariableType.Normal)
-                            {
-                                // Special arrays
-                                pushTarget.ArrayIndices = new List<Expression>() { stack.Pop() };
+                            if (pushTarget.InstType is ExpressionConstant c &&
+                                c.Type == UndertaleInstruction.DataType.Int16 && (short)c.Value == -9)
                                 pushTarget.InstType = stack.Pop();
-                            }
                             stack.Push(pushTarget);
                         }
                         else
@@ -1950,43 +1956,61 @@ namespace UndertaleModLib.Decompiler
                         {
                             switch ((short)instr.Value)
                             {
-                                case -2: // pushaf
+                                case -2: // GMS2.3+, pushaf
                                     {
                                         // TODO, work out more specifics here, like ++
                                         Expression ind = stack.Pop();
-                                        ExpressionVar target = stack.Pop() as ExpressionVar;
-                                        target.ArrayIndices.Add(ind);
-                                        stack.Push(target);
+                                        Expression target = stack.Pop();
+                                        if (target is ExpressionVar targetVar)
+                                        {
+                                            if (targetVar.VarType != UndertaleInstruction.VariableType.ArrayPushAF && targetVar.VarType != UndertaleInstruction.VariableType.ArrayPopAF) // The popaf arrays support pushaf as well, judging by how they are used with dup
+                                                throw new InvalidOperationException("Tried to pushaf on var of type " + targetVar.VarType);
+
+                                            ExpressionVar newVar = new ExpressionVar(targetVar.Var, targetVar.InstType, targetVar.VarType);
+                                            newVar.Opcode = instr.Kind;
+                                            newVar.ArrayIndices = new List<Expression>(targetVar.ArrayIndices);
+                                            newVar.ArrayIndices.Add(ind);
+                                            stack.Push(newVar);
+                                        }
+                                        else
+                                            throw new InvalidOperationException("Tried to pushaf on something that is not a var");
                                     }
                                     break;
-                                case -3: // popaf
+                                case -3: // GMS2.3+, popaf
                                     {
                                         // TODO, work out more specifics here, like ++
                                         Expression ind = stack.Pop();
-                                        ExpressionVar target = stack.Pop() as ExpressionVar;
-                                        target.ArrayIndices.Add(ind);
-                                        Expression value = stack.Pop();
-                                        statements.Add(new AssignmentStatement(target, value));
+                                        Expression target = stack.Pop();
+                                        if (target is ExpressionVar targetVar)
+                                        {
+                                            if (targetVar.VarType != UndertaleInstruction.VariableType.ArrayPopAF)
+                                                throw new InvalidOperationException("Tried to popaf on var of type " + targetVar.VarType);
+
+                                            ExpressionVar newVar = new ExpressionVar(targetVar.Var, targetVar.InstType, targetVar.VarType);
+                                            newVar.Opcode = instr.Kind;
+                                            newVar.ArrayIndices = new List<Expression>(targetVar.ArrayIndices);
+                                            newVar.ArrayIndices.Add(ind);
+
+                                            Expression value = stack.Pop();
+                                            statements.Add(new AssignmentStatement(newVar, value));
+                                        }
+                                        else
+                                            throw new InvalidOperationException("Tried to popaf on something that is not a var");
                                     }
                                     break;
-                                case -5: // setowner
+                                case -5: // GMS2.3+, setowner
                                     // Stop 'setowner' values from leaking into the decompiled output as tempvars.
                                     // Used in the VM to let copy-on-write functionality work, but unnecessary for decompilation
-                                    if (stack.Count > 0)
-                                    {
-                                        stack.Pop();
-                                        /*
-                                        var statement = stack.Pop();
-                                        object owner;
-                                        if (statement is ExpressionConstant)
-                                            owner = (statement as ExpressionConstant).Value?.ToString();
-                                        else
-                                            owner = statement.ToString(context);
-                                        statements.Add(new CommentStatement("setowner: " + (owner ?? "<null>")));
-                                        */
-                                    }
+                                    stack.Pop();
+                                    /*
+                                    var statement = stack.Pop();
+                                    object owner;
+                                    if (statement is ExpressionConstant)
+                                        owner = (statement as ExpressionConstant).Value?.ToString();
                                     else
-                                        statements.Add(new CommentStatement("WARNING: attempted to setowner without an owner on the stack."));
+                                        owner = statement.ToString(context);
+                                    statements.Add(new CommentStatement("setowner: " + (owner ?? "<null>")));
+                                    */
                                     break;
                             }
                         }

--- a/UndertaleModLib/Decompiler/Disassembler.cs
+++ b/UndertaleModLib/Decompiler/Disassembler.cs
@@ -44,7 +44,7 @@ namespace UndertaleModLib.Decompiler
                 sb.Append(code.GenerateLocalVarDefinitions(vars, locals));
 
             Dictionary<uint, string> fragments = new Dictionary<uint, string>();
-            foreach (var dup in code.Duplicates)
+            foreach (var dup in code.ChildEntries)
                 fragments.Add(dup.Offset / 4, (dup.Name?.Content ?? "<null>") + $" (locals={dup.LocalsCount}, argc={dup.ArgumentsCount})");
             List<uint> blocks = FindBlockAddresses(code);
 

--- a/UndertaleModLib/Models/UndertaleCode.cs
+++ b/UndertaleModLib/Models/UndertaleCode.cs
@@ -959,9 +959,9 @@ namespace UndertaleModLib.Models
         public uint Offset { get; set; }
         public List<UndertaleInstruction> Instructions { get; } = new List<UndertaleInstruction>();
         public bool WeirdLocalFlag { get; set; }
-        public bool DuplicateEntry { get; set; } = false;
 
-        public List<UndertaleCode> Duplicates { get; set; } = new List<UndertaleCode>();
+        public UndertaleCode ParentEntry { get; set; } = null;
+        public List<UndertaleCode> ChildEntries { get; set; } = new List<UndertaleCode>();
 
         internal uint _BytecodeAbsoluteAddress;
         internal byte[] _UnsupportedBuffer;
@@ -970,7 +970,7 @@ namespace UndertaleModLib.Models
         {
             if (writer.undertaleData.UnsupportedBytecodeVersion || writer.Bytecode14OrLower)
                 return;
-            if (DuplicateEntry)
+            if (ParentEntry != null)
             {
                 // In GMS 2.3, code entries repeat often
                _BytecodeAbsoluteAddress = writer.LastBytecodeAddress;
@@ -1060,8 +1060,8 @@ namespace UndertaleModLib.Models
                 reader.Position = _BytecodeAbsoluteAddress;
                 if (Length > 0 && reader.GMS2_3 && reader.GetOffsetMap().TryGetValue(_BytecodeAbsoluteAddress, out var i))
                 {
-                    DuplicateEntry = true;
-                    (i as UndertaleInstruction).Entry.Duplicates.Add(this);
+                    ParentEntry = (i as UndertaleInstruction).Entry;
+                    ParentEntry.ChildEntries.Add(this);
                 }
                 Instructions.Clear();
                 while (reader.Position < _BytecodeAbsoluteAddress + Length)
@@ -1071,7 +1071,7 @@ namespace UndertaleModLib.Models
                     instr.Address = a;
                     Instructions.Add(instr);
                 }
-                if (!DuplicateEntry && Instructions.Count != 0)
+                if (ParentEntry == null && Instructions.Count != 0)
                     Instructions[0].Entry = this;
                 reader.Position = here;
                 Offset = reader.ReadUInt32();

--- a/UndertaleModLib/Models/UndertaleCode.cs
+++ b/UndertaleModLib/Models/UndertaleCode.cs
@@ -134,10 +134,12 @@ namespace UndertaleModLib.Models
 
         public enum VariableType : byte
         {
-            Array,
+            Array = 0x00,
             StackTop = 0x80,
             Normal = 0xA0,
-            Unknown = 0xE0,  // room scope?
+            Instance = 0xE0, // the InstanceType is an instance ID inside the room -100000
+            ArrayPushAF = 0x10, // GMS2.3+, multidimensional array with pushaf
+            ArrayPopAF = 0x90, // GMS2.3+, multidimensional array with pushaf or popaf
         }
 
         public enum ComparisonType : byte

--- a/UndertaleModLib/Models/UndertaleString.cs
+++ b/UndertaleModLib/Models/UndertaleString.cs
@@ -39,11 +39,6 @@ namespace UndertaleModLib.Models
             return ToString(true);
         }
 
-        public string ToString(DecompileContext context)
-        {
-            return ToString(context.isGameMaker2);
-        }
-
         public string ToString(bool isGMS2)
         {
             if (Content == null)

--- a/UndertaleModTests/GameLoadingTests.cs
+++ b/UndertaleModTests/GameLoadingTests.cs
@@ -33,7 +33,7 @@ namespace UndertaleModTests
         [TestMethod]
         public void DecompileAllScripts()
         {
-            DecompileContext context = new DecompileContext(data, true);
+            GlobalDecompileContext context = new GlobalDecompileContext(data, true);
             Parallel.ForEach(data.Code, (code) =>
             {
                 //Console.WriteLine(code.Name.Content);

--- a/UndertaleModTool/CommunityScripts/UndertaleWithJSONs.csx
+++ b/UndertaleModTool/CommunityScripts/UndertaleWithJSONs.csx
@@ -13,7 +13,7 @@ int maxCount = 1;
 EnsureDataLoaded();
 
 string langFolder = GetFolder(FilePath) + "lang" + Path.DirectorySeparatorChar;
-ThreadLocal<DecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<DecompileContext>(() => new DecompileContext(Data, false));
+ThreadLocal<GlobalDecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<GlobalDecompileContext>(() => new GlobalDecompileContext(Data, false));
 
 if (Directory.Exists(langFolder)) 
 {

--- a/UndertaleModTool/DemoScripts/TestExportAllCode.csx
+++ b/UndertaleModTool/DemoScripts/TestExportAllCode.csx
@@ -7,7 +7,7 @@ using System.Collections;
 
 int progress = 0;
 string codeFolder = GetFolder(FilePath) + "Export_Code" + Path.DirectorySeparatorChar;
-ThreadLocal<DecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<DecompileContext>(() => new DecompileContext(Data, false));
+ThreadLocal<GlobalDecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<GlobalDecompileContext>(() => new GlobalDecompileContext(Data, false));
 
 Directory.CreateDirectory(codeFolder);
 

--- a/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
@@ -207,10 +207,10 @@ namespace UndertaleModTool
             string text;
 
             DisassemblyEditor.TextArea.ClearSelection();
-            if (code.DuplicateEntry)
+            if (code.ParentEntry != null)
             {
                 DisassemblyEditor.IsReadOnly = true;
-                text = "; Duplicate code entry; cannot edit here.";
+                text = "; This code entry is a reference to an anonymous function within " + code.ParentEntry.Name.Content + ", view it there";
             }
             else
             {
@@ -295,9 +295,9 @@ namespace UndertaleModTool
         {
             DecompiledEditor.IsReadOnly = true;
             DecompiledEditor.TextArea.ClearSelection();
-            if (code.DuplicateEntry)
+            if (code.ParentEntry != null)
             {
-                DecompiledEditor.Text = "// Duplicate code entry; cannot edit here.";
+                DecompiledEditor.Text = "// This code entry is a reference to an anonymous function within " + code.ParentEntry.Name.Content + ", view it there";
                 CurrentDecompiled = code;
                 existingDialog?.TryClose();
             }
@@ -451,7 +451,7 @@ namespace UndertaleModTool
 
         private async void GraphCode(UndertaleCode code)
         {
-            if (code.DuplicateEntry)
+            if (code.ParentEntry != null)
             {
                 GraphView.Source = null;
                 CurrentGraphed = code;
@@ -466,7 +466,11 @@ namespace UndertaleModTool
                 try
                 {
                     code.UpdateAddresses();
-                    var blocks = Decompiler.DecompileFlowGraph(code);
+                    List<uint> entryPoints = new List<uint>();
+                    entryPoints.Add(0);
+                    foreach (UndertaleCode duplicate in code.ChildEntries)
+                        entryPoints.Add(duplicate.Offset / 4);
+                    var blocks = Decompiler.DecompileFlowGraph(code, entryPoints);
                     string dot = Decompiler.ExportFlowGraph(blocks);
 
                     try
@@ -475,6 +479,7 @@ namespace UndertaleModTool
                         var getProcessStartInfoQuery = new GetProcessStartInfoQuery();
                         var registerLayoutPluginCommand = new RegisterLayoutPluginCommand(getProcessStartInfoQuery, getStartProcessQuery);
                         var wrapper = new GraphGeneration(getStartProcessQuery, getProcessStartInfoQuery, registerLayoutPluginCommand);
+                        wrapper.GraphvizPath = Settings.Instance.GraphVizPath;
 
                         byte[] output = wrapper.GenerateGraph(dot, Enums.GraphReturnType.Png); // TODO: Use SVG instead
 
@@ -530,7 +535,7 @@ namespace UndertaleModTool
             UndertaleCode code = this.DataContext as UndertaleCode;
             if (code == null)
                 return; // Probably loaded another data.win or something.
-            if (code.DuplicateEntry)
+            if (code.ParentEntry != null)
                 return;
 
             // Check to make sure this isn't an element inside of the textbox, or another tab
@@ -652,7 +657,7 @@ namespace UndertaleModTool
             UndertaleCode code = this.DataContext as UndertaleCode;
             if (code == null)
                 return; // Probably loaded another data.win or something.
-            if (code.DuplicateEntry)
+            if (code.ParentEntry != null)
                 return;
 
             // Check to make sure this isn't an element inside of the textbox, or another tab

--- a/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
@@ -944,9 +944,17 @@ namespace UndertaleModTool
                     // Process the content of this identifier/function
                     if (func)
                     {
-                        val = data.Scripts.ByName(m.Value);
+                        val = null;
+                        if (!data.GMS2_3) // in GMS2.3 every custom "function" is in fact a member variable and scripts are never referenced directly
+                            val = data.Scripts.ByName(m.Value);
                         if (val == null)
+                        {
                             val = data.Functions.ByName(m.Value);
+                            if (val != null)
+                                Debug.WriteLine(val.Name.Content);
+                            if (data.GMS2_3 && val != null && data.Code.ByName(val.Name.Content) != null)
+                                val = null; // in GMS2.3 every custom "function" is in fact a member variable, and the names in functions make no sense (they have the gml_Script_ prefix)
+                        }
                         if (val == null)
                         {
                             if (data.BuiltinList.Functions.ContainsKey(m.Value))
@@ -959,7 +967,11 @@ namespace UndertaleModTool
                         }
                     }
                     else
+                    {
                         val = data.ByName(m.Value);
+                        if (data.GMS2_3 & val is UndertaleScript)
+                            val = null; // in GMS2.3 scripts are never referenced directly
+                    }
                     if (val == null)
                     {
                         if (offset >= 7)

--- a/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
@@ -239,7 +239,7 @@ namespace UndertaleModTool
             gettext = new Dictionary<string, string>();
             string[] decompilationOutput;
             if (!SettingsWindow.ProfileModeEnabled)
-                decompilationOutput = Decompiler.Decompile(gettextCode, new DecompileContext(null, false)).Replace("\r\n", "\n").Split('\n');
+                decompilationOutput = Decompiler.Decompile(gettextCode, new GlobalDecompileContext(null, false)).Replace("\r\n", "\n").Split('\n');
             else
             {
                 try
@@ -248,11 +248,11 @@ namespace UndertaleModTool
                     if (File.Exists(path))
                         decompilationOutput = File.ReadAllText(path).Replace("\r\n", "\n").Split('\n');
                     else
-                        decompilationOutput = Decompiler.Decompile(gettextCode, new DecompileContext(null, false)).Replace("\r\n", "\n").Split('\n');
+                        decompilationOutput = Decompiler.Decompile(gettextCode, new GlobalDecompileContext(null, false)).Replace("\r\n", "\n").Split('\n');
                 }
                 catch
                 {
-                    decompilationOutput = Decompiler.Decompile(gettextCode, new DecompileContext(null, false)).Replace("\r\n", "\n").Split('\n');
+                    decompilationOutput = Decompiler.Decompile(gettextCode, new GlobalDecompileContext(null, false)).Replace("\r\n", "\n").Split('\n');
                 }
             }
             foreach (var line in decompilationOutput)
@@ -333,7 +333,7 @@ namespace UndertaleModTool
                 var dataa = (Application.Current.MainWindow as MainWindow).Data;
                 Task t = Task.Run(() =>
                 {
-                    DecompileContext context = new DecompileContext(dataa, false);
+                    GlobalDecompileContext context = new GlobalDecompileContext(dataa, false);
                     string decompiled = null;
                     Exception e = null;
                     try

--- a/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
@@ -950,8 +950,6 @@ namespace UndertaleModTool
                         if (val == null)
                         {
                             val = data.Functions.ByName(m.Value);
-                            if (val != null)
-                                Debug.WriteLine(val.Name.Content);
                             if (data.GMS2_3 && val != null && data.Code.ByName(val.Name.Content) != null)
                                 val = null; // in GMS2.3 every custom "function" is in fact a member variable, and the names in functions make no sense (they have the gml_Script_ prefix)
                         }

--- a/UndertaleModTool/HelperScripts/CheckDecompiler_2_3.csx
+++ b/UndertaleModTool/HelperScripts/CheckDecompiler_2_3.csx
@@ -13,7 +13,7 @@ using UndertaleModLib.Util;
 
 EnsureDataLoaded();
 
-ThreadLocal<DecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<DecompileContext>(() => new DecompileContext(Data, false));
+ThreadLocal<GlobalDecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<GlobalDecompileContext>(() => new GlobalDecompileContext(Data, false));
 int progress = 0;
 int identical_count = 0;
 

--- a/UndertaleModTool/ImportCodeSystem.cs
+++ b/UndertaleModTool/ImportCodeSystem.cs
@@ -111,7 +111,7 @@ namespace UndertaleModTool
             }
             if (Data.ToolInfo.ProfileMode == false || Data.GMS2_3)
             {
-                ThreadLocal<DecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<DecompileContext>(() => new DecompileContext(Data, false));
+                ThreadLocal<GlobalDecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<GlobalDecompileContext>(() => new GlobalDecompileContext(Data, false));
                 try
                 {
                     passBack = GetPassBack((code != null ? Decompiler.Decompile(code, DECOMPILE_CONTEXT.Value) : ""), keyword, replacement, case_sensitive, isRegex);
@@ -135,7 +135,7 @@ namespace UndertaleModTool
                     }
                     else
                     {
-                        ThreadLocal<DecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<DecompileContext>(() => new DecompileContext(Data, false));
+                        ThreadLocal<GlobalDecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<GlobalDecompileContext>(() => new GlobalDecompileContext(Data, false));
                         try
                         {
                             passBack = GetPassBack((code != null ? Decompiler.Decompile(code, DECOMPILE_CONTEXT.Value) : ""), keyword, replacement, case_sensitive, isRegex);

--- a/UndertaleModTool/MainWindow.xaml
+++ b/UndertaleModTool/MainWindow.xaml
@@ -278,6 +278,16 @@
                             </TreeViewItem.ItemTemplate>
                         </TreeViewItem>
                         <TreeViewItem Header="Code" ItemsSource="{Binding Code, Converter={StaticResource FilteredViewConverter}}" Visibility="{Binding Code, Converter={StaticResource VisibleIfNotNull}}">
+                            <TreeViewItem.ItemContainerStyle>
+                                <Style TargetType="{x:Type TreeViewItem}">
+                                    <Setter Property="Foreground" Value="Gray"></Setter>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding Path=ParentEntry}" Value="{x:Null}">
+                                            <Setter Property="Foreground" Value="Black"></Setter>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TreeViewItem.ItemContainerStyle>
                             <TreeViewItem.ItemTemplate>
                                 <HierarchicalDataTemplate DataType="{x:Type undertale:UndertaleCode}">
                                     <TextBlock Text="{Binding Name.Content}" />
@@ -298,7 +308,7 @@
                                 </HierarchicalDataTemplate>
                             </TreeViewItem.ItemTemplate>
                         </TreeViewItem>
-                        <TreeViewItem Header="Code locals (unused?)" ItemsSource="{Binding CodeLocals, Converter={StaticResource FilteredViewConverter}}" Foreground="Gray" Visibility="{Binding CodeLocals, Converter={StaticResource VisibleIfNotNull}}">
+                        <TreeViewItem Header="Code locals" ItemsSource="{Binding CodeLocals, Converter={StaticResource FilteredViewConverter}}" Visibility="{Binding CodeLocals, Converter={StaticResource VisibleIfNotNull}}">
                             <TreeViewItem.ItemTemplate>
                                 <HierarchicalDataTemplate DataType="{x:Type undertale:UndertaleCodeLocals}">
                                     <TextBlock Text="{Binding Name.Content}" />

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -685,7 +685,6 @@ Please extract all contents of the ZIP file to a folder before running the progr
                     "General info" => new GeneralInfoEditor(Data?.GeneralInfo, Data?.Options, Data?.Language),
                     "Global init" => new GlobalInitEditor(Data?.GlobalInitScripts),
                     "Game End scripts" => new GameEndEditor(Data?.GameEndScripts),
-                    "Code locals (unused?)" => new DescriptionView(item, "This seems to be unused as far as I can tell - you can remove the whole list and nothing happens"),
                     "Variables" => (object)Data.FORM.Chunks["VARI"],
                     _ => new DescriptionView(item, "Expand the list on the left to edit items"),
                 };

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -543,7 +543,7 @@ Please extract all contents of the ZIP file to a folder before running the progr
                         object countLock = new object();
                         string[] outputs = new string[Data.Code.Count];
                         UndertaleDebugInfo[] outputsOffsets = new UndertaleDebugInfo[Data.Code.Count];
-                        DecompileContext context = new DecompileContext(Data, false);
+                        GlobalDecompileContext context = new GlobalDecompileContext(Data, false);
                         Parallel.For(0, Data.Code.Count, (i) =>
                         {
                             var code = Data.Code[i];

--- a/UndertaleModTool/ProfileSystem.cs
+++ b/UndertaleModTool/ProfileSystem.cs
@@ -19,7 +19,7 @@ namespace UndertaleModTool
         public string GetDecompiledText(string codeName)
         {
             UndertaleCode code = Data.Code.ByName(codeName);
-            ThreadLocal<DecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<DecompileContext>(() => new DecompileContext(Data, false));
+            ThreadLocal<GlobalDecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<GlobalDecompileContext>(() => new GlobalDecompileContext(Data, false));
             try
             {
                 return code != null ? Decompiler.Decompile(code, DECOMPILE_CONTEXT.Value) : "";

--- a/UndertaleModTool/Repackers/GameObjectCopy.csx
+++ b/UndertaleModTool/Repackers/GameObjectCopy.csx
@@ -123,7 +123,7 @@ for (var j = 0; j < splitStringsList.Count; j++)
                                 nativeACT.ActionName = Data.Strings.MakeString(donorACT.ActionName.Content);
                             if (donorACT.CodeId?.Name?.Content != null)
                             {
-                                ThreadLocal<DecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<DecompileContext>(() => new DecompileContext(DonorData, false));
+                                ThreadLocal<GlobalDecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<GlobalDecompileContext>(() => new GlobalDecompileContext(DonorData, false));
                                 string codeToCopy = "";
                                 try
                                 {

--- a/UndertaleModTool/Repackers/GameObjectCopyInternal.csx
+++ b/UndertaleModTool/Repackers/GameObjectCopyInternal.csx
@@ -83,7 +83,7 @@ for (var j = 0; j < splitStringsList.Count; j++)
                                 nativeACT.ActionName = Data.Strings.MakeString(donorACT.ActionName.Content);
                             if (donorACT.CodeId?.Name?.Content != null)
                             {
-                                ThreadLocal<DecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<DecompileContext>(() => new DecompileContext(Data, false));
+                                ThreadLocal<GlobalDecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<GlobalDecompileContext>(() => new GlobalDecompileContext(Data, false));
                                 string codeToCopy = "";
                                 try
                                 {

--- a/UndertaleModTool/SampleScripts/Search.csx
+++ b/UndertaleModTool/SampleScripts/Search.csx
@@ -14,7 +14,7 @@ int progress = 0;
 string results = "";
 int result_count = 0;
 int code_count = 0;
-ThreadLocal<DecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<DecompileContext>(() => new DecompileContext(Data, false));
+ThreadLocal<GlobalDecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<GlobalDecompileContext>(() => new GlobalDecompileContext(Data, false));
 
 UpdateProgress();
 

--- a/UndertaleModTool/TechnicalScripts/ExportAllCode2_3.csx
+++ b/UndertaleModTool/TechnicalScripts/ExportAllCode2_3.csx
@@ -17,7 +17,7 @@ else
 
 int progress = 0;
 string codeFolder = GetFolder(FilePath) + "Export_Code" + Path.DirectorySeparatorChar;
-ThreadLocal<DecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<DecompileContext>(() => new DecompileContext(Data, false));
+ThreadLocal<GlobalDecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<GlobalDecompileContext>(() => new GlobalDecompileContext(Data, false));
 
 if (Directory.Exists(codeFolder)) 
 {

--- a/UndertaleModTool/TechnicalScripts/ExportAllCodeSync.csx
+++ b/UndertaleModTool/TechnicalScripts/ExportAllCodeSync.csx
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 int progress = 0;
 string codeFolder = GetFolder(FilePath) + "Export_Code" + Path.DirectorySeparatorChar;
-ThreadLocal<DecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<DecompileContext>(() => new DecompileContext(Data, false));
+ThreadLocal<GlobalDecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<GlobalDecompileContext>(() => new GlobalDecompileContext(Data, false));
 
 if (Directory.Exists(codeFolder)) 
 {

--- a/UndertaleModTool/TechnicalScripts/ExportAllCodeSync.csx
+++ b/UndertaleModTool/TechnicalScripts/ExportAllCodeSync.csx
@@ -37,7 +37,7 @@ void DumpCode()
     foreach(UndertaleCode code in Data.Code)
     {
         string path = Path.Combine(codeFolder, code.Name.Content + ".gml");
-        if (!(code.DuplicateEntry))
+        if (code.ParentEntry == null)
         {
             if (path.Length > 150)
             {

--- a/UndertaleModTool/TechnicalScripts/ExportAndConvert_2_3_ASM.csx
+++ b/UndertaleModTool/TechnicalScripts/ExportAndConvert_2_3_ASM.csx
@@ -12,7 +12,7 @@ if (Data.ToolInfo.ProfileMode)
 
 int progress = 0;
 string codeFolder = GetFolder(FilePath) + "Export_Assembly2" + Path.DirectorySeparatorChar;
-ThreadLocal<DecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<DecompileContext>(() => new DecompileContext(Data, false));
+ThreadLocal<GlobalDecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<GlobalDecompileContext>(() => new GlobalDecompileContext(Data, false));
 
 if (Directory.Exists(codeFolder)) 
 {

--- a/UndertaleModTool/TechnicalScripts/ExportAndConvert_2_3_ASM.csx
+++ b/UndertaleModTool/TechnicalScripts/ExportAndConvert_2_3_ASM.csx
@@ -72,7 +72,7 @@ void DumpCode()
                 }
                 code_orig.LocalsCount = codeLocalsCount;
                 code_orig.GenerateLocalVarDefinitions(code_orig.FindReferencedLocalVars(), locals); // Dunno if we actually need this line, but it seems to work?
-                code_orig.DuplicateEntry = false;
+                code_orig.ParentEntry = null;
             }
             else
             {
@@ -86,7 +86,7 @@ void DumpCode()
             Data.CodeLocals.Add(locals);
         }
         string path = Path.Combine(codeFolder, code_orig.Name.Content + ".asm");
-        if (!code_orig.DuplicateEntry)
+        if (code_orig.ParentEntry == null)
         {
             string x = "";
             try 

--- a/UndertaleModTool/Unpackers/DumpSpecificCode.csx
+++ b/UndertaleModTool/Unpackers/DumpSpecificCode.csx
@@ -86,7 +86,7 @@ for (var j = 0; j < codeToDump.Count; j++)
 void DumpCode(UndertaleCode code) 
 {
     string path = Path.Combine(codeFolder, code.Name.Content + ".gml");
-    if (!(code.DuplicateEntry))
+    if (code.ParentEntry == null)
     {
         if (path.Length > 150)
         {

--- a/UndertaleModTool/Unpackers/DumpSpecificCode.csx
+++ b/UndertaleModTool/Unpackers/DumpSpecificCode.csx
@@ -6,7 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using UndertaleModLib.Util;
 
-ThreadLocal<DecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<DecompileContext>(() => new DecompileContext(Data, false));
+ThreadLocal<GlobalDecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<GlobalDecompileContext>(() => new GlobalDecompileContext(Data, false));
 
 int failed = 0;
 

--- a/UndertaleModTool/Unpackers/ExportASM.csx
+++ b/UndertaleModTool/Unpackers/ExportASM.csx
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 int progress = 0;
 string codeFolder = GetFolder(FilePath) + "Export_Assembly" + Path.DirectorySeparatorChar;
-ThreadLocal<DecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<DecompileContext>(() => new DecompileContext(Data, false));
+ThreadLocal<GlobalDecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<GlobalDecompileContext>(() => new GlobalDecompileContext(Data, false));
 
 if (Directory.Exists(codeFolder)) 
 {

--- a/UndertaleModTool/Unpackers/ExportAllCode.csx
+++ b/UndertaleModTool/Unpackers/ExportAllCode.csx
@@ -4,14 +4,6 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
-if (!((Data.GMS2_3 == false) && (Data.GMS2_3_1 == false) && (Data.GMS2_3_2 == false)))
-{
-    //bool x = RunUMTScript(Path.Combine(ExePath, "HelperScripts", "ExportAllCode2_3.csx"));
-    //if (x == false)
-    ScriptError("Please run \"ExportAllCode2_3.csx\" instead!");
-    return;
-}
-
 int progress = 0;
 string codeFolder = GetFolder(FilePath) + "Export_Code" + Path.DirectorySeparatorChar;
 ThreadLocal<DecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<DecompileContext>(() => new DecompileContext(Data, false));
@@ -24,6 +16,14 @@ if (Directory.Exists(codeFolder))
 
 Directory.CreateDirectory(codeFolder);
 
+var toDump = new List<UndertaleCode>();
+foreach (UndertaleCode code in Data.Code)
+{
+    if (code.ParentEntry != null)
+        continue;
+    toDump.Add(code);
+}
+
 UpdateProgress();
 await DumpCode();
 HideProgressBar();
@@ -31,7 +31,7 @@ ScriptMessage("Export Complete.\n\nLocation: " + codeFolder);
 
 void UpdateProgress()
 {
-    UpdateProgressBar(null, "Code Entries", progress++, Data.Code.Count);
+    UpdateProgressBar(null, "Code Entries", progress++, toDump.Count);
 }
 
 string GetFolder(string path)
@@ -42,7 +42,7 @@ string GetFolder(string path)
 
 async Task DumpCode()
 {
-    await Task.Run(() => Parallel.ForEach(Data.Code, DumpCode));
+    await Task.Run(() => Parallel.ForEach(toDump, DumpCode));
 }
 
 void DumpCode(UndertaleCode code)

--- a/UndertaleModTool/Unpackers/ExportAllCode.csx
+++ b/UndertaleModTool/Unpackers/ExportAllCode.csx
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 int progress = 0;
 string codeFolder = GetFolder(FilePath) + "Export_Code" + Path.DirectorySeparatorChar;
-ThreadLocal<DecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<DecompileContext>(() => new DecompileContext(Data, false));
+ThreadLocal<GlobalDecompileContext> DECOMPILE_CONTEXT = new ThreadLocal<GlobalDecompileContext>(() => new GlobalDecompileContext(Data, false));
 
 if (Directory.Exists(codeFolder))
 {


### PR DESCRIPTION
**EXPERIMENTAL CODE AHEAD**

This adds preliminary supports for the GMS2.3 methods.

* Methods defined using inline functions will now properly inline the body of the function
* Calls to child code objects that are actually method definitions will get resolved to the method name (no more `gml_Script_...`)
* Recursive asset resolution *should* now work with child code blocks (not fully tested)

Needs more testing to make sure it doesn't break any existing decompilation, because I had to mess with how the decompiler generates entry points quite a bit. I'm especially worried about the consequences of removing the unreachable code detector that was apparently fixing the loop detection sometimes.