### PR TITLE
2022.3 detection, cleaner 2022.2 detection

### DIFF
--- a/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
+++ b/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
@@ -36,22 +36,6 @@ namespace UndertaleModLib.Models
             Scaled = reader.ReadUInt32();
             if (reader.undertaleData.GeneralInfo.Major >= 2)
                 GeneratedMips = reader.ReadUInt32();
-            // Detect GM2022.3
-            if (!reader.undertaleData.GM2022_3)
-            {
-                uint positionToReturn = reader.Position;
-                uint firstValue = reader.ReadUInt32();
-                /* The first condition ensures padding exists (have not researched, it might always);
-                 * The second is a general check for a wonky pointer;
-                 * And the third finds a pointer value in the padding, showing we're off.
-                 * (If it's zero, that's regular padding and we're pre-2022.3)
-                 */
-                if ((firstValue > reader.Position + 4
-                    || firstValue < reader.Position)
-                    && reader.ReadUInt32() > 0)
-                    reader.undertaleData.GM2022_3 = true;
-                reader.Position = positionToReturn;
-            }
             if (reader.undertaleData.GM2022_3)
                 TextureBlockSize = reader.ReadUInt32();
             TextureData = reader.ReadUndertaleObjectPointer<TexData>();

--- a/UndertaleModLib/Models/UndertaleFont.cs
+++ b/UndertaleModLib/Models/UndertaleFont.cs
@@ -169,7 +169,7 @@ namespace UndertaleModLib.Models
                             }
                             reader.Position += 14;
                             ushort kerningLength = reader.ReadUInt16();
-                            reader.Position += (uint)2 * kerningLength; // combining read/write would apparently break
+                            reader.Position += (uint)4 * kerningLength; // combining read/write would apparently break
                         }
                     }
                     reader.Position = positionToReturn;

--- a/UndertaleModLib/Models/UndertaleFont.cs
+++ b/UndertaleModLib/Models/UndertaleFont.cs
@@ -140,43 +140,9 @@ namespace UndertaleModLib.Models
             if (reader.undertaleData.GeneralInfo?.BytecodeVersion >= 17)
             {
                 AscenderOffset = reader.ReadInt32();
-                // TODO: Add a second check so it doesn't iterate over every font twice (just the first should do)
-                if (!reader.undertaleData.GMS2022_2)
-                {
-                    /* This code performs three checks to identify GM2022.2.
-                     * First, as you've seen, is the bytecode version.
-                     * Second, we assume it is. If there are no Glyphs, we are vindicated by the impossibility of null values there.
-                     * Third, in case of a terrible fluke causing this to appear valid erroneously, we verify that each pointer leads into the next.
-                     * And if someone builds their game so the first pointer is absolutely valid length data and the next font is valid glyph data-
-                     * screw it, call Jacky720 when someone constructs that and you want to mod it.
-                     * Maybe try..catch on the whole shebang?
-                     */
-                    uint positionToReturn = reader.Position;
-                    reader.ReadUInt32(); // We assume this is the ascender
-                    uint glyphsLength = reader.ReadUInt32();
-                    reader.undertaleData.GMS2022_2 = true;
-                    if (glyphsLength != 0)
-                    {
-                        List<uint> glyphPointers = new List<uint>();
-                        for (uint i = 0; i < glyphsLength; i++)
-                            glyphPointers.Add(reader.ReadUInt32());
-                        foreach (uint pointer in glyphPointers)
-                        {
-                            if (reader.Position != pointer)
-                            {
-                                reader.undertaleData.GMS2022_2 = false;
-                                break;
-                            }
-                            reader.Position += 14;
-                            ushort kerningLength = reader.ReadUInt16();
-                            reader.Position += (uint)4 * kerningLength; // combining read/write would apparently break
-                        }
-                    }
-                    reader.Position = positionToReturn;
-                }
+                if (reader.undertaleData.GMS2022_2)
+                    Ascender = reader.ReadUInt32();
             }
-            if (reader.undertaleData.GMS2022_2)
-                Ascender = reader.ReadUInt32();
             Glyphs = reader.ReadUndertaleObject<UndertalePointerList<Glyph>>();
         }
 

--- a/UndertaleModLib/UndertaleChunks.cs
+++ b/UndertaleModLib/UndertaleChunks.cs
@@ -264,6 +264,44 @@ namespace UndertaleModLib
 
         internal override void UnserializeChunk(UndertaleReader reader)
         {
+            if (reader.undertaleData.GeneralInfo?.BytecodeVersion >= 17)
+            {
+                /* This code performs three checks to identify GM2022.2.
+                 * First, as you've seen, is the bytecode version.
+                 * Second, we assume it is. If there are no Glyphs, we are vindicated by the impossibility of null values there.
+                 * Third, in case of a terrible fluke causing this to appear valid erroneously, we verify that each pointer leads into the next.
+                 * And if someone builds their game so the first pointer is absolutely valid length data and the next font is valid glyph data-
+                 * screw it, call Jacky720 when someone constructs that and you want to mod it.
+                 * Maybe try..catch on the whole shebang?
+                 */
+                uint positionToReturn = reader.Position;
+                if (reader.ReadUInt32() > 0) // Font count
+                {
+                    uint firstFontPointer = reader.ReadUInt32();
+                    reader.Position = firstFontPointer + 48; // There are 48 bytes of existing metadata.
+                    uint glyphsLength = reader.ReadUInt32();
+                    reader.undertaleData.GMS2022_2 = true;
+                    if (glyphsLength != 0)
+                    {
+                        List<uint> glyphPointers = new List<uint>();
+                        for (uint i = 0; i < glyphsLength; i++)
+                            glyphPointers.Add(reader.ReadUInt32());
+                        foreach (uint pointer in glyphPointers)
+                        {
+                            if (reader.Position != pointer)
+                            {
+                                reader.undertaleData.GMS2022_2 = false;
+                                break;
+                            }
+                            reader.Position += 14;
+                            ushort kerningLength = reader.ReadUInt16();
+                            reader.Position += (uint)4 * kerningLength; // combining read/write would apparently break
+                        }
+                    }
+                }
+                reader.Position = positionToReturn;
+            }
+
             base.UnserializeChunk(reader);
 
             Padding = reader.ReadBytes(512);
@@ -505,6 +543,27 @@ namespace UndertaleModLib
 
         internal override void UnserializeChunk(UndertaleReader reader)
         {
+            // Detect GM2022.3
+            if (reader.undertaleData.GMS2_3)
+            {
+                uint positionToReturn = reader.Position;
+                uint texCount = reader.ReadUInt32();
+                if (texCount == 1) // If no textures exist, this could false positive.
+                {
+                    reader.Position += 16; // Jump to either padding or length, depending on version
+                    if (reader.ReadUInt32() > 0) // Check whether it's padding or length
+                        reader.undertaleData.GM2022_3 = true;
+                }
+                else if (texCount > 1)
+                {
+                    uint firstTex = reader.ReadUInt32();
+                    uint secondTex = reader.ReadUInt32();
+                    if (firstTex + 16 == secondTex)
+                        reader.undertaleData.GM2022_3 = true;
+                }
+                reader.Position = positionToReturn;
+            }
+
             base.UnserializeChunk(reader);
 
             // texture blobs

--- a/UndertaleModLib/UndertaleData.cs
+++ b/UndertaleModLib/UndertaleData.cs
@@ -117,6 +117,7 @@ namespace UndertaleModLib
         public bool UseBZipFormat = false;
         public bool GMS2022_1 = false;
         public bool GMS2022_2 = false;
+        public bool GM2022_3 = false;
         public ToolInfo ToolInfo = new ToolInfo();
         public int PaddingAlignException = -1;
 


### PR DESCRIPTION
This PR fixes #819 and moves 2022.2 detection to the chunk level rather than wasting time on every font.

We may want to add some way to set the 2022.2 flag if 2022.3 is detected on a game with no fonts like DogScepter's global version number, as opposed to our current series of booleans.