### PR TITLE
Minor room editor fixes

### DIFF
--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -346,7 +346,7 @@ namespace UndertaleModTool
                 if (texName is null or "PageItem Unknown Index")
                 {
                     texName = ((Application.Current.MainWindow as MainWindow).Data.TexturePageItems.IndexOf(tilesBG.Texture) + 1).ToString();
-                    if (texName == "-1")
+                    if (texName == "0")
                         return null;
                 }
 

--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -89,7 +89,7 @@ namespace UndertaleModTool
                 else
                     texName = (mainWindow.Data.TexturePageItems.IndexOf(texture) + 1).ToString();
 
-                if (texName == "-1")
+                if (texName == "0")
                     return null;
             }
 

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -1526,7 +1526,7 @@ namespace UndertaleModTool
             tileTextures = tiles?.AsParallel()
                                  .WithExecutionMode(ParallelExecutionMode.ForceParallelism)
                                  .GroupBy(x => x.Tpag?.Name?.Content ?? (mainWindow.Data.TexturePageItems.IndexOf(x.Tpag) + 1).ToString())
-                                 .Where(x => x.Key != "-1")
+                                 .Where(x => x.Key != "0")
                                  .Select(x =>
                                  {
                                      return new Tuple<UndertaleTexturePageItem, List<Tuple<uint, uint, uint, uint>>>(
@@ -1556,7 +1556,7 @@ namespace UndertaleModTool
                     if (textPageName is null)
                     {
                         textPageName = (mainWindow.Data.TexturePageItems.IndexOf(texture) + 1).ToString();
-                        if (textPageName == "-1")
+                        if (textPageName == "0")
                             return;
                     }
 


### PR DESCRIPTION
1. `UndertaleCachedImageLoader.Convert()` and `CachedTileDataLoader.Convert()` now properly return `null` if _(somehow)_ texture page item is not found in the list.
2. `UndertaleRoomEditor.GenerateSpriteCache()` now properly handles texture page items that are not found in the list.