### PR TITLE
Fixed moving newly created objects

### DIFF
--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -912,6 +912,7 @@ namespace UndertaleModTool
                         InstanceID = mainWindow.Data.GeneralInfo.LastObj++
                     };
                     room.GameObjects.Add(obj);
+                    roomObjDict.TryAdd(obj.InstanceID, layer);
                     if (layer != null)
                         layer.InstancesData.Instances.Add(obj);
 


### PR DESCRIPTION
The Will You Snail? modding community found another issue. When adding a new object into a room and trying to move it the tool crashes. This PR aims to fix this. I tested it with Will You Snail? and deltarune.