### PR TITLE
More room editor improvements, and fixes

### DIFF
--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -271,7 +271,7 @@ namespace UndertaleModLib.Models
                     {
                         if (layer.LayerType == LayerType.Assets)
                             tileList = tileList.Concat(layer.AssetsData.LegacyTiles);
-                        else if (layer.LayerType == LayerType.Tiles)
+                        else if (layer.LayerType == LayerType.Tiles && layer.TilesData.TileData.Length != 0)
                         {
                             int w = (int)(Width / layer.TilesData.TilesX);
                             int h = (int)(Height / layer.TilesData.TilesY);

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -1034,12 +1034,17 @@ namespace UndertaleModLib.Models
             public float AnimationSpeed { get; set; }
             public AnimationSpeedType AnimationSpeedType { get; set; }
             public float FrameIndex { get; set; }
+            public float SafeFrameIndex { get => FrameIndex; set { FrameIndex = Math.Clamp(value, 0, Sprite.Textures.Count - 1); OnPropertyChanged(); } }
             public float Rotation { get; set; }
             public float OppositeRotation => 360F - Rotation;
             public int XOffset => Sprite is not null ? X - Sprite.OriginX : X;
             public int YOffset => Sprite is not null ? Y - Sprite.OriginY : Y;
 
             public event PropertyChangedEventHandler PropertyChanged;
+            protected void OnPropertyChanged([CallerMemberName] string name = null)
+            {
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+            }
 
             public void Serialize(UndertaleWriter writer)
             {

--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -74,7 +74,7 @@ namespace UndertaleModTool
                 tile = value as Tile;
 
             UndertaleTexturePageItem texture = isTile ? tile.Tpag : value as UndertaleTexturePageItem;
-            if (texture is null)
+            if (texture is null || texture.TexturePage is null)
                 return null;
 
             string texName = texture.Name.Content;
@@ -297,6 +297,9 @@ namespace UndertaleModTool
 
             Layer.LayerTilesData tilesData = values[0] as Layer.LayerTilesData;
             UndertaleBackground tilesBG = tilesData.Background;
+
+            if (tilesBG is null)
+                return null;
 
             Bitmap tilePageBMP;
             if (tilePageCache.ContainsKey(tilesBG.Texture.Name.Content))

--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -248,9 +248,9 @@ namespace UndertaleModTool
         {
             throw new NotImplementedException();
         }
-    }
+    }    
 
-    // UndertaleCachedImageLoader wrapper
+    // UndertaleCachedImageLoader wrappers
     public class CachedTileImageLoader : IMultiValueConverter
     {
         private static UndertaleCachedImageLoader loader = new();
@@ -263,6 +263,27 @@ namespace UndertaleModTool
                 return null;
 
             return loader.Convert(values[0], null, "tile", null);
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+    public class CachedImageLoaderWithIndex : IMultiValueConverter
+    {
+        private static UndertaleCachedImageLoader loader = new();
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values.Any(x => x is null))
+                return null;
+
+            IList<UndertaleSprite.TextureEntry> textures = values[0] as IList<UndertaleSprite.TextureEntry>;
+            int index = (int)(float)values[1];
+            if (index > textures.Count - 1 || index < 0)
+                return null;
+            else
+                return loader.Convert(textures[index].Texture, null, null, null);
         }
 
         public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
@@ -30,6 +30,7 @@
         <local:CachedTileDataLoader x:Key="CachedTileDataLoader"/>
         <local:TileLayerTemplateSelector x:Key="TileLayerTemplateSelector"/>
         <local:TileRectanglesConverter x:Key="TileRectanglesConverter"/>
+        <local:CachedImageLoaderWithIndex x:Key="CachedImageLoaderWithIndex"/>
         <CompositeCollection x:Key="AllObjectsGMS1">
             <CollectionContainer Collection="{Binding Source={x:Reference RoomEditor}, Path=DataContext.Backgrounds}"/>
             <CollectionContainer Collection="{Binding Source={x:Reference RoomEditor}, Path=DataContext.Tiles}"/>
@@ -939,7 +940,7 @@
                             </Grid>
 
                             <TextBlock Grid.Row="7" Grid.Column="0" Margin="3">Frame index</TextBlock>
-                            <TextBox Grid.Row="7" Grid.Column="2" Margin="3" Text="{Binding FrameIndex}"/>
+                            <TextBox Grid.Row="7" Grid.Column="2" Margin="3" Text="{Binding SafeFrameIndex}"/>
 
                             <TextBlock Grid.Row="8" Grid.Column="0" Margin="3">Rotation</TextBlock>
                             <TextBox Grid.Row="8" Grid.Column="2" Margin="3" Text="{Binding Rotation}"/>
@@ -1067,7 +1068,7 @@
                             <Rectangle.RenderTransform>
                                 <TransformGroup>
                                     <ScaleTransform x:Name="transform1_0" ScaleX="{Binding ScaleX, Mode=OneWay}" ScaleY="{Binding ScaleY, Mode=OneWay}"/>
-                                    <RotateTransform x:Name="transform1_1" CenterX="{Binding X, Mode=OneWay}" CenterY="{Binding Y, Mode=OneWay}" Angle="{Binding OppositeRotation, Mode=OneWay}"/>
+                                    <RotateTransform x:Name="transform1_1" Angle="{Binding OppositeRotation, Mode=OneWay}"/>
                                     <TranslateTransform x:Name="transform1_2" X="{Binding XOffset, Mode=OneWay}" Y="{Binding YOffset, Mode=OneWay}"/>
                                 </TransformGroup>
                             </Rectangle.RenderTransform>
@@ -1117,15 +1118,20 @@
                             <Rectangle.RenderTransform>
                                 <TransformGroup>
                                     <ScaleTransform x:Name="transform4_0" ScaleX="{Binding ScaleX, Mode=OneWay}" ScaleY="{Binding ScaleY, Mode=OneWay}"/>
-                                    <RotateTransform x:Name="transform4_1" CenterX="{Binding X, Mode=OneWay}" CenterY="{Binding Y, Mode=OneWay}" Angle="{Binding OppositeRotation, Mode=OneWay}"/>
+                                    <RotateTransform x:Name="transform4_1" Angle="{Binding OppositeRotation, Mode=OneWay}"/>
                                     <TranslateTransform x:Name="transform4_2" X="{Binding XOffset, Mode=OneWay}" Y="{Binding YOffset, Mode=OneWay}"/>
                                 </TransformGroup>
                             </Rectangle.RenderTransform>
                             <Rectangle.Fill>
                                 <ImageBrush
-                                    ImageSource="{Binding Sprite.Textures[0].Texture, Mode=OneWay, Converter={StaticResource UndertaleCachedImageLoader}}"
                                     TileMode="None"
                                     Stretch="UniformToFill">
+                                    <ImageBrush.ImageSource>
+                                        <MultiBinding Converter="{StaticResource CachedImageLoaderWithIndex}">
+                                            <Binding Path="Sprite.Textures" Mode="OneWay"/>
+                                            <Binding Path="FrameIndex" Mode="OneWay"/>
+                                        </MultiBinding>
+                                    </ImageBrush.ImageSource>
                                 </ImageBrush>
                             </Rectangle.Fill>
                         </Rectangle>
@@ -1230,6 +1236,7 @@
                                         </Rectangle.RenderTransform>
                                         <Rectangle.Fill>
                                             <ImageBrush
+                                                x:Name="TileImageSource"
                                                 ImageSource="{Binding ImageSrc, Mode=OneTime}"
                                                 TileMode="None"
                                                 Stretch="UniformToFill">

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -1373,6 +1373,12 @@ namespace UndertaleModTool
         {
             if (RoomObjectsTree.SelectedItem is Layer layer)
             {
+                if (layer.TilesData.TileData.Length == 0)
+                {
+                    MainWindow.ShowError("Tile data is empty.");
+                    return;
+                }
+
                 StringBuilder sb = new();
                 foreach (uint[] dataRow in layer.TilesData.TileData)
                     sb.AppendLine(String.Join(";", dataRow.Select(x => x.ToString())));
@@ -2070,6 +2076,9 @@ namespace UndertaleModTool
             if (values[0] is Layer.LayerTilesData tilesData)
             {
                 UndertaleBackground tilesBG = tilesData.Background;
+
+                if (tilesBG is null)
+                    return null;
 
                 _ = loader.Convert(new object[] { tilesData }, null, "cache", null);
                 

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -1403,6 +1403,12 @@ namespace UndertaleModTool
         {
             if (RoomObjectsTree.SelectedItem is Layer layer)
             {
+                if (layer.TilesData.TilesX == 0 || layer.TilesData.TilesY == 0)
+                {
+                    MainWindow.ShowError("Tile data size can't be zero.");
+                    return;
+                }
+
                 OpenFileDialog dlg = new()
                 {
                     DefaultExt = "csv",


### PR DESCRIPTION
1) Fixed crashes on: empty tile layer _(GMS 2022)_, adding new texture page item.
2) Added emptiness check for tile layer data import and export.
3) Moved `UndertaleSprite` class declaration to the beginning _(most of code change count)_.
4) Room object rotation is rendered more correctly.
5) Frame index of sprite instance is taken into account.