### PR TITLE
Minor compiler fix

### DIFF
--- a/UndertaleModLib/Compiler/Lexer.cs
+++ b/UndertaleModLib/Compiler/Lexer.cs
@@ -493,7 +493,7 @@ namespace UndertaleModLib.Compiler
                     "return" => new Token(Token.TokenKind.KeywordReturn, cr.GetPositionInfo(index)),
                     "default" => new Token(Token.TokenKind.KeywordDefault, cr.GetPositionInfo(index)),
                     "struct" => new Token(Token.TokenKind.KeywordStruct, cr.GetPositionInfo(index)),
-                    "function" => new Token(Token.TokenKind.KeywordFunction, cr.GetPositionInfo(index)),
+                    "function" when cr.compileContext.Data.GMS2_3 => new Token(Token.TokenKind.KeywordFunction, cr.GetPositionInfo(index)),
                     "for" => new Token(Token.TokenKind.KeywordFor, cr.GetPositionInfo(index)),
                     "case" => new Token(Token.TokenKind.KeywordCase, cr.GetPositionInfo(index)),
                     "switch" => new Token(Token.TokenKind.KeywordSwitch, cr.GetPositionInfo(index)),

--- a/UndertaleModLib/Models/UndertaleFont.cs
+++ b/UndertaleModLib/Models/UndertaleFont.cs
@@ -232,11 +232,9 @@ namespace UndertaleModLib.Models
             ScaleX = reader.ReadSingle();
             ScaleY = reader.ReadSingle();
             if (reader.undertaleData.GeneralInfo?.BytecodeVersion >= 17)
-            {
                 AscenderOffset = reader.ReadInt32();
-                if (reader.undertaleData.GMS2022_2)
-                    Ascender = reader.ReadUInt32();
-            }
+            if (reader.undertaleData.GMS2022_2)
+                Ascender = reader.ReadUInt32();
             Glyphs = reader.ReadUndertaleObject<UndertalePointerList<Glyph>>();
         }
 


### PR DESCRIPTION
Fixes a bug where gml_Object_obj_darkcontroller_Draw_0 in the SURVEY_PROGRAM demo of Deltarune would not compile due to the use of the "function" variable (naturally renamed in the Chapter 1&2 demo thanks to the introduction of the function keyword). Does not fix any similar issues with 2.3 keywords, but it should be a similar simple fix if such arise.

Code highlighting is still erroneous due to its hardcoded XML nature (see UndertaleCodeEditor.xaml.cs, lines 97-131).