### PR TITLE
Room editor fixes.

### DIFF
--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -29,6 +29,7 @@ namespace UndertaleModTool
 
         private static readonly ConcurrentDictionary<string, ImageSource> imageCache = new();
         private static readonly ConcurrentDictionary<Tuple<string, Tuple<uint, uint, uint, uint>>, ImageSource> tileCache = new();
+        private static readonly MainWindow mainWindow = Application.Current.MainWindow as MainWindow;
 
         private static bool _reuseTileBuffer;
         public static bool ReuseTileBuffer
@@ -77,7 +78,21 @@ namespace UndertaleModTool
             if (texture is null || texture.TexturePage is null)
                 return null;
 
-            string texName = texture.Name.Content;
+            string texName = texture.Name?.Content;
+            if (texName is null)
+            {
+                if (generate)
+                    texName = mainWindow.Dispatcher.Invoke(() =>
+                    {
+                        return (mainWindow.Data.TexturePageItems.IndexOf(texture) + 1).ToString();
+                    });
+                else
+                    texName = (mainWindow.Data.TexturePageItems.IndexOf(texture) + 1).ToString();
+
+                if (texName == "-1")
+                    return null;
+            }
+
 
             if (tileRectList is not null)
             {

--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -79,7 +79,7 @@ namespace UndertaleModTool
                 return null;
 
             string texName = texture.Name?.Content;
-            if (texName is null)
+            if (texName is null || texName == "PageItem Unknown Index")
             {
                 if (generate)
                     texName = mainWindow.Dispatcher.Invoke(() =>
@@ -337,10 +337,18 @@ namespace UndertaleModTool
             if (tilesBG is null)
                 return null;
 
-            Bitmap tilePageBMP;
-            if (tilePageCache.ContainsKey(tilesBG.Texture.Name.Content))
+            string texName = tilesBG.Texture?.Name?.Content;
+            if (texName is null or "PageItem Unknown Index")
             {
-                tilePageBMP = tilePageCache[tilesBG.Texture.Name.Content];
+                texName = ((Application.Current.MainWindow as MainWindow).Data.TexturePageItems.IndexOf(tilesBG.Texture) + 1).ToString();
+                if (texName == "-1")
+                    return null;
+            }
+
+            Bitmap tilePageBMP;
+            if (tilePageCache.ContainsKey(texName))
+            {
+                tilePageBMP = tilePageCache[texName];
             }
             else
             {
@@ -349,7 +357,7 @@ namespace UndertaleModTool
                                                                                 tilesBG.Texture.SourceWidth,
                                                                                 tilesBG.Texture.SourceHeight), tilesBG.Texture);
 
-                tilePageCache[tilesBG.Texture.Name.Content] = tilePageBMP;
+                tilePageCache[texName] = tilePageBMP;
             }
 
             BitmapData data = tilePageBMP.LockBits(new Rectangle(0, 0, tilePageBMP.Width, tilePageBMP.Height), ImageLockMode.ReadOnly, tilePageBMP.PixelFormat);
@@ -396,7 +404,7 @@ namespace UndertaleModTool
                     tileBMP.UnlockBits(tileData);
                     ArrayPool<byte>.Shared.Return(bufferRes);
 
-                    TileCache.TryAdd(new(tilesBG.Texture.Name.Content, (uint)((tilesBG.GMS2TileColumns * y) + x)), tileBMP);
+                    TileCache.TryAdd(new(texName, (uint)((tilesBG.GMS2TileColumns * y) + x)), tileBMP);
                 }
             });
 

--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -210,6 +210,9 @@ namespace UndertaleModTool
                 int w = (int)tileRect.Item3;
                 int h = (int)tileRect.Item4;
 
+                if (w == 0 || h == 0)
+                    return;
+
                 /// Sometimes, tile size can be bigger than texture size
                 /// (for example, BG tile of "room_torielroom")
                 /// Also, it can be out of texture bounds

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -1516,11 +1516,12 @@ namespace UndertaleModTool
 
             tileTextures = tiles?.AsParallel()
                                  .WithExecutionMode(ParallelExecutionMode.ForceParallelism)
-                                 .GroupBy(x => x.Tpag?.Name)
+                                 .GroupBy(x => x.Tpag?.Name?.Content ?? (mainWindow.Data.TexturePageItems.IndexOf(x.Tpag) + 1).ToString())
+                                 .Where(x => x.Key != "-1")
                                  .Select(x =>
                                  {
                                      return new Tuple<UndertaleTexturePageItem, List<Tuple<uint, uint, uint, uint>>>(
-                                         x.First().Tpag, 
+                                         x.First().Tpag,
                                          x.Select(tile => new Tuple<uint, uint, uint, uint>(tile.SourceX, tile.SourceY, tile.Width, tile.Height))
                                           .Distinct()
                                           .ToList());
@@ -1540,9 +1541,16 @@ namespace UndertaleModTool
                     _ => null
                 };
 
-                if (texture is not null)
+                if (texture is not null && texture.TexturePage is not null)
                 {
-                    string textPageName = texture.TexturePage.Name.Content;
+                    string textPageName = texture.TexturePage.Name?.Content;
+                    if (textPageName is null)
+                    {
+                        textPageName = (mainWindow.Data.TexturePageItems.IndexOf(texture) + 1).ToString();
+                        if (textPageName == "-1")
+                            return;
+                    }
+
                     _ = textPages.AddOrUpdate(textPageName, new ConcurrentBag<UndertaleTexturePageItem>() { texture }, (_, list) =>
                     {
                         list.Add(texture);

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -2036,21 +2036,30 @@ namespace UndertaleModTool
             }
         }
 
-        public static void ShowMessage(string message)
+        public static void ShowMessage(string message, bool wait = true)
         {
-            MessageBox.Show(message, "UndertaleModTool", MessageBoxButton.OK, MessageBoxImage.Information);
+            if (wait)
+                MessageBox.Show(message, "UndertaleModTool", MessageBoxButton.OK, MessageBoxImage.Information);
+            else
+                _ = Task.Run(() => MessageBox.Show(message, "UndertaleModTool", MessageBoxButton.OK, MessageBoxImage.Information));
         }
         public static MessageBoxResult ShowQuestion(string message, MessageBoxImage icon = MessageBoxImage.Question)
         {
             return MessageBox.Show(message, "UndertaleModTool", MessageBoxButton.YesNo, icon);
         }
-        public static void ShowWarning(string message)
+        public static void ShowWarning(string message, bool wait = true)
         {
-            MessageBox.Show(message, "UndertaleModTool", MessageBoxButton.OK, MessageBoxImage.Warning);
+            if (wait)
+                MessageBox.Show(message, "UndertaleModTool", MessageBoxButton.OK, MessageBoxImage.Warning);
+            else
+                _ = Task.Run(() => MessageBox.Show(message, "UndertaleModTool", MessageBoxButton.OK, MessageBoxImage.Warning));
         }
-        public static void ShowError(string message)
+        public static void ShowError(string message, bool wait = true)
         {
-            MessageBox.Show(message, "UndertaleModTool", MessageBoxButton.OK, MessageBoxImage.Error);
+            if (wait)
+                MessageBox.Show(message, "UndertaleModTool", MessageBoxButton.OK, MessageBoxImage.Error);
+            else
+                _ = Task.Run(() => MessageBox.Show(message, "UndertaleModTool", MessageBoxButton.OK, MessageBoxImage.Error));
         }
 
         public void SetUMTConsoleText(string message)

--- a/UndertaleModTool/Repackers/CopySpriteBgFont.csx
+++ b/UndertaleModTool/Repackers/CopySpriteBgFont.csx
@@ -48,6 +48,8 @@ List<string> splitStringsList = GetSplitStringsList("sprite(s)/background(s)/fon
 bool[] SpriteSheetsCopyNeeded = new bool[DonorDataEmbeddedTexturesCount];
 bool[] SpriteSheetsUsed = new bool[(DataEmbeddedTexturesCount + DonorDataEmbeddedTexturesCount)];
 
+int lastTextPage = Data.EmbeddedTextures.Count - 1;
+
 SetProgressBar(null, "Textures Exported", 0, DonorData.TexturePageItems.Count);
 StartUpdater();
 
@@ -64,9 +66,9 @@ await Task.Run(() => {
     for (var i = 0; i < DonorDataEmbeddedTexturesCount; i++)
     {
         UndertaleEmbeddedTexture texture = new UndertaleEmbeddedTexture();
+        texture.Name = new UndertaleString("Texture " + ++lastTextPage);
         texture.TextureData.TextureBlob = DonorData.EmbeddedTextures[i].TextureData.TextureBlob;
         Data.EmbeddedTextures.Add(texture);
-        texture.Name = new UndertaleString("Texture " + Data.EmbeddedTextures.IndexOf(texture).ToString());
     }
     for (var j = 0; j < splitStringsList.Count; j++)
     {

--- a/UndertaleModTool/Repackers/CopySpriteBgFontInternal.csx
+++ b/UndertaleModTool/Repackers/CopySpriteBgFontInternal.csx
@@ -38,6 +38,8 @@ List<string> splitStringsList = GetSplitStringsList("sprite(s)/background(s)/fon
 bool[] SpriteSheetsCopyNeeded = new bool[DataEmbeddedTexturesCount];
 bool[] SpriteSheetsUsed = new bool[(DataEmbeddedTexturesCount + DataEmbeddedTexturesCount)];
 
+int lastTextPage = Data.EmbeddedTextures.Count - 1;
+
 SetProgressBar(null, "Textures Exported", 0, Data.TexturePageItems.Count);
 StartUpdater();
 
@@ -54,9 +56,9 @@ await Task.Run(() => {
     for (var i = 0; i < DataEmbeddedTexturesCount; i++)
     {
         UndertaleEmbeddedTexture texture = new UndertaleEmbeddedTexture();
+        texture.Name = new UndertaleString("Texture " + ++lastTextPage);
         texture.TextureData.TextureBlob = Data.EmbeddedTextures[i].TextureData.TextureBlob;
         Data.EmbeddedTextures.Add(texture);
-        texture.Name = new UndertaleString("Texture " + Data.EmbeddedTextures.IndexOf(texture).ToString());
     }
     for (var j = 0; j < splitStringsList.Count; j++)
     {

--- a/UndertaleModTool/Repackers/ImportFontData.csx
+++ b/UndertaleModTool/Repackers/ImportFontData.csx
@@ -27,6 +27,8 @@ Packer packer = new Packer();
 packer.Process(sourcePath, searchPattern, textureSize, border, debug);
 packer.SaveAtlasses(outName);
 
+int lastTextPage = Data.EmbeddedTextures.Count - 1;
+int lastTextPageItem = Data.TexturePageItems.Count - 1;
 
 string prefix = outName.Replace(Path.GetExtension(outName), "");
 int atlasCount = 0;
@@ -35,6 +37,7 @@ foreach (Atlas atlas in packer.Atlasses)
     string atlasName = String.Format(prefix + "{0:000}" + ".png", atlasCount);
     Bitmap atlasBitmap = new Bitmap(atlasName);
     UndertaleEmbeddedTexture texture = new UndertaleEmbeddedTexture();
+    texture.Name = new UndertaleString("Texture " + ++lastTextPage);
     texture.TextureData.TextureBlob = File.ReadAllBytes(atlasName);
     Data.EmbeddedTextures.Add(texture);
     foreach (Node n in atlas.Nodes)
@@ -42,6 +45,7 @@ foreach (Atlas atlas in packer.Atlasses)
         if (n.Texture != null)
         {
             UndertaleTexturePageItem texturePageItem = new UndertaleTexturePageItem();
+            texturePageItem.Name = new UndertaleString("PageItem " + ++lastTextPageItem);
             texturePageItem.SourceX = (ushort)n.Bounds.X;
             texturePageItem.SourceY = (ushort)n.Bounds.Y;
             texturePageItem.SourceWidth = (ushort)n.Bounds.Width;

--- a/UndertaleModTool/Repackers/ImportGraphics.csx
+++ b/UndertaleModTool/Repackers/ImportGraphics.csx
@@ -28,6 +28,9 @@ Packer packer = new Packer();
 packer.Process(sourcePath, searchPattern, textureSize, PaddingValue, debug);
 packer.SaveAtlasses(outName);
 
+int lastTextPage = Data.EmbeddedTextures.Count - 1;
+int lastTextPageItem = Data.TexturePageItems.Count - 1;
+
 // Import everything into UMT
 string prefix = outName.Replace(Path.GetExtension(outName), "");
 int atlasCount = 0;
@@ -36,6 +39,7 @@ foreach (Atlas atlas in packer.Atlasses)
     string atlasName = Path.Combine(packDir, String.Format(prefix + "{0:000}" + ".png", atlasCount));
     Bitmap atlasBitmap = new Bitmap(atlasName);
     UndertaleEmbeddedTexture texture = new UndertaleEmbeddedTexture();
+    texture.Name = new UndertaleString("Texture " + ++lastTextPage);
     texture.TextureData.TextureBlob = File.ReadAllBytes(atlasName);
     Data.EmbeddedTextures.Add(texture);
     foreach (Node n in atlas.Nodes)
@@ -44,6 +48,7 @@ foreach (Atlas atlas in packer.Atlasses)
         {
             // Initalize values of this texture
             UndertaleTexturePageItem texturePageItem = new UndertaleTexturePageItem();
+            texturePageItem.Name = new UndertaleString("PageItem " + ++lastTextPageItem);
             texturePageItem.SourceX = (ushort)n.Bounds.X;
             texturePageItem.SourceY = (ushort)n.Bounds.Y;
             texturePageItem.SourceWidth = (ushort)n.Bounds.Width;

--- a/UndertaleModTool/Repackers/NewTextureRepacker.csx
+++ b/UndertaleModTool/Repackers/NewTextureRepacker.csx
@@ -416,6 +416,8 @@ var texPageLookup = texPageItems.OrderBy(
 ResetProgress("Laying out texture items");
 var atlases = await layoutPageItemLists(texPageLookup, pageSize, padding);
 
+int lastTextPage = Data.EmbeddedTextures.Count - 1;
+
 // Now recreate texture pages and link the items to the pages
 ResetProgress("Regenerating Texture Pages");
 using (var f = new StreamWriter($"{packagerDirectory}log.txt"))
@@ -434,6 +436,7 @@ using (var f = new StreamWriter($"{packagerDirectory}log.txt"))
         {
             // Textures that are contained into an atlas
             UndertaleEmbeddedTexture tex = new UndertaleEmbeddedTexture();
+            tex.Name = new UndertaleString("Texture " + ++lastTextPage);
             Data.EmbeddedTextures.Add(tex);
             Image img = new Bitmap(atlas.Size, atlas.Size, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
             Graphics g = Graphics.FromImage(img);
@@ -476,6 +479,7 @@ using (var f = new StreamWriter($"{packagerDirectory}log.txt"))
                 f.WriteLine($"tex: {texPageItems.IndexOf(item)}: {0}, {0}, {item.OriginalRect.Width}, {item.OriginalRect.Height}");
 
                 UndertaleEmbeddedTexture tex = new UndertaleEmbeddedTexture();
+                tex.Name = new UndertaleString("Texture " + ++lastTextPage);
                 Data.EmbeddedTextures.Add(tex);
 
                 // Create POT texture if needed

--- a/UndertaleModTool/Repackers/ReduceEmbeddedTexturePages.csx
+++ b/UndertaleModTool/Repackers/ReduceEmbeddedTexturePages.csx
@@ -120,6 +120,9 @@ Packer packer = new Packer();
 packer.Process(sourcePath, searchPattern, textureSize, PaddingValue, debug);
 packer.SaveAtlasses(outName);
 
+int lastTextPage = Data.EmbeddedTextures.Count - 1;
+int lastTextPageItem = Data.TexturePageItems.Count - 1;
+
 // Import everything into UMT
 string prefix = outName.Replace(Path.GetExtension(outName), "");
 int atlasCount = 0;
@@ -128,6 +131,7 @@ foreach (Atlas atlas in packer.Atlasses)
     string atlasName = String.Format(prefix + "{0:000}" + ".png", atlasCount);
     Bitmap atlasBitmap = new Bitmap(atlasName);
     UndertaleEmbeddedTexture texture = new UndertaleEmbeddedTexture();
+    texture.Name = new UndertaleString("Texture " + ++lastTextPage);
     texture.TextureData.TextureBlob = File.ReadAllBytes(atlasName);
     Data.EmbeddedTextures.Add(texture);
     foreach (Node n in atlas.Nodes)
@@ -136,6 +140,7 @@ foreach (Atlas atlas in packer.Atlasses)
         {
             // Initalize values of this texture
             UndertaleTexturePageItem texturePageItem = new UndertaleTexturePageItem();
+            texturePageItem.Name = new UndertaleString("PageItem " + ++lastTextPageItem);
             texturePageItem.SourceX = (ushort)n.Bounds.X;
             texturePageItem.SourceY = (ushort)n.Bounds.Y;
             texturePageItem.SourceWidth = (ushort)n.Bounds.Width;

--- a/UndertaleModTool/SampleScripts/BorderEnabler.csx
+++ b/UndertaleModTool/SampleScripts/BorderEnabler.csx
@@ -66,10 +66,13 @@ if (!Directory.Exists(bordersPath))
 }
 
 // throw new ScriptException(bordersPath);
+int lastTextPage = Data.EmbeddedTextures.Count - 1;
+int lastTextPageItem = Data.TexturePageItems.Count - 1;
 
-foreach(var path in Directory.EnumerateFiles(bordersPath))
+foreach (var path in Directory.EnumerateFiles(bordersPath))
 {
     UndertaleEmbeddedTexture newtex = new UndertaleEmbeddedTexture();
+    newtex.Name = new UndertaleString("Texture " + ++lastTextPage);
     newtex.TextureData.TextureBlob = File.ReadAllBytes(path);
     Data.EmbeddedTextures.Add(newtex);
     textures.Add(Path.GetFileName(path), newtex);
@@ -83,6 +86,7 @@ Action<string, UndertaleEmbeddedTexture, ushort, ushort, ushort, ushort> AssignB
         return;
     }
     UndertaleTexturePageItem tpag = new UndertaleTexturePageItem();
+    tpag.Name = new UndertaleString("PageItem " + ++lastTextPageItem);
     tpag.SourceX = x; tpag.SourceY = y; tpag.SourceWidth = width; tpag.SourceHeight = height;
     tpag.TargetX = 0; tpag.TargetY = 0; tpag.TargetWidth = width; tpag.TargetHeight = height;
     tpag.BoundingWidth = width; tpag.BoundingHeight = height;

--- a/UndertaleModTool/TechnicalScripts/ImportGraphics_Full_Repack.csx
+++ b/UndertaleModTool/TechnicalScripts/ImportGraphics_Full_Repack.csx
@@ -226,6 +226,9 @@ Packer packer = new Packer();
 packer.Process(sourcePath, searchPattern, textureSize, PaddingValue, debug);
 packer.SaveAtlasses(outName);
 
+int lastTextPage = Data.EmbeddedTextures.Count - 1;
+int lastTextPageItem = Data.TexturePageItems.Count - 1;
+
 // Import everything into UMT
 string prefix = outName.Replace(Path.GetExtension(outName), "");
 int atlasCount = 0;
@@ -234,6 +237,7 @@ foreach (Atlas atlas in packer.Atlasses)
     string atlasName = String.Format(prefix + "{0:000}" + ".png", atlasCount);
     Bitmap atlasBitmap = new Bitmap(atlasName);
     UndertaleEmbeddedTexture texture = new UndertaleEmbeddedTexture();
+    texture.Name = new UndertaleString("Texture " + ++lastTextPage);
     texture.TextureData.TextureBlob = File.ReadAllBytes(atlasName);
     Data.EmbeddedTextures.Add(texture);
     foreach (Node n in atlas.Nodes)
@@ -242,6 +246,7 @@ foreach (Atlas atlas in packer.Atlasses)
         {
             // Initalize values of this texture
             UndertaleTexturePageItem texturePageItem = new UndertaleTexturePageItem();
+            texturePageItem.Name = new UndertaleString("PageItem " + ++lastTextPageItem);
             texturePageItem.SourceX = (ushort)n.Bounds.X;
             texturePageItem.SourceY = (ushort)n.Bounds.Y;
             texturePageItem.SourceWidth = (ushort)n.Bounds.Width;


### PR DESCRIPTION
1. Room editor doesn't crash if there are used texture page items with `null` name or with empty texture page.
2. All the scripts that adding new texture pages and texture page items give names to them.
3. Added `wait` argument _(`true` by default)_ to the `ShowMessage()`, `ShowWarning()` and `ShowError()` methods.
4. Room editor doesn't crash on other errors that occurred on tile layer rendering.
5. Also, it doesn't crash on zero size GMS 1 tile.

Closes #782