### PR TITLE
Additional fixes

### DIFF
--- a/UndertaleModLib/Compiler/AssemblyWriter.cs
+++ b/UndertaleModLib/Compiler/AssemblyWriter.cs
@@ -1584,6 +1584,15 @@ namespace UndertaleModLib.Compiler
                             cw.Emit(Opcode.PushI, DataType.Int16).Value = (short)e.Children[0].ID;
                             // Pushing array (incl. 2D) but not popping
                             AssembleArrayPush(cw, e.Children[0], !duplicate);
+
+                            if (cw.compileContext.Data.GMS2_3 && e.Children[0].Children.Count > 2)
+                            {
+                                for (int i = 2; i < e.Children[0].Children.Count; i++)
+                                {
+                                    cw.Emit(Opcode.Break, DataType.Int16).Value = (short)-4; // pushac
+                                    AssembleExpression(cw, e.Children[0].Children[i]); // this needs error handling
+                                }
+                            }
                             if (duplicate)
                             {
                                 if (cw.compileContext.Data.GMS2_3 && e.Children[0].Children.Count != 1)
@@ -1599,7 +1608,7 @@ namespace UndertaleModLib.Compiler
                                         cw.Emit(Opcode.Dup, DataType.Int32).Extra = 1;
                                 }
                             }
-                            if (cw.compileContext.Data.GMS2_3 && e.Children[0].Children.Count != 1)
+                            if (cw.compileContext.Data.GMS2_3 && e.Children[0].Children.Count > 1)
                             {
                                 cw.Emit(Opcode.Break, DataType.Int16).Value = (short)-2; // pushaf
                             }
@@ -1900,6 +1909,14 @@ namespace UndertaleModLib.Compiler
                                     UndertaleInstruction dupInst = cw.Emit(Opcode.Dup, DataType.Int32);
                                     dupInst.Extra = 4;
                                     dupInst.ComparisonKind = (ComparisonType)168; // idek what this is but it disassembles as 40
+                                }
+                                else if (s.Children[0].Children.Count > 2)
+                                {
+                                    for (int i = 2; i < s.Children[0].Children.Count; i++)
+                                    {
+                                        cw.Emit(Opcode.Break, DataType.Int16).Value = (short)-4; // pushac
+                                        AssembleExpression(cw, s.Children[0].Children[i]); // this needs error handling
+                                    }
                                 }
                                 cw.Emit(Opcode.Break, DataType.Int16).Value = (short)-3; // popaf
                             }

--- a/UndertaleModLib/Compiler/Parser.cs
+++ b/UndertaleModLib/Compiler/Parser.cs
@@ -1337,13 +1337,15 @@ namespace UndertaleModLib.Compiler
                 Statement result = new Statement(Statement.StatementKind.ExprSingleVariable, s.Token);
                 result.ID = s.ID;
                 // Check for array
-                if (remainingStageOne.Count > 0 && IsNextToken(
+                bool array = false; // hack because you can't else if a while
+                while (remainingStageOne.Count > 0 && IsNextToken(
                     TokenKind.OpenArray,
                     TokenKind.OpenArrayBaseArray,
                     TokenKind.OpenArrayGrid,
                     TokenKind.OpenArrayList,
                     TokenKind.OpenArrayMap))
                 {
+                    array = true;
                     Lexer.Token tok = remainingStageOne.Dequeue().Token;
                     TokenKind t = tok.Kind;
 
@@ -1378,7 +1380,7 @@ namespace UndertaleModLib.Compiler
 
                     if (EnsureTokenKind(TokenKind.CloseArray) == null) return null;
                 }
-                else if (context.BuiltInList.GlobalArray.TryGetValue(result.Text, out _) || context.BuiltInList.InstanceLimitedEvent.TryGetValue(result.Text, out _))
+                if (!array && (context.BuiltInList.GlobalArray.TryGetValue(result.Text, out _) || context.BuiltInList.InstanceLimitedEvent.TryGetValue(result.Text, out _)))
                 {
                     // The compiler apparently does this
                     // I think this makes some undefined value for whatever reason

--- a/UndertaleModTool/ImportCodeSystem.cs
+++ b/UndertaleModTool/ImportCodeSystem.cs
@@ -155,11 +155,11 @@ namespace UndertaleModTool
         {
             try
             {
-                if (!(Path.GetFileName(file).EndsWith(IsGML ? ".gml" : ".asm")))
+                if (!Path.GetFileName(file).ToLower().EndsWith(IsGML ? ".gml" : ".asm"))
                     return;
-                if (Path.GetFileName(file).EndsWith("CleanUp_0" + (IsGML ? ".gml" : ".asm")) && (Data.GeneralInfo.Major < 2))
+                if (Path.GetFileName(file).ToLower().EndsWith("cleanup_0" + (IsGML ? ".gml" : ".asm")) && (Data.GeneralInfo.Major < 2))
                     return;
-                if (Path.GetFileName(file).EndsWith("PreCreate_0" + (IsGML ? ".gml" : ".asm")) && (Data.GeneralInfo.Major < 2))
+                if (Path.GetFileName(file).ToLower().EndsWith("precreate_0" + (IsGML ? ".gml" : ".asm")) && (Data.GeneralInfo.Major < 2))
                     return;
                 string codeName = Path.GetFileNameWithoutExtension(file);
                 string gmlCode = File.ReadAllText(file);


### PR DESCRIPTION
Includes:
* pretty-good support for 3D, 4D, etc arrays and a variable resolution in `scr_weaponinfo` (DR1&2)
* hacky workaround support for breaks in repeat loops, corrupt function detection, and parentheses in not statements (may just make more duplicate parentheses has not been tested)