### PR TITLE
Rudimentary 2.3 (de)compiler fixes

### DIFF
--- a/UndertaleModLib/Compiler/AssemblyWriter.cs
+++ b/UndertaleModLib/Compiler/AssemblyWriter.cs
@@ -189,9 +189,10 @@ namespace UndertaleModLib.Compiler
                                                 patch.Target.Destination = new Reference<UndertaleVariable>(def, patch.VarType);
                                             else
                                                 patch.Target.Value = new Reference<UndertaleVariable>(def, patch.VarType);
+                                            
                                             if (patch.VarType == VariableType.Normal)
                                                 patch.Target.TypeInst = InstanceType.Local;
-                                            else
+                                            else if (compileContext.Data.GMS2_3)
                                                 patch.InstType = InstanceType.Self;
                                         }
                                     }
@@ -851,9 +852,9 @@ namespace UndertaleModLib.Compiler
                                (s.Children[0].Kind == Parser.Statement.StatementKind.ExprConstant &&
                                (InstanceType)s.Children[0].Constant.valueNumber == InstanceType.Other))
                             {
-                                cw.Emit(Opcode.Call, DataType.Int32).Function = new Reference<UndertaleFunction>(new UndertaleFunction() {
-                                    Name = new UndertaleString("@@Other@@")
-                                });
+                                cw.Emit(Opcode.Call, DataType.Int32).Function = new Reference<UndertaleFunction>(
+                                    cw.compileContext.Data.Functions.ByName("@@Other@@")
+                                );
                                 cw.typeStack.Push(DataType.Variable);
                             }
                             else
@@ -1786,27 +1787,15 @@ namespace UndertaleModLib.Compiler
                     // inefficient because these could be easily combined into
                     // one small instruction.
                     // And they were, in 2.3.
-                    if (cw.compileContext.Data.GMS2_3) {
-                        if (arraypushaf)
+                    if (cw.compileContext.Data.GMS2_3)
+                    {
+                        cw.varPatches.Add(new VariablePatch()
                         {
-                            cw.varPatches.Add(new VariablePatch()
-                            {
-                                Target = cw.EmitRef(Opcode.Push, DataType.Variable),
-                                Name = a.Text,
-                                InstType = InstanceType.Self,
-                                VarType = VariableType.ArrayPushAF
-                            });
-                        }
-                        else
-                        {
-                            cw.varPatches.Add(new VariablePatch()
-                            {
-                                Target = cw.EmitRef(Opcode.Push, DataType.Variable),
-                                Name = a.Text,
-                                InstType = InstanceType.Self,
-                                VarType = VariableType.ArrayPopAF
-                            });
-                        }
+                            Target = cw.EmitRef(Opcode.Push, DataType.Variable),
+                            Name = a.Text,
+                            InstType = InstanceType.Self,
+                            VarType = arraypushaf ? VariableType.ArrayPushAF : VariableType.ArrayPopAF
+                        });
                     }
                     else
                     {

--- a/UndertaleModLib/Compiler/AssemblyWriter.cs
+++ b/UndertaleModLib/Compiler/AssemblyWriter.cs
@@ -1716,7 +1716,10 @@ namespace UndertaleModLib.Compiler
                             {
                                 if (duplicate && next + 1 >= e.Children.Count)
                                 {
-                                    cw.Emit(Opcode.Dup, DataType.Int32).Extra = 0;
+                                    if (cw.compileContext.Data.GMS2_3)
+                                        cw.Emit(Opcode.Dup, DataType.Int32).Extra = 4;
+                                    else
+                                        cw.Emit(Opcode.Dup, DataType.Int32).Extra = 0;
                                 }
                                 cw.varPatches.Add(new VariablePatch()
                                 {
@@ -2013,7 +2016,7 @@ namespace UndertaleModLib.Compiler
                         }
                     }
                     fix.Children.Add(fix2);
-                    AssembleStoreVariable(cw, fix, typeToStore, skip);
+                    AssembleStoreVariable(cw, fix, typeToStore, skip, duplicate);
                 }
                 else
                 {

--- a/UndertaleModLib/Compiler/AssemblyWriter.cs
+++ b/UndertaleModLib/Compiler/AssemblyWriter.cs
@@ -211,6 +211,15 @@ namespace UndertaleModLib.Compiler
                                         else if (realInstType == InstanceType.Stacktop)
                                             realInstType = InstanceType.Self; // used with @@GetInstance@@
 
+                                        // 2.3 variable fix
+                                        // Definitely needs at least some change when ++/-- support is added,
+                                        // since that does use instance type global
+                                        if (compileContext.Data.GMS2_3 && 
+                                            (patch.Target.Kind == Opcode.Pop || patch.Target.Kind == Opcode.Push) &&
+                                            patch.VarType == VariableType.Array &&
+                                            realInstType == InstanceType.Global)
+                                            realInstType = InstanceType.Self;
+
                                         UndertaleVariable def = variables.EnsureDefined(patch.Name, realInstType,
                                                                  compileContext.BuiltInList.GlobalArray.ContainsKey(patch.Name) ||
                                                                  compileContext.BuiltInList.GlobalNotArray.ContainsKey(patch.Name) ||
@@ -1797,6 +1806,12 @@ namespace UndertaleModLib.Compiler
                             // Special array set- instance type needs to be pushed beforehand
                             if (!skip)
                             {
+                                // Convert to variable in 2.3
+                                if (cw.compileContext.Data.GMS2_3 && typeToStore == DataType.Int32)
+                                {
+                                    cw.Emit(Opcode.Conv, DataType.Int32, DataType.Variable);
+                                    typeToStore = DataType.Variable;
+                                }
                                 cw.Emit(Opcode.PushI, DataType.Int16).Value = (short)s.Children[0].ID;
                                 AssembleArrayPush(cw, s.Children[0]);
                             }

--- a/UndertaleModLib/Decompiler/Decompiler.cs
+++ b/UndertaleModLib/Decompiler/Decompiler.cs
@@ -1528,20 +1528,23 @@ namespace UndertaleModLib.Decompiler
             public override string ToString(DecompileContext context)
             {
                 string name = Var.Name.Content;
-                if (context.GlobalContext.Data?.GMS2_3 == true)
+                if (ArrayIndices != null)
                 {
-                    if (ArrayIndices != null)
+                    if (context.GlobalContext.Data?.GMS2_3 == true)
                     {
+                        name += "[";
                         foreach (Expression e in ArrayIndices)
-                            name += "[" + e.ToString(context) + "]";
+                            name += e.ToString(context) + ", ";
+                        name = name[0..^2];
+                        name += "]";
                     }
-                }
-                else if (ArrayIndices != null)
-                {
-                    if (ArrayIndices.Count == 2 && ArrayIndices[0] != null && ArrayIndices[1] != null)
-                        name += "[" + ArrayIndices[0].ToString(context) + ", " + ArrayIndices[1].ToString(context) + "]";
-                    else if (ArrayIndices[0] != null)
-                        name += "[" + ArrayIndices[0].ToString(context) + "]";
+                    else
+                    {
+                        if (ArrayIndices.Count == 2 && ArrayIndices[0] != null && ArrayIndices[1] != null)
+                            name += "[" + ArrayIndices[0].ToString(context) + ", " + ArrayIndices[1].ToString(context) + "]";
+                        else if (ArrayIndices[0] != null)
+                            name += "[" + ArrayIndices[0].ToString(context) + "]";
+                    }
                 }
 
                 // NOTE: The "var" prefix is handled in Decompiler.Decompile. 

--- a/UndertaleModTool/TechnicalScripts/CheckDecompiler.csx
+++ b/UndertaleModTool/TechnicalScripts/CheckDecompiler.csx
@@ -139,21 +139,21 @@ void FileCompare(string asm_orig_path, string asm_new_path, string gml_orig_path
     {
         UpdateProgressBar(null, "Grouping identical and different files", progress++, Data.Code.Count);
         string DetCodeName = (Is_GMS_2_3 ? i.ToString() : Data.Code[i].Name.Content);
-        string orig_asm_path = Path.Combine(asm_orig_path, DetCodeName + ".asm");
-        string new1_asm_path = Path.Combine(asm_new_path, DetCodeName + ".asm");
-        string orig_gml_path = Path.Combine(gml_orig_path, DetCodeName + ".gml");
-        if (!(File.Exists(orig_asm_path) && File.Exists(new1_asm_path) && File.Exists(orig_gml_path)))
+        string asm_orig_fullpath = Path.Combine(asm_orig_path, DetCodeName + ".asm");
+        string asm_new_fullpath = Path.Combine(asm_new_path, DetCodeName + ".asm");
+        string gml_orig_fullpath = Path.Combine(gml_orig_path, DetCodeName + ".gml");
+        if (!(File.Exists(asm_orig_fullpath) && File.Exists(asm_new_fullpath) && File.Exists(gml_orig_fullpath)))
         {
             continue;
         }
-        if (AreFilesIdentical(orig_asm_path, new1_asm_path))
+        if (AreFilesIdentical(asm_orig_fullpath, asm_new_fullpath))
         {
             Directory.CreateDirectory(Path.Combine(gml_orig_path, "Identical"));
             Directory.CreateDirectory(Path.Combine(asm_new_path, "Identical"));
             Directory.CreateDirectory(Path.Combine(asm_orig_path, "Identical"));
-            File.Move(orig_gml_path, Path.Combine(gml_orig_path, "Identical", DetCodeName + ".gml"));
-            File.Move(orig_asm_path, Path.Combine(asm_new_path, "Identical", DetCodeName + ".asm"));
-            File.Move(new1_asm_path, Path.Combine(asm_orig_path, "Identical", DetCodeName + ".asm"));
+            File.Move(gml_orig_fullpath, Path.Combine(gml_orig_path, "Identical", DetCodeName + ".gml"));
+            File.Move(asm_orig_fullpath, Path.Combine(asm_orig_path, "Identical", DetCodeName + ".asm"));
+            File.Move(asm_new_fullpath, Path.Combine(asm_new_path, "Identical", DetCodeName + ".asm"));
             identical_count += 1;
         }
         else
@@ -161,9 +161,9 @@ void FileCompare(string asm_orig_path, string asm_new_path, string gml_orig_path
             Directory.CreateDirectory(Path.Combine(gml_orig_path, "Different"));
             Directory.CreateDirectory(Path.Combine(asm_new_path, "Different"));
             Directory.CreateDirectory(Path.Combine(asm_orig_path, "Different"));
-            File.Move(orig_gml_path, Path.Combine(gml_orig_path, "Different", DetCodeName + ".gml"));
-            File.Move(orig_asm_path, Path.Combine(asm_new_path, "Different", DetCodeName + ".asm"));
-            File.Move(new1_asm_path, Path.Combine(asm_orig_path, "Different", DetCodeName + ".asm"));
+            File.Move(gml_orig_fullpath, Path.Combine(gml_orig_path, "Different", DetCodeName + ".gml"));
+            File.Move(asm_orig_fullpath, Path.Combine(asm_orig_path, "Different", DetCodeName + ".asm"));
+            File.Move(asm_new_fullpath, Path.Combine(asm_new_path, "Different", DetCodeName + ".asm"));
             different_count += 1;
         }
     }


### PR DESCRIPTION
* Fix 2.3 global array assignment to convert its value to a variable, as well as use the `self` instance type.
* Fix 2.3 2D array decompilation to be comma separated and thus not crash the compiler (though, the result is nonfunctional anyway so that may be better left alone until it's taken care of on the other end).