### PR TITLE
Added the "Frame index" and "Image speed" fields.

### DIFF
--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -699,7 +699,7 @@ namespace UndertaleModLib.Models
             /// </summary>
             public int ImageIndex { get; set; }
             /// <summary>
-            /// A wrapper of <see cref="ImageIndex"/> that prevents entering index that's out of bounds.
+            /// A wrapper of <see cref="ImageIndex"/> that prevents using an out of bounds index.
             /// </summary>
             public int SafeImageIndex { get => ImageIndex; set { ImageIndex = Math.Clamp(value, 0, (ObjectDefinition?.Sprite?.Textures?.Count ?? 1) - 1); OnPropertyChanged(); } }
 

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -698,6 +698,10 @@ namespace UndertaleModLib.Models
             /// The image index of this object. Game Maker: Studio 2 only.
             /// </summary>
             public int ImageIndex { get; set; }
+            /// <summary>
+            /// A wrapper of <see cref="ImageIndex"/> that prevents entering index that's out of bounds.
+            /// </summary>
+            public int SafeImageIndex { get => ImageIndex; set { ImageIndex = Math.Clamp(value, 0, (ObjectDefinition?.Sprite?.Textures?.Count ?? 1) - 1); OnPropertyChanged(); } }
 
             public event PropertyChangedEventHandler PropertyChanged;
             protected void OnPropertyChanged([CallerMemberName] string name = null)
@@ -1362,7 +1366,7 @@ namespace UndertaleModLib.Models
             public float AnimationSpeed { get; set; }
             public AnimationSpeedType AnimationSpeedType { get; set; }
             public float FrameIndex { get; set; }
-            public float SafeFrameIndex { get => FrameIndex; set { FrameIndex = Math.Clamp(value, 0, Sprite.Textures.Count - 1); OnPropertyChanged(); } }
+            public float SafeFrameIndex { get => FrameIndex; set { FrameIndex = Math.Clamp(value, 0, (Sprite?.Textures?.Count ?? 1) - 1); OnPropertyChanged(); } }
             public float Rotation { get; set; }
             public float OppositeRotation => 360F - Rotation;
             public int XOffset => Sprite is not null ? X - Sprite.OriginX : X;

--- a/UndertaleModTool/Controls/UndertaleRoomRenderer.xaml
+++ b/UndertaleModTool/Controls/UndertaleRoomRenderer.xaml
@@ -26,6 +26,7 @@
         <local:CachedTileDataLoader x:Key="CachedTileDataLoader"/>
         <local:TileLayerTemplateSelector x:Key="TileLayerTemplateSelector"/>
         <local:TileRectanglesConverter x:Key="TileRectanglesConverter"/>
+        <local:CachedImageLoaderWithIndex x:Key="CachedImageLoaderWithIndex"/>
         <CompositeCollection x:Key="AllObjectsGMS1">
             <CollectionContainer Collection="{Binding Source={x:Reference RoomRenderer}, Path=DataContext.Backgrounds}"/>
             <CollectionContainer Collection="{Binding Source={x:Reference RoomRenderer}, Path=DataContext.Tiles}"/>
@@ -146,9 +147,14 @@
                         </Rectangle.RenderTransform>
                         <Rectangle.Fill>
                             <ImageBrush
-                                ImageSource="{Binding ObjectDefinition.Sprite.Textures[0].Texture, Converter={StaticResource UndertaleCachedImageLoader}, Mode=OneTime}"
                                 TileMode="None"
                                 Stretch="UniformToFill">
+                                <ImageBrush.ImageSource>
+                                    <MultiBinding Converter="{StaticResource CachedImageLoaderWithIndex}" Mode="OneTime">
+                                        <Binding Path="ObjectDefinition.Sprite.Textures" Mode="OneTime"/>
+                                        <Binding Path="ImageIndex" Mode="OneTime"/>
+                                    </MultiBinding>
+                                </ImageBrush.ImageSource>
                             </ImageBrush>
                         </Rectangle.Fill>
                     </Rectangle>
@@ -180,9 +186,14 @@
                         </Rectangle.RenderTransform>
                         <Rectangle.Fill>
                             <ImageBrush
-                                ImageSource="{Binding Sprite.Textures[0].Texture, Mode=OneTime, Converter={StaticResource UndertaleCachedImageLoader}}"
                                 TileMode="None"
                                 Stretch="UniformToFill">
+                                <ImageBrush.ImageSource>
+                                    <MultiBinding Converter="{StaticResource CachedImageLoaderWithIndex}" Mode="OneTime">
+                                        <Binding Path="Sprite.Textures" Mode="OneTime"/>
+                                        <Binding Path="FrameIndex" Mode="OneTime"/>
+                                    </MultiBinding>
+                                </ImageBrush.ImageSource>
                             </ImageBrush>
                         </Rectangle.Fill>
                     </Rectangle>

--- a/UndertaleModTool/Converters/DataFieldOneTimeConverter.cs
+++ b/UndertaleModTool/Converters/DataFieldOneTimeConverter.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Data;
+using UndertaleModLib;
+
+namespace UndertaleModTool
+{
+    public class DataFieldOneTimeConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is not UndertaleData data || parameter is not string par)
+                return null;
+
+            FieldInfo info = data.GetType().GetField(par);
+            object resObj = info?.GetValue(data);
+
+            if (resObj is bool res)
+                return res ? Visibility.Visible : Visibility.Collapsed;
+            else
+                return null;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -300,7 +300,12 @@ namespace UndertaleModTool
             if (textures is null)
                 return null;
 
-            int index = (int)(float)values[1];
+            int index = -1;
+            if (values[1] is int indexInt)
+                index = indexInt;
+            else if (values[1] is float indexFloat)
+                index = (int)indexFloat;
+
             if (index > textures.Count - 1 || index < 0)
                 return null;
             else

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
@@ -31,6 +31,7 @@
         <local:TileLayerTemplateSelector x:Key="TileLayerTemplateSelector"/>
         <local:TileRectanglesConverter x:Key="TileRectanglesConverter"/>
         <local:CachedImageLoaderWithIndex x:Key="CachedImageLoaderWithIndex"/>
+        <local:DataFieldOneTimeConverter x:Key="DataFieldOneTimeConverter"/>
         <CompositeCollection x:Key="AllObjectsGMS1">
             <CollectionContainer Collection="{Binding Source={x:Reference RoomEditor}, Path=DataContext.Backgrounds}"/>
             <CollectionContainer Collection="{Binding Source={x:Reference RoomEditor}, Path=DataContext.Tiles}"/>
@@ -355,7 +356,7 @@
                     </DataTemplate>
 
                     <DataTemplate DataType="{x:Type undertale:UndertaleRoom+Background}">
-                        <Grid>
+                        <Grid IsSharedSizeScope="True">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto"/>
                                 <ColumnDefinition Width="5"/>
@@ -422,7 +423,7 @@
                     </DataTemplate>
 
                     <DataTemplate DataType="{x:Type undertale:UndertaleRoom+View}">
-                        <Grid>
+                        <Grid IsSharedSizeScope="True">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto"/>
                                 <ColumnDefinition Width="5"/>
@@ -500,9 +501,9 @@
                     </DataTemplate>
 
                     <DataTemplate DataType="{x:Type undertale:UndertaleRoom+GameObject}">
-                        <Grid>
+                        <Grid IsSharedSizeScope="True">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="FirstColumn"/>
                                 <ColumnDefinition Width="5"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
@@ -514,6 +515,7 @@
                                 <RowDefinition Height="Auto" SharedSizeGroup="s22"/>
                                 <RowDefinition Height="Auto" SharedSizeGroup="s22"/>
                                 <RowDefinition Height="Auto" SharedSizeGroup="s22"/>
+                                <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto" SharedSizeGroup="s22"/>
                             </Grid.RowDefinitions>
                             <Grid.Resources>
@@ -558,13 +560,30 @@
                             <TextBlock Grid.Row="6" Grid.Column="0" Margin="3">Rotation</TextBlock>
                             <TextBox Grid.Row="6" Grid.Column="2" Margin="3" Text="{Binding Rotation}"/>
 
-                            <TextBlock Grid.Row="7" Grid.Column="0" Margin="3">Pre Create code</TextBlock>
-                            <local:UndertaleObjectReference Grid.Row="7" Grid.Column="2" Margin="3" ObjectReference="{Binding PreCreateCode}" ObjectType="{x:Type undertale:UndertaleCode}"  ObjectEventType="{x:Static undertale:EventType.PreCreate}" ObjectEventSubtype="0"/>
+                            <Grid Grid.Row="7" Grid.ColumnSpan="3" Visibility="{Binding Data, ConverterParameter=GMS2_2_2_302, Mode=OneTime, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type local:MainWindow}}, Converter={StaticResource DataFieldOneTimeConverter}}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" SharedSizeGroup="FirstColumn"/>
+                                    <ColumnDefinition Width="5"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+                                <TextBlock Grid.Row="0" Grid.Column="0" Margin="3">Frame index</TextBlock>
+                                <TextBox Grid.Row="0" Grid.Column="2" Margin="3" Text="{Binding SafeImageIndex}"/>
+
+                                <TextBlock Grid.Row="1" Grid.Column="0" Margin="3">Image speed</TextBlock>
+                                <TextBox Grid.Row="1" Grid.Column="2" Margin="3" Text="{Binding ImageSpeed}"/>
+                            </Grid>
+                            
+                            <TextBlock Grid.Row="8" Grid.Column="0" Margin="3">Pre Create code</TextBlock>
+                            <local:UndertaleObjectReference Grid.Row="9" Grid.Column="2" Margin="3" ObjectReference="{Binding PreCreateCode}" ObjectType="{x:Type undertale:UndertaleCode}"  ObjectEventType="{x:Static undertale:EventType.PreCreate}" ObjectEventSubtype="0"/>
                         </Grid>
                     </DataTemplate>
 
                     <DataTemplate DataType="{x:Type undertale:UndertaleRoom+Tile}">
-                        <Grid>
+                        <Grid IsSharedSizeScope="True">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto"/>
                                 <ColumnDefinition Width="5"/>
@@ -873,7 +892,7 @@
                     </DataTemplate>
 
                     <DataTemplate DataType="{x:Type undertale:UndertaleRoom+SpriteInstance}">
-                        <Grid>
+                        <Grid IsSharedSizeScope="True">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto"/>
                                 <ColumnDefinition Width="5"/>

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
@@ -1093,9 +1093,14 @@
                             </Rectangle.RenderTransform>
                             <Rectangle.Fill>
                                 <ImageBrush
-                                    ImageSource="{Binding ObjectDefinition.Sprite.Textures[0].Texture, Mode=OneWay, Converter={StaticResource UndertaleCachedImageLoader}}"
                                     TileMode="None"
                                     Stretch="UniformToFill">
+                                    <ImageBrush.ImageSource>
+                                        <MultiBinding Converter="{StaticResource CachedImageLoaderWithIndex}">
+                                            <Binding Path="ObjectDefinition.Sprite.Textures" Mode="OneWay"/>
+                                            <Binding Path="ImageIndex" Mode="OneWay"/>
+                                        </MultiBinding>
+                                    </ImageBrush.ImageSource>
                                 </ImageBrush>
                             </Rectangle.Fill>
                         </Rectangle>


### PR DESCRIPTION
1. Added _"Frame index"_ and _"Image speed"_ fields for game object instances in the room editor.
2. Fixed crash when changing frame index of sprite instance with `null` sprite.
3. `UndertaleRoomRenderer` _(used in "ExportAllRoomsToPng.csx")_ now takes into account frame index of sprite instances _(+ object instances)_.
4. Added _"DataFieldOneTimeConverter"_ for one-time binding to `bool` fields.

Closes #834 