### PR TITLE
Various Console Improvements

### DIFF
--- a/UndertaleModCli/Program.cs
+++ b/UndertaleModCli/Program.cs
@@ -525,7 +525,7 @@ namespace UndertaleModCli
         public bool Make_New_File()
         {
             Data = UndertaleData.CreateNew();
-            Console.WriteLine("Don't you have anything better to do?");
+            Console.WriteLine("New file created.");
             return true;
         }
 
@@ -860,32 +860,32 @@ namespace UndertaleModCli
 
         public string PromptLoadFile(string defaultExt, string filter)
         {
-            throw new NotImplementedException("don't you have ANYTHING better to do?");
+            throw new NotImplementedException("Sorry, this hasn't been implemented yet!");
         }
 
         public void ImportGMLString(string codeName, string gmlCode, bool doParse = true, bool CheckDecompiler = false)
         {
-            throw new NotImplementedException("don't you have ANYTHING better to do?");
+            throw new NotImplementedException("Sorry, this hasn't been implemented yet!");
         }
 
         public void ImportASMString(string codeName, string gmlCode, bool doParse = true, bool destroyASM = true, bool CheckDecompiler = false)
         {
-            throw new NotImplementedException("don't you have ANYTHING better to do?");
+            throw new NotImplementedException("Sorry, this hasn't been implemented yet!");
         }
 
         public void ImportGMLFile(string fileName, bool doParse = true, bool CheckDecompiler = false)
         {
-            throw new NotImplementedException("don't you have ANYTHING better to do?");
+            throw new NotImplementedException("Sorry, this hasn't been implemented yet!");
         }
 
         public void ImportASMFile(string fileName, bool doParse = true, bool destroyASM = true, bool CheckDecompiler = false)
         {
-            throw new NotImplementedException("don't you have ANYTHING better to do?");
+            throw new NotImplementedException("Sorry, this hasn't been implemented yet!");
         }
 
         public void ReplaceTextInGML(string codeName, string keyword, string replacement, bool case_sensitive = false, bool isRegex = false)
         {
-            throw new NotImplementedException("don't you have ANYTHING better to do?");
+            throw new NotImplementedException("Sorry, this hasn't been implemented yet!");
         }
 
         public bool DummyBool()

--- a/UndertaleModCli/Program.cs
+++ b/UndertaleModCli/Program.cs
@@ -171,12 +171,11 @@ namespace UndertaleModCli
 
         public static int Main(string[] args)
         {
-            var verboseOption = new Option<bool>("--verbose", "Detailed logs");
-            verboseOption.AddAlias("-v");
+            var verboseOption = new Option<bool>(new[]{"-v", "--verbose"}, "Detailed logs");
 
             var dataFileOption = new Argument<FileInfo>("datafile")
             {
-                Description = "path to the data.win/.ios/.droid/.unx file"
+                Description = "Path to the data.win/.ios/.droid/.unx file"
             };
 
             var infoCommand = new Command("info", "Show info about game data file")
@@ -186,15 +185,13 @@ namespace UndertaleModCli
             };
             infoCommand.Handler = CommandHandler.Create<InfoOptions>(Program.Info);
 
-            var scriptRunnerOption = new Option<FileInfo[]>("--scripts", "Scripts to apply to the <datafile>. ex. a.csx b.csx");
-            scriptRunnerOption.AddAlias("-s");
-            scriptRunnerOption.AddAlias("--applyscripts");
+            var scriptRunnerOption = new Option<FileInfo[]>(new []{"-s", "--scripts", "--applyscripts"}, "Scripts to apply to the <datafile>. ex. a.csx b.csx");
             var loadCommand = new Command("load", "Load data file and perform actions on it") {
                 dataFileOption,
                 scriptRunnerOption,
                 verboseOption,
-                new Option<FileInfo>("--dest", "Where to save the modified data file"),
-                new Option<string>("--line", "run c# string. Runs AFTER everything else"),
+                new Option<FileInfo>(new[]{"-o", "--output"}, "Where to save the modified data file"),
+                new Option<string>("--line", "Run c# string. Runs AFTER everything else"),
                 new Option<bool>("--interactive", "Interactive menu launch"),
 
             };
@@ -202,9 +199,9 @@ namespace UndertaleModCli
 
             var newCommand = new Command("new", "Generates a blank data file")
             {
-                new Option<FileInfo>(new []{"-d", "--dest" },getDefaultValue: () => new NewOptions().Dest),
+                new Option<FileInfo>(new []{"-o", "--output" },getDefaultValue: () => new NewOptions().Dest),
                 new Option<bool>(new []{"-f", "--overwrite"}, "Overwrite destination file if it already exists"),
-                new Option<bool>(new []{"-o", "--stdout"}, "Write new data content to stdout"),
+                new Option<bool>(new []{"-", "--stdout"}, "Write new data content to stdout"),  // "-" is often used in *nix land as a replacement for stdout
             };
             newCommand.Handler = CommandHandler.Create<NewOptions>(Program.New);
 
@@ -214,7 +211,7 @@ namespace UndertaleModCli
                 newCommand,
                 };
 
-            rootCommand.Description = "cli tool for modding, decompiling and unpacking Undertale (and other Game Maker: Studio games!";
+            rootCommand.Description = "CLI tool for modding, decompiling and unpacking Undertale (and other Game Maker: Studio games)!";
             var commandLine = new CommandLineBuilder(rootCommand)
                                     .UseDefaults() // automatically configures dotnet-suggest
                                     .Build();
@@ -467,7 +464,7 @@ namespace UndertaleModCli
             {
                 case ConsoleKey.D1:
                     {
-                        Console.Write("File path (you can drag and drop on Windows)?: ");
+                        Console.Write("File path (you can drag and drop)? ");
                         string path = Dequote(Console.ReadLine());
                         Console.WriteLine("Trying to run script {0}", path);
                         RunCodeFile(path);
@@ -476,7 +473,7 @@ namespace UndertaleModCli
 
                 case ConsoleKey.D2:
                     {
-                        Console.Write("C# code line?: ");
+                        Console.Write("C# code line? ");
                         string line = Console.ReadLine();
                         ScriptPath = null;
                         RunCodeLine(line);
@@ -491,7 +488,7 @@ namespace UndertaleModCli
 
                 case ConsoleKey.D4:
                     {
-                        Console.Write("Where to save?: ");
+                        Console.Write("Where to save? ");
                         string path = Dequote(Console.ReadLine());
                         CliSave(path);
                         break;
@@ -507,7 +504,7 @@ namespace UndertaleModCli
                 case ConsoleKey.D6:
                     {
                         Console.WriteLine("Are you SURE? You can press 'n' and save before the changes are gone forever!!");
-                        Console.WriteLine("(Y/N)?: ");
+                        Console.WriteLine("(Y/N)? ");
                         var yes = Console.ReadKey(false).Key == ConsoleKey.Y;
                         Console.WriteLine();
                         if (yes) return false;
@@ -577,7 +574,7 @@ namespace UndertaleModCli
         public bool ScriptQuestion(string message)
         {
             Console.WriteLine(message);
-            Console.Write("Input (Y/N)?: ");
+            Console.Write("Input (Y/N)? ");
             var yes = Console.ReadKey(false).Key == ConsoleKey.Y;
             Console.WriteLine();
             return yes;
@@ -861,7 +858,7 @@ namespace UndertaleModCli
 
         public string PromptChooseDirectory(string prompt)
         {
-            Console.WriteLine("Please type a path (or drag and drop on Windows) to a directory:");
+            Console.WriteLine("Please type a path (or drag and drop) to a directory:");
             Console.Write("Path: ");
             string p = Console.ReadLine();
             return p;

--- a/UndertaleModCli/Program.cs
+++ b/UndertaleModCli/Program.cs
@@ -165,7 +165,7 @@ namespace UndertaleModCli
 
         public static int Main(string[] args)
         {
-            var verboseOption = new Option<bool>(new[]{"-v", "--verbose"}, "Detailed logs");
+            var verboseOption = new Option<bool>(new []{"-v", "--verbose"}, "Detailed logs");
 
             var dataFileOption = new Argument<FileInfo>("datafile")
             {
@@ -179,7 +179,7 @@ namespace UndertaleModCli
             };
             infoCommand.Handler = CommandHandler.Create<InfoOptions>(Program.Info);
 
-            var scriptRunnerOption = new Option<FileInfo[]>(new[] { "-s", "--scripts"}, "Scripts to apply to the <datafile>. ex. a.csx b.csx");
+            var scriptRunnerOption = new Option<FileInfo[]>(new []{ "-s", "--scripts"}, "Scripts to apply to the <datafile>. ex. a.csx b.csx");
             var loadCommand = new Command("load", "Load data file and perform actions on it") {
                 dataFileOption,
                 scriptRunnerOption,

--- a/UndertaleModCli/UndertaleModCli.csproj
+++ b/UndertaleModCli/UndertaleModCli.csproj
@@ -6,6 +6,7 @@
     <Platforms>AnyCPU;x64</Platforms>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
 	<Nullable>annotations</Nullable>
+	<RollForward>LatestMajor</RollForward>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR has the following changes to UTMTCli:
- Typo fixes in prompts and error messages being less rude.
- Get rid of the `--applyscripts` alias
- Rename the `--dest` alias to `--output`, shortalias is `-o`, usage is consistent between the load and new command and thus fixes #692 
- Introduce shortalias `-l` for `--line`
- Introduce shortalias `-i` for `--interactive`
- Rename the shortalias for `--stdout` to `-`
- Allow the project to be ran with higher .NET versions than targeted with. I.e, people with a .NET 6 runtime are able to run it even though the project only targets .NET 5.
