### PR TITLE
Room editor improvements

### DIFF
--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -42,7 +43,8 @@ namespace UndertaleModLib.Models
         public float GravityX { get; set; } = 0;
         public float GravityY { get; set; } = 10;
         public float MetersPerPixel { get; set; } = 0.1f;
-        public double Grid { get; set; } = 16d;
+        public double GridWidth { get; set; } = 16d;
+        public double GridHeight { get; set; } = 16d;
         public double GridThicknessPx { get; set; } = 1d;
         public UndertalePointerList<Background> Backgrounds { get; private set; } = new UndertalePointerList<Background>();
         public UndertalePointerList<View> Views { get; private set; } = new UndertalePointerList<View>();
@@ -237,6 +239,30 @@ namespace UndertaleModLib.Models
             }
             foreach (UndertaleRoom.Background bgnd in Backgrounds)
                 bgnd.ParentRoom = this;
+
+            // Automagically set the grid size to whatever most tiles are sized
+
+            Dictionary<Point, uint> tileSizes = new Dictionary<Point, uint>();
+
+            // Loop through each tile and save how many times their sizes are used
+            foreach (UndertaleRoom.Tile tile in Tiles)
+            {
+                Point scale = new Point((int)tile.Width, (int)tile.Height);
+                if (tileSizes.ContainsKey(scale))
+                {
+                    tileSizes[scale]++;
+                } else {
+                    tileSizes.Add(scale, 1);
+                }
+            }
+
+            // If tiles exist at all, grab the most used tile size and use that as our grid size
+            if (tileSizes.Count > 0)
+            {
+                var largestKey = tileSizes.Aggregate((x, y) => x.Value > y.Value ? x : y).Key;
+                GridWidth = largestKey.X;
+                GridHeight = largestKey.Y;
+            }
         }
 
         public override string ToString()

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -247,7 +247,7 @@ namespace UndertaleModLib.Models
             // Loop through each tile and save how many times their sizes are used
             foreach (UndertaleRoom.Tile tile in Tiles)
             {
-                Point scale = new Point((int)tile.Width, (int)tile.Height);
+                Point scale = new((int)tile.Width, (int)tile.Height);
                 if (tileSizes.ContainsKey(scale))
                 {
                     tileSizes[scale]++;

--- a/UndertaleModTool/Converters/GridConverter.cs
+++ b/UndertaleModTool/Converters/GridConverter.cs
@@ -9,14 +9,14 @@ using System.Windows.Data;
 
 namespace UndertaleModTool
 {
-    public class GridConverter : IValueConverter
+    public class GridConverter : IMultiValueConverter
     {
-        public object Convert(object value, System.Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        public object Convert(object[] values, System.Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            return "0,0,"+value.ToString()+","+value.ToString();
+            return new Rect(0, 0, (double)values[0], (double)values[1]);
         }
 
-        public object ConvertBack(object value, System.Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        public object[] ConvertBack(object value, System.Type[] targetType, object parameter, System.Globalization.CultureInfo culture)
         {
             return null;
         }

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
@@ -351,11 +351,14 @@
                                 <TextBox Grid.Column="1" Margin="3" Text="{Binding GravityY}" ToolTip="Y"/>
                             </Grid>
 
-                            <TextBlock Grid.Row="12" Grid.Column="0" Margin="3">Grid</TextBlock>
-                            <TextBox Grid.Row="12" Grid.Column="1" Margin="3" Text="{Binding Grid}"/>
+                            <TextBlock Grid.Row="12" Grid.Column="0" Margin="3">Grid Width</TextBlock>
+                            <TextBox Grid.Row="12" Grid.Column="1" Margin="3" Text="{Binding GridWidth}"/>
 
-                            <TextBlock Grid.Row="13" Grid.Column="0" Margin="3">Grid Thickness</TextBlock>
-                            <TextBox Grid.Row="13" Grid.Column="1" Margin="3" Text="{Binding GridThicknessPx}"/>
+                            <TextBlock Grid.Row="13" Grid.Column="0" Margin="3">Grid Height</TextBlock>
+                            <TextBox Grid.Row="13" Grid.Column="1" Margin="3" Text="{Binding GridHeight}"/>
+
+                            <TextBlock Grid.Row="14" Grid.Column="0" Margin="3">Grid Thickness</TextBlock>
+                            <TextBox Grid.Row="14" Grid.Column="1" Margin="3" Text="{Binding GridThicknessPx}"/>
                         </Grid>
                     </DataTemplate>
 

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
@@ -610,7 +610,7 @@
                             </Grid>
 
                             <Viewbox Grid.Row="3" Grid.Column="1" Margin="3" Stretch="Uniform" StretchDirection="DownOnly">
-                                <Canvas Width="{Binding Tpag.BoundingWidth}" Height="{Binding Tpag.BoundingHeight}" SnapsToDevicePixels="True" MouseMove="RectangleTile_MouseMove" MouseUp="RectangleTile_MouseUp">
+                                <Canvas Width="{Binding Tpag.BoundingWidth}" Height="{Binding Tpag.BoundingHeight}" SnapsToDevicePixels="True" MouseDown="RectangleTile_MouseDown" MouseMove="RectangleTile_MouseMove">
                                     <Border>
                                         <Border.Background>
                                             <DrawingBrush Stretch="None" TileMode="Tile" Viewport="0,0,20,20" ViewportUnits="Absolute">
@@ -624,7 +624,7 @@
                                         </Border.Background>
                                         <local:UndertaleTexturePageItemDisplay DataContext="{Binding Tpag}"/>
                                     </Border>
-                                    <Rectangle Canvas.Left="{Binding SourceX}" Canvas.Top="{Binding SourceY}" Width="{Binding Width}" Height="{Binding Height}" Stroke="#FFB23131" Panel.ZIndex="50" StrokeThickness="2" MouseDown="RectangleTile_MouseDown" SnapsToDevicePixels="True">
+                                    <Rectangle x:Name="TileSelector" Canvas.Left="{Binding SourceX}" Canvas.Top="{Binding SourceY}" Width="{Binding Width}" Height="{Binding Height}" Stroke="#FFB23131" Panel.ZIndex="50" StrokeThickness="2" SnapsToDevicePixels="True">
                                         <Rectangle.Fill>
                                             <SolidColorBrush Color="Red" Opacity=".1"/>
                                         </Rectangle.Fill>

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
@@ -906,8 +906,8 @@
 
         <GridSplitter Grid.Column="0" Grid.Row="1" HorizontalAlignment="Stretch" VerticalAlignment="Center" ShowsPreview="True" Width="Auto" Height="3"/>
 
-        <ScrollViewer Margin="0,8,0,0" Grid.Column="0" Grid.Row="2" HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Visible" ScrollChanged="ScrollViewer_ScrollChanged">
-            <ItemsControl Name="RoomGraphics" Background="Black" MouseMove="Rectangle_MouseMove" MouseWheel="Canvas_MouseWheel">
+        <ScrollViewer Name="RoomGraphicsScroll" Margin="0,8,0,0" Grid.Column="0" Grid.Row="2" HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Visible" ScrollChanged="ScrollViewer_ScrollChanged">
+            <ItemsControl Name="RoomGraphics" Background="Black" MouseDown="RectangleBackground_MouseDown" MouseMove="RectangleBackground_MouseMove" MouseUp="RectangleBackground_MouseUp" MouseWheel="Canvas_MouseWheel">
                 <ItemsControl.Style>
                     <Style TargetType="ItemsControl">
                         <Setter Property="ItemsSource" Value="{Binding Source={StaticResource AllObjectsGMS1}}"/>
@@ -922,16 +922,29 @@
                 </ItemsControl.Style>
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
-                        <Canvas Width="{Binding Width}" Height="{Binding Height}" IsItemsHost="True" AllowDrop="True" DragOver="Canvas_DragOver" Drop="Canvas_Drop">
+                        <Canvas Name="RoomCanvas" Width="{Binding Width}" Height="{Binding Height}" IsItemsHost="True" AllowDrop="True" DragOver="Canvas_DragOver" Drop="Canvas_Drop" Loaded="Canvas_Loaded">
                             <!--<Canvas.RenderTransform>
                                 <ScaleTransform ScaleX="2" ScaleY="2"></ScaleTransform>
                             </Canvas.RenderTransform>-->
                             <Canvas.Background>
-                                <DrawingBrush TileMode="Tile" Viewport="{Binding Grid, Converter={StaticResource GridConverter}}" ViewportUnits="Absolute">
+                                <DrawingBrush TileMode="Tile" ViewportUnits="Absolute">
+                                    <DrawingBrush.Viewport>
+                                        <MultiBinding Converter="{StaticResource GridConverter}">
+                                            <Binding Path="GridWidth"></Binding>
+                                            <Binding Path="GridHeight"></Binding>
+                                        </MultiBinding>
+                                    </DrawingBrush.Viewport>
                                     <DrawingBrush.Drawing>
                                         <GeometryDrawing>
                                             <GeometryDrawing.Geometry>
-                                                <RectangleGeometry Rect="{Binding Grid, Converter={StaticResource GridConverter}}"/>
+                                                <RectangleGeometry>
+                                                    <RectangleGeometry.Rect>
+                                                        <MultiBinding Converter="{StaticResource GridConverter}">
+                                                            <Binding Path="GridWidth"></Binding>
+                                                            <Binding Path="GridHeight"></Binding>
+                                                        </MultiBinding>
+                                                    </RectangleGeometry.Rect>
+                                                </RectangleGeometry>
                                             </GeometryDrawing.Geometry>
                                             <GeometryDrawing.Pen>
                                                 <Pen Brush="Gray" Thickness="{Binding GridThicknessPx}"/>

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -239,17 +239,23 @@ namespace UndertaleModTool
                 int tgtX = (int)(mousePos.X - hotpointX);
                 int tgtY = (int)(mousePos.Y - hotpointY);
 
-                int gridSize = Convert.ToInt32(room.Grid);
-                if (gridSize <= 0)
-                    gridSize = 1;
-                else if (Keyboard.Modifiers.HasFlag(ModifierKeys.Control))
-                    gridSize = gridSize/2;
+                int gridWidth  = Math.Max(Convert.ToInt32(room.GridWidth ), 1);
+                int gridHeight = Math.Max(Convert.ToInt32(room.GridHeight), 1);
+
+                if (Keyboard.Modifiers.HasFlag(ModifierKeys.Control))
+                {
+                    gridWidth  /= 2;
+                    gridHeight /= 2;
+                }
                 else if (Keyboard.Modifiers.HasFlag(ModifierKeys.Shift))
-                    gridSize = gridSize*2;
+                {
+                    gridWidth  *= 2;
+                    gridHeight *= 2;
+                }
 
                 // Snap to grid
-                tgtX = ((tgtX + gridSize / 2) / gridSize) * gridSize;
-                tgtY = ((tgtY + gridSize / 2) / gridSize) * gridSize;
+                tgtX = ((tgtX + gridWidth  / 2) / gridWidth ) * gridWidth;
+                tgtY = ((tgtY + gridHeight / 2) / gridHeight) * gridHeight;
 
                 if (movingObj is UndertaleRoom.GameObject)
                 {
@@ -266,15 +272,21 @@ namespace UndertaleModTool
 
         private Point GetGridMouseCoordinates(Point mousePos, UndertaleRoom room)
         {
-            int gridSize = Convert.ToInt32(room.Grid);
-            if (gridSize <= 0)
-                gridSize = 1;
-            else if (Keyboard.Modifiers.HasFlag(ModifierKeys.Control))
-                gridSize = gridSize / 2;
-            else if (Keyboard.Modifiers.HasFlag(ModifierKeys.Shift))
-                gridSize = gridSize * 2;
+                int gridWidth  = Math.Max(Convert.ToInt32(room.GridWidth ), 1);
+                int gridHeight = Math.Max(Convert.ToInt32(room.GridHeight), 1);
 
-            return new Point(Math.Floor(mousePos.X / gridSize) * gridSize, Math.Floor(mousePos.Y / gridSize) * gridSize);
+                if (Keyboard.Modifiers.HasFlag(ModifierKeys.Control))
+                {
+                    gridWidth  /= 2;
+                    gridHeight /= 2;
+                }
+                else if (Keyboard.Modifiers.HasFlag(ModifierKeys.Shift))
+                {
+                    gridWidth  *= 2;
+                    gridHeight *= 2;
+                }
+
+            return new Point(Math.Floor(mousePos.X / gridWidth) * gridWidth, Math.Floor(mousePos.Y / gridHeight) * gridHeight);
         }
 
         double scaleOriginX, scaleOriginY;
@@ -291,8 +303,8 @@ namespace UndertaleModTool
             scaleOriginY = gridMouseCoordinates.Y;
             clickedTile.SourceX = (uint)gridMouseCoordinates.X;
             clickedTile.SourceY = (uint)gridMouseCoordinates.Y;
-            clickedTile.Width = (uint)room.Grid;
-            clickedTile.Height = (uint)room.Grid;
+            clickedTile.Width = (uint)room.GridWidth;
+            clickedTile.Height = (uint)room.GridHeight;
         }
 
         private void RectangleTile_MouseMove(object sender, MouseEventArgs e)
@@ -313,8 +325,8 @@ namespace UndertaleModTool
             {
                 double differenceX = gridMouseCoordinates.X - scaleOriginX;
                 double differenceY = gridMouseCoordinates.Y - scaleOriginY;
-                clickedTile.Width  = (uint)Math.Clamp(Math.Abs(differenceX), 0, clickedTile.Tpag.BoundingWidth ) + (uint)room.Grid;
-                clickedTile.Height = (uint)Math.Clamp(Math.Abs(differenceY), 0, clickedTile.Tpag.BoundingHeight) + (uint)room.Grid;
+                clickedTile.Width  = (uint)Math.Clamp(Math.Abs(differenceX), 0, clickedTile.Tpag.BoundingWidth ) + (uint)room.GridWidth;
+                clickedTile.Height = (uint)Math.Clamp(Math.Abs(differenceY), 0, clickedTile.Tpag.BoundingHeight) + (uint)room.GridHeight;
 
                 if (differenceX < 0)
                     clickedTile.SourceX = (uint)gridMouseCoordinates.X;

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -251,9 +251,9 @@ namespace UndertaleModTool
         bool placingTiles = false;
         List<Point> placedTiles = new();
 
-        private void PlaceTileCopy(Point gridMouse, UndertaleObject other, UndertaleRoom room)
+        private void PaintObjects(Point gridMouse, UndertaleObject other, UndertaleRoom room)
         {
-            if (Mouse.LeftButton != MouseButtonState.Pressed)
+            if ((Mouse.LeftButton != MouseButtonState.Pressed) || !(Keyboard.Modifiers.HasFlag(ModifierKeys.Alt)))
             {
                 placingTiles = false;
                 return;
@@ -335,12 +335,13 @@ namespace UndertaleModTool
 
             placedTiles.Clear();
 
-            PlaceTileCopy(GetGridMouseCoordinates(mousePos, room), other, room);
+            PaintObjects(GetGridMouseCoordinates(mousePos, room), other, room);
         }
 
         private void RectangleBackground_MouseUp(object sender, MouseButtonEventArgs e)
         {
             placingTiles = false;
+            placedTiles.Clear();
         }
 
         private void RectangleBackground_MouseMove(object sender, MouseEventArgs e)
@@ -352,7 +353,7 @@ namespace UndertaleModTool
 
                 var mousePos = e.GetPosition(roomCanvas);
 
-                PlaceTileCopy(GetGridMouseCoordinates(mousePos, room), other, room);
+                PaintObjects(GetGridMouseCoordinates(mousePos, room), other, room);
                 return;
             }
             Rectangle_MouseMove(sender, e);

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -251,14 +251,13 @@ namespace UndertaleModTool
         bool placingTiles = false;
         List<Point> placedTiles = new();
 
-        private void PlaceTileCopy(Point gridMouse, UndertaleRoom.Tile other, UndertaleRoom room)
+        private void PlaceTileCopy(Point gridMouse, UndertaleObject other, UndertaleRoom room)
         {
             if (Mouse.LeftButton != MouseButtonState.Pressed)
             {
                 placingTiles = false;
                 return;
             }
-            if (!(selectedObject is UndertaleRoom.Tile)) return;
             UndertaleRoom.Layer layer = ObjectEditor.Content as UndertaleRoom.Layer;
 
             if (layer != null && layer.AssetsData == null)
@@ -271,26 +270,53 @@ namespace UndertaleModTool
             placedTiles.Add(gridMouse);
             placingTiles = true;
 
-            var newObj = new UndertaleRoom.Tile
+            if (other is UndertaleRoom.Tile)
             {
-                X = (int)gridMouse.X,
-                Y = (int)gridMouse.Y,
-                _SpriteMode = other._SpriteMode,
-                ObjectDefinition = other.ObjectDefinition,
-                SpriteDefinition = other.SpriteDefinition,
-                SourceX = other.SourceX,
-                SourceY = other.SourceY,
-                Width = other.Width,
-                Height = other.Height,
-                TileDepth = other.TileDepth,
-                InstanceID = (Application.Current.MainWindow as MainWindow).Data.GeneralInfo.LastTile++,
-                ScaleX = other.ScaleX,
-                ScaleY = other.ScaleY,
-                Color = other.Color
-            };
-
-            room.Tiles.Add(newObj);
-            SelectObject(newObj);
+                var otherTile = other as UndertaleRoom.Tile;
+                var newObj = new UndertaleRoom.Tile
+                {
+                    X = (int)gridMouse.X,
+                    Y = (int)gridMouse.Y,
+                    _SpriteMode = otherTile._SpriteMode,
+                    ObjectDefinition = otherTile.ObjectDefinition,
+                    SpriteDefinition = otherTile.SpriteDefinition,
+                    SourceX = otherTile.SourceX,
+                    SourceY = otherTile.SourceY,
+                    Width = otherTile.Width,
+                    Height = otherTile.Height,
+                    TileDepth = otherTile.TileDepth,
+                    InstanceID = (Application.Current.MainWindow as MainWindow).Data.GeneralInfo.LastTile++,
+                    ScaleX = otherTile.ScaleX,
+                    ScaleY = otherTile.ScaleY,
+                    Color = otherTile.Color
+                };
+                if (layer != null)
+                    layer.AssetsData.LegacyTiles.Add(newObj);
+                else
+                    room.Tiles.Add(newObj);
+                SelectObject(newObj);
+            }
+            else if (other is UndertaleRoom.GameObject)
+            {
+                var otherObject = other as UndertaleRoom.GameObject;
+                var newObj = new UndertaleRoom.GameObject
+                {
+                    X = (int)gridMouse.X,
+                    Y = (int)gridMouse.Y,
+                    ObjectDefinition = otherObject.ObjectDefinition,
+                    InstanceID = (Application.Current.MainWindow as MainWindow).Data.GeneralInfo.LastObj++,
+                    CreationCode = otherObject.CreationCode,
+                    ScaleX = otherObject.ScaleX,
+                    ScaleY = otherObject.ScaleY,
+                    Color = otherObject.Color,
+                    Rotation = otherObject.Rotation,
+                    PreCreateCode = otherObject.PreCreateCode
+                };
+                room.GameObjects.Add(newObj);
+                if (layer != null)
+                    layer.InstancesData.Instances.Add(newObj);
+                SelectObject(newObj);
+            }
         }
 
         Canvas roomCanvas;
@@ -303,7 +329,7 @@ namespace UndertaleModTool
         private void RectangleBackground_MouseDown(object sender, MouseButtonEventArgs e)
         {
             UndertaleRoom room = DataContext as UndertaleRoom;
-            var other = selectedObject as UndertaleRoom.Tile;
+            var other = selectedObject as UndertaleObject;
 
             var mousePos = e.GetPosition(roomCanvas);
 
@@ -322,7 +348,7 @@ namespace UndertaleModTool
             if (placingTiles)
             {
                 UndertaleRoom room = this.DataContext as UndertaleRoom;
-                var other = selectedObject as UndertaleRoom.Tile;
+                var other = selectedObject as UndertaleObject;
 
                 var mousePos = e.GetPosition(roomCanvas);
 


### PR DESCRIPTION
This PR adds a few improvements for the room editor.

- The grid now has independent width and height.
- The grid is now automatically set to what most tiles are sized, instead of being a hardcoded 16.
- Adding objects to rooms by dragging and dropping now places them at the correct position.
- You can now "paint" objects and tiles by holding down ALT and clicking and dragging.
- Tile selection has been remade, where you now click on a tile to select it instead of dragging around the red rectangle.
- Resizing the tile selection rectangle can now go to the left and up.