### PR TITLE
Unbreak compiler

### DIFF
--- a/UndertaleModLib/Compiler/AssemblyWriter.cs
+++ b/UndertaleModLib/Compiler/AssemblyWriter.cs
@@ -212,11 +212,11 @@ namespace UndertaleModLib.Compiler
                         Dictionary<string, UndertaleFunction> knownFunctions = new Dictionary<string, UndertaleFunction>();
                         foreach (UndertaleFunction func in compileContext.Data.Functions)
                         {
-                            if (compileContext.Data.GMS2_3 && compileContext.Data.Code.ByName(func.Name.Content) != null)
-                                continue; // ignore fake functions which are refences to anonymous functions (i.e. don't include gml_Script_...)
+                            //if (compileContext.Data.GMS2_3 && compileContext.Data.Code.ByName(func.Name.Content) != null)
+                            //    continue; // ignore fake functions which are refences to anonymous functions (i.e. don't include gml_Script_...)
                             knownFunctions.Add(func.Name.Content, func);
                         }
-                        if (compileContext.Data.GMS2_3)
+                        if (false)//(compileContext.Data.GMS2_3)
                         {
                             // Find all functions defined in GlobalScripts
                             // TODO: This may be slow...
@@ -259,7 +259,7 @@ namespace UndertaleModLib.Compiler
                             patch.Target.ArgumentsCount = (ushort)patch.ArgCount;
 
                             UndertaleFunction def = knownFunctions.GetValueOrDefault(patch.Name);
-                            if (def == null && compileContext.ensureFunctionsDefined && !compileContext.Data.GMS2_3) // TODO: ensureFunctionsDefined not supported for GMS2_3 for now to avoid accidentaly defining custom functions as builtins
+                            if (def == null && compileContext.ensureFunctionsDefined)// && !compileContext.Data.GMS2_3) // TODO: ensureFunctionsDefined not supported for GMS2_3 for now to avoid accidentaly defining custom functions as builtins
                             {
                                 def = compileContext.Data.Functions?.EnsureDefined(patch.Name, compileContext.Data.Strings);
                                 knownFunctions.Add(patch.Name, def);

--- a/UndertaleModLib/Decompiler/Decompiler.cs
+++ b/UndertaleModLib/Decompiler/Decompiler.cs
@@ -38,7 +38,7 @@ namespace UndertaleModLib.Decompiler
         /// to its actual name, obtained by decompiling the parent CodeObject and looking for the assignment to global variable with function
         /// name.
         /// </summary>
-        public Dictionary<UndertaleFunction, string> AnonymousFunctionNameCache = new Dictionary<UndertaleFunction, string>();
+        //public Dictionary<UndertaleFunction, string> AnonymousFunctionNameCache = new Dictionary<UndertaleFunction, string>();
 
         public GlobalDecompileContext(UndertaleData data, bool enableStringLabels)
         {
@@ -51,7 +51,7 @@ namespace UndertaleModLib.Decompiler
             // This will not be done automatically, because it would cause significant slowdown having to recalculate this each time, and there's no reason to reset it if it's decompiling a bunch at once.
             // But, since it is possible to invalidate this data, we add this here so we'll be able to invalidate it if we need to.
             ScriptArgsCache.Clear();
-            AnonymousFunctionNameCache.Clear();
+            //AnonymousFunctionNameCache.Clear();
         }
     }
 
@@ -1061,7 +1061,7 @@ namespace UndertaleModLib.Decompiler
                 {
                     if (AssetTypeResolver.return_types.ContainsKey(context.TargetCode.Name.Content))
                         Value.DoTypePropagation(context, AssetTypeResolver.return_types[context.TargetCode.Name.Content]);
-                    if (context.GlobalContext.Data != null && !context.GlobalContext.Data.GMS2_3)
+                    if (context.GlobalContext.Data != null)// && !context.GlobalContext.Data.GMS2_3)
                     {
                         // We might be decompiling a legacy script - resolve it's name
                         UndertaleScript script = context.GlobalContext.Data.Scripts.FirstOrDefault(x => x.Code == context.TargetCode);
@@ -2132,12 +2132,13 @@ namespace UndertaleModLib.Decompiler
                                     }
                                 }
 
-                                string funcName;
-                                if (!context.GlobalContext.AnonymousFunctionNameCache.TryGetValue(instr.Function.Target, out funcName))
+                                string funcName = string.Empty;
+/*                                if (!context.GlobalContext.AnonymousFunctionNameCache.TryGetValue(instr.Function.Target, out funcName))
                                 {
                                     funcName = FindActualNameForAnonymousCodeObject(context, callTargetBody);
                                     context.GlobalContext.AnonymousFunctionNameCache.Add(instr.Function.Target, funcName);
                                 }
+*/
                                 if (funcName != string.Empty)
                                 {
                                     stack.Push(new DirectFunctionCall(funcName, instr.Function.Target, instr.Type1, args));

--- a/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
@@ -564,7 +564,14 @@ namespace UndertaleModTool
             var dispatcher = Dispatcher;
             Task t = Task.Run(() =>
             {
-                compileContext = Compiler.CompileGMLText(text, data, code, (f) => { dispatcher.Invoke(() => f()); });
+                try
+                {
+                    compileContext = Compiler.CompileGMLText(text, data, code, (f) => { dispatcher.Invoke(() => f()); });
+                }
+                catch (Exception e)
+                {
+                    throw;// new Exception(e.Message);
+                }
             });
             await t;
 

--- a/UndertaleModTool/HelperScripts/CheckDecompiler_2_3.csx
+++ b/UndertaleModTool/HelperScripts/CheckDecompiler_2_3.csx
@@ -191,9 +191,9 @@ void ImportCode(string importFolder, bool IsGML = true)
             continue; // Restarts loop if file is not a valid code asset.
         string gmlCode = File.ReadAllText(file);
         if (IsGML)
-            ImportGMLString(codeName, gmlCode, true, true);
+            ImportGMLString(codeName, gmlCode, false, true);
         else
-            ImportASMString(codeName, gmlCode, true, true);
+            ImportASMString(codeName, gmlCode, false, true);
     }
     progress = 0;
 }

--- a/UndertaleModTool/ImportCodeSystem.cs
+++ b/UndertaleModTool/ImportCodeSystem.cs
@@ -171,9 +171,13 @@ namespace UndertaleModTool
             catch (Exception exc)
             {
                 if (!CheckDecompiler)
+                {
                     MessageBox.Show("Import" + (IsGML ? "GML" : "ASM") + "File error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                }
                 else
-                    throw new Exception("Error!");
+                {
+                    MessageBox.Show("Import" + (IsGML ? "GML" : "ASM") + "File error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                }
             }
         }
 
@@ -422,7 +426,10 @@ namespace UndertaleModTool
                     MessageBox.Show(ErrorText, "UndertaleModTool", MessageBoxButton.OK, MessageBoxImage.Warning);
                 }
                 else
-                    throw new Exception("Error!");
+                {
+                    ImportASMString(codeName, "", false, true);
+                    //throw new Exception("Error!");
+                }
             }
         }
     }

--- a/UndertaleModTool/ImportCodeSystem.cs
+++ b/UndertaleModTool/ImportCodeSystem.cs
@@ -427,7 +427,7 @@ namespace UndertaleModTool
                 }
                 else
                 {
-                    ImportASMString(codeName, "", false, true);
+                    ImportGMLString(codeName, "", false, true);
                     //throw new Exception("Error!");
                 }
             }

--- a/UndertaleModTool/SampleScripts/FindAndReplace.csx
+++ b/UndertaleModTool/SampleScripts/FindAndReplace.csx
@@ -7,6 +7,12 @@ using System.Text.RegularExpressions;
 
 EnsureDataLoaded();
 
+if (Data?.GeneralInfo?.DisplayName?.Content.ToLower() == "deltarune chapter 1 & 2")
+{
+    ScriptError("Incompatible with the new Deltarune Chapter 1 & 2 demo");
+    return;
+}
+
 int progress = 0;
 
 UpdateProgress();


### PR DESCRIPTION
The compiler takes an extremely long time (probably 20x-100x slower than normal at the minimum) due to linking up simplified names with internal global script entries. The simplification of the names is unnecessary where the unsimplified names produces accurate disassembly of about the same quality. Therefore by removing the unsimplified names aspect it is possible to remove the (and I am stressing this for emphasis) ***extremely slow (practically making the compiler unusable)*** linking code. 

It is recommended to either unsimplify the names (as is crudely done in this pull request) or to find a proper remedy to make the compiler usable, as in its current state it is not adequate for release of any kind, not now nor in the future. 