### PR TITLE
Unbreak compiler

### DIFF
--- a/UndertaleModLib/Compiler/AssemblyWriter.cs
+++ b/UndertaleModLib/Compiler/AssemblyWriter.cs
@@ -212,11 +212,11 @@ namespace UndertaleModLib.Compiler
                         Dictionary<string, UndertaleFunction> knownFunctions = new Dictionary<string, UndertaleFunction>();
                         foreach (UndertaleFunction func in compileContext.Data.Functions)
                         {
-                            if (compileContext.Data.GMS2_3 && compileContext.Data.Code.ByName(func.Name.Content) != null)
-                                continue; // ignore fake functions which are refences to anonymous functions (i.e. don't include gml_Script_...)
+                            //if (compileContext.Data.GMS2_3 && compileContext.Data.Code.ByName(func.Name.Content) != null)
+                            //    continue; // ignore fake functions which are refences to anonymous functions (i.e. don't include gml_Script_...)
                             knownFunctions.Add(func.Name.Content, func);
                         }
-                        if (compileContext.Data.GMS2_3)
+                        if (false)//(compileContext.Data.GMS2_3)
                         {
                             // Find all functions defined in GlobalScripts
                             // TODO: This may be slow...

--- a/UndertaleModLib/Decompiler/Decompiler.cs
+++ b/UndertaleModLib/Decompiler/Decompiler.cs
@@ -38,7 +38,7 @@ namespace UndertaleModLib.Decompiler
         /// to its actual name, obtained by decompiling the parent CodeObject and looking for the assignment to global variable with function
         /// name.
         /// </summary>
-        public Dictionary<UndertaleFunction, string> AnonymousFunctionNameCache = new Dictionary<UndertaleFunction, string>();
+        //public Dictionary<UndertaleFunction, string> AnonymousFunctionNameCache = new Dictionary<UndertaleFunction, string>();
 
         public GlobalDecompileContext(UndertaleData data, bool enableStringLabels)
         {
@@ -51,7 +51,7 @@ namespace UndertaleModLib.Decompiler
             // This will not be done automatically, because it would cause significant slowdown having to recalculate this each time, and there's no reason to reset it if it's decompiling a bunch at once.
             // But, since it is possible to invalidate this data, we add this here so we'll be able to invalidate it if we need to.
             ScriptArgsCache.Clear();
-            AnonymousFunctionNameCache.Clear();
+            //AnonymousFunctionNameCache.Clear();
         }
     }
 
@@ -1061,7 +1061,7 @@ namespace UndertaleModLib.Decompiler
                 {
                     if (AssetTypeResolver.return_types.ContainsKey(context.TargetCode.Name.Content))
                         Value.DoTypePropagation(context, AssetTypeResolver.return_types[context.TargetCode.Name.Content]);
-                    if (context.GlobalContext.Data != null && !context.GlobalContext.Data.GMS2_3)
+                    if (context.GlobalContext.Data != null)// && !context.GlobalContext.Data.GMS2_3)
                     {
                         // We might be decompiling a legacy script - resolve it's name
                         UndertaleScript script = context.GlobalContext.Data.Scripts.FirstOrDefault(x => x.Code == context.TargetCode);
@@ -2132,12 +2132,13 @@ namespace UndertaleModLib.Decompiler
                                     }
                                 }
 
-                                string funcName;
-                                if (!context.GlobalContext.AnonymousFunctionNameCache.TryGetValue(instr.Function.Target, out funcName))
+                                string funcName = string.Empty;
+/*                                if (!context.GlobalContext.AnonymousFunctionNameCache.TryGetValue(instr.Function.Target, out funcName))
                                 {
                                     funcName = FindActualNameForAnonymousCodeObject(context, callTargetBody);
                                     context.GlobalContext.AnonymousFunctionNameCache.Add(instr.Function.Target, funcName);
                                 }
+*/
                                 if (funcName != string.Empty)
                                 {
                                     stack.Push(new DirectFunctionCall(funcName, instr.Function.Target, instr.Type1, args));


### PR DESCRIPTION
The compiler takes an extremely long time (probably 20x-100x slower than normal at the minimum) due to linking up simplified names with internal global script entries. The simplification of the names is unnecessary where the unsimplified names produces accurate disassembly of about the same quality. Therefore by removing the unsimplified names aspect it is possible to remove the (and I am stressing this for emphasis) ***extremely slow (practically making the compiler unusable)*** linking code. 

It is recommended to either unsimplify the names (as is crudely done in this pull request) or to find a proper remedy to make the compiler usable, as in its current state it is not adequate for release of any kind, not now nor in the future. 

Edited to use the minimum number of changes to achieve this.