### PR TITLE
Show the updater location when not found

### DIFF
--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -2436,7 +2436,7 @@ namespace UndertaleModTool
                     string updaterFolder = Path.Combine(Directory.GetCurrentDirectory(), "Updater");
                     if (!File.Exists(Path.Combine(updaterFolder, "UndertaleModToolUpdater.exe")))
                     {
-                        ShowError("Updater not found! Aborting update, try to update manually.");
+                        ShowError("Updater not found! Aborting update, report this to the devs!\nLocation checked: " + updaterFolder);
                         window.UpdateButtonEnabled = true;
                         return;
                     }


### PR DESCRIPTION
This PR shows the checked location when the updater is not found, and changes the text slightly. This should help with debugging any errors that pop up in the future with this system, instead of a vague "not found, update manually" message.