### PR TITLE
Fixes of UTMT updater

### DIFF
--- a/UndertaleModToolUpdater/Program.cs
+++ b/UndertaleModToolUpdater/Program.cs
@@ -69,6 +69,7 @@ namespace UndertaleModToolUpdater
 
             Process.Start(new ProcessStartInfo(Path.Combine(appPath, "UndertaleModTool.exe"))
             {
+                WorkingDirectory = appPath,
                 Arguments = "deleteTempFolder"
             });
             


### PR DESCRIPTION
1. Fixed `StackOverflowException` _(silent crash)_ on change of update progress bar.
2. Fixed _"Can't delete the updater temp folder."_ error on updated UTMT startup.