### PR TITLE
Use Ookii.Dialogs.Wpf for folder pickers

### DIFF
--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -1904,7 +1904,7 @@ namespace UndertaleModTool
         public string PromptChooseDirectory(string prompt)
         {
             VistaFolderBrowserDialog folderBrowser = new VistaFolderBrowserDialog();
-            return folderBrowser.ShowDialog() == true ? Path.GetDirectoryName(folderBrowser.SelectedPath) + Path.DirectorySeparatorChar : null;
+            return folderBrowser.ShowDialog() == true ? folderBrowser.SelectedPath : null;
         }
         
         #pragma warning disable CA1416

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -29,6 +29,7 @@ using UndertaleModLib.ModelsDebug;
 using UndertaleModLib.Scripting;
 using UndertaleModTool.Windows;
 using System.IO.Pipes;
+using Ookii.Dialogs.Wpf;
 
 using ColorConvert = System.Windows.Media.ColorConverter;
 using System.Text.RegularExpressions;
@@ -1899,16 +1900,11 @@ namespace UndertaleModTool
             return dlg.ShowDialog() == true ? dlg.FileName : null;
         }
 
+        #pragma warning disable CA1416
         public string PromptChooseDirectory(string prompt)
         {
-            OpenFileDialog folderBrowser = new OpenFileDialog();
-            // Set validate names and check file exists to false otherwise windows will
-            // not let you select "Folder Selection."
-            folderBrowser.ValidateNames = false;
-            folderBrowser.CheckFileExists = false;
-            folderBrowser.CheckPathExists = true;
-            folderBrowser.FileName = prompt != null ? prompt + "." : "Folder Selection."; // Adding the . at the end makes sure it will accept the folder.
-            return folderBrowser.ShowDialog() == true ? Path.GetDirectoryName(folderBrowser.FileName) + Path.DirectorySeparatorChar : null;
+            VistaFolderBrowserDialog folderBrowser = new VistaFolderBrowserDialog();
+            return folderBrowser.ShowDialog() == true ? Path.GetDirectoryName(folderBrowser.SelectedPath) + Path.DirectorySeparatorChar : null;
         }
         
         #pragma warning disable CA1416

--- a/UndertaleModTool/UndertaleModTool.csproj
+++ b/UndertaleModTool/UndertaleModTool.csproj
@@ -4121,6 +4121,7 @@
         <PackageReference Include="Newtonsoft.Json">
             <Version>13.0.1</Version>
         </PackageReference>
+        <PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
         <PackageReference Include="PropertyChanged.Fody" Version="3.3.3" />
         <PackageReference Include="System.AppContext">
             <Version>4.3.0</Version>


### PR DESCRIPTION
Currently, UTMT uses file pickers to choose a folder. This is both confusing and a bit harder to use for new users than what would be ideal. Sadly, WPF only supports the very old style of folder pickers; which is why [Ookii.Dialogs.Wpf](https://github.com/ookii-dialogs/ookii-dialogs-wpf) exists; to add modern folder picker support to WPF. This PR switches the folder picker to this library, to hopefully make selecting a folder a bit easier for users.