### PR TITLE
Limiting "Scripts" menu while "data.win" is not loaded.

### DIFF
--- a/UndertaleModTool/MainWindow.xaml
+++ b/UndertaleModTool/MainWindow.xaml
@@ -89,20 +89,20 @@
                     <MenuItem Header="S_ettings" Command="Properties"/>
                     <MenuItem Header="_Close" Command="Close" InputGestureText="Ctrl+W"/>
                 </MenuItem>
-                <MenuItem Header="_Scripts">
-                    <MenuItem Header="_Run builtin script" SubmenuOpened="MenuItem_RunBuiltinScript_SubmenuOpened">
+                <MenuItem x:Name="ScriptsMenuItem" Header="_Scripts">
+                    <MenuItem Header="_Run builtin script" SubmenuOpened="MenuItem_RunBuiltinScript_SubmenuOpened" IsEnabled="False">
                         <MenuItem Header="(...loading...)" IsEnabled="False"/>
                     </MenuItem>
-                    <MenuItem Header="_Run community script" SubmenuOpened="MenuItem_RunCommunityScript_SubmenuOpened">
+                    <MenuItem Header="_Run community script" SubmenuOpened="MenuItem_RunCommunityScript_SubmenuOpened" IsEnabled="False">
                         <MenuItem Header="(...loading...)" IsEnabled="False"/>
                     </MenuItem>
-                    <MenuItem Header="_Unpack assets" SubmenuOpened="MenuItem_RunUnpackScript_SubmenuOpened">
+                    <MenuItem Header="_Unpack assets" SubmenuOpened="MenuItem_RunUnpackScript_SubmenuOpened" IsEnabled="False">
                         <MenuItem Header="(...loading...)" IsEnabled="False"/>
                     </MenuItem>
-                    <MenuItem Header="_Repack assets" SubmenuOpened="MenuItem_RunRepackScript_SubmenuOpened">
+                    <MenuItem Header="_Repack assets" SubmenuOpened="MenuItem_RunRepackScript_SubmenuOpened" IsEnabled="False">
                         <MenuItem Header="(...loading...)" IsEnabled="False"/>
                     </MenuItem>
-                    <MenuItem Header="_Run technical script" SubmenuOpened="MenuItem_RunTechnicalScript_SubmenuOpened">
+                    <MenuItem Header="_Run technical script" SubmenuOpened="MenuItem_RunTechnicalScript_SubmenuOpened" IsEnabled="False">
                         <MenuItem Header="(...loading...)" IsEnabled="False"/>
                     </MenuItem>
                     <MenuItem Header="_Run demo script" SubmenuOpened="MenuItem_RunDemoScript_SubmenuOpened">

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -55,6 +55,7 @@ namespace UndertaleModTool
         public bool CanSafelySave = false;
         public bool WasWarnedAboutTempRun = false;
         public bool FinishedMessageEnabled = true;
+        public bool IsScriptsEnabled = false;
         public bool ScriptExecutionSuccess { get; set; } = true;
         public bool DisplayLongError { get; set; } = true;
         public string ScriptErrorMessage { get; set; } = "";
@@ -541,6 +542,17 @@ namespace UndertaleModTool
                         UndertaleCodeEditor.gettextJSON = null;
                         ChangeSelection(Highlighted = new DescriptionView("Welcome to UndertaleModTool!", "Double click on the items on the left to view them!"));
                         SelectionHistory.Clear();
+
+                        if (!IsScriptsEnabled)
+                        {
+                            foreach (MenuItem item in (FindName("ScriptsMenuItem") as MenuItem).Items)
+                            {
+                                if (!item.IsEnabled)
+                                    item.IsEnabled = true;
+                            }
+
+                            IsScriptsEnabled = true;
+                        }
                     }
                     dialog.Hide();
                 });
@@ -1109,6 +1121,9 @@ namespace UndertaleModTool
                     if (!filename.EndsWith(".csx"))
                         continue;
                     MenuItem subitem = new MenuItem() { Header = filename.Replace("_", "__") };
+                    if (Data == null)
+                        if (filename == "TestExportAllCode.csx")
+                            subitem.IsEnabled = false;
                     subitem.Click += MenuItem_RunBuiltinScript_Item_Click;
                     subitem.CommandParameter = path;
                     item.Items.Add(subitem);


### PR DESCRIPTION
Keep disabled scripts that use "_data.win_", until it will be loaded.