### PR TITLE
Room editor fixes and improvements.

### DIFF
--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -728,7 +728,8 @@ namespace UndertaleModLib.Models
             public int ImageIndex { get; set; }
 
             /// <summary>
-            /// A wrapper for <see cref="ImageIndex"/> that returns the value being wrapped around available frames of the sprite
+            /// A wrapper for <see cref="ImageIndex"/> that returns the value being wrapped around available frames of the sprite.<br/>
+            /// For example, if this sprite has 3 frames, and the index is 5, then this will return 2.
             /// </summary>
             /// <remarks>
             /// This attribute is UMT-only and does not exist in GameMaker.

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -1393,10 +1393,10 @@ namespace UndertaleModLib.Models
             public UndertaleSprite Sprite { get => _Sprite.Resource; set { _Sprite.Resource = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Sprite))); } }
             public int X { get; set; }
             public int Y { get; set; }
-            public float ScaleX { get; set; }
-            public float ScaleY { get; set; }
-            public uint Color { get; set; }
-            public float AnimationSpeed { get; set; }
+            public float ScaleX { get; set; } = 1;
+            public float ScaleY { get; set; } = 1;
+            public uint Color { get; set; } = 0xFFFFFFFF;
+            public float AnimationSpeed { get; set; } = 1;
             public AnimationSpeedType AnimationSpeedType { get; set; }
             public float FrameIndex { get; set; }
             public int WrappedFrameIndex

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -714,7 +714,7 @@ namespace UndertaleModLib.Models
             /// <summary>
             /// A wrapper of <see cref="ImageIndex"/> that prevents using an out of bounds index.
             /// </summary>
-            public int SafeImageIndex { get => ImageIndex; set { ImageIndex = Math.Clamp(value, 0, (ObjectDefinition?.Sprite?.Textures?.Count ?? 1) - 1); OnPropertyChanged(); } }
+            public int SafeImageIndex { get => ImageIndex; set { ImageIndex = Math.Clamp(value, 0, (ObjectDefinition?.Sprite?.Textures.Count ?? 1) - 1); OnPropertyChanged(); } }
 
 
             public event PropertyChangedEventHandler PropertyChanged;
@@ -727,11 +727,11 @@ namespace UndertaleModLib.Models
             /// The opposite angle of the current rotation.
             /// </summary>
             public float OppositeRotation => 360F - (Rotation % 360);
-            public int XOffset => ObjectDefinition.Sprite != null
-                                  ? X - ObjectDefinition.Sprite.OriginX + (ObjectDefinition.Sprite.Textures.FirstOrDefault()?.Texture?.TargetX ?? 0)
+            public int XOffset => ObjectDefinition?.Sprite != null
+                                  ? X - ObjectDefinition.Sprite.OriginX + (ObjectDefinition.Sprite.Textures.ElementAtOrDefault(ImageIndex)?.Texture?.TargetX ?? 0)
                                   : X;
-            public int YOffset => ObjectDefinition.Sprite != null
-                                  ? Y - ObjectDefinition.Sprite.OriginY + (ObjectDefinition.Sprite.Textures.FirstOrDefault()?.Texture?.TargetY ?? 0)
+            public int YOffset => ObjectDefinition?.Sprite != null
+                                  ? Y - ObjectDefinition.Sprite.OriginY + (ObjectDefinition.Sprite.Textures.ElementAtOrDefault(ImageIndex)?.Texture?.TargetY ?? 0)
                                   : Y;
 
             public void Serialize(UndertaleWriter writer)
@@ -867,7 +867,7 @@ namespace UndertaleModLib.Models
             //TODO?
             public uint Color { get; set; } = 0xFFFFFFFF;
 
-            public UndertaleTexturePageItem Tpag => _SpriteMode ? SpriteDefinition?.Textures?.FirstOrDefault()?.Texture : BackgroundDefinition?.Texture; // TODO: what happens on sprites with multiple textures?
+            public UndertaleTexturePageItem Tpag => _SpriteMode ? SpriteDefinition?.Textures.FirstOrDefault()?.Texture : BackgroundDefinition?.Texture; // TODO: what happens on sprites with multiple textures?
 
             public event PropertyChangedEventHandler PropertyChanged;
             protected void OnPropertyChanged([CallerMemberName] string name = null)
@@ -1350,7 +1350,7 @@ namespace UndertaleModLib.Models
             public float AnimationSpeed { get; set; }
             public AnimationSpeedType AnimationSpeedType { get; set; }
             public float FrameIndex { get; set; }
-            public float SafeFrameIndex { get => FrameIndex; set { FrameIndex = Math.Clamp(value, 0, (Sprite?.Textures?.Count ?? 1) - 1); OnPropertyChanged(); } }
+            public float SafeFrameIndex { get => FrameIndex; set { FrameIndex = Math.Clamp(value, 0, (Sprite?.Textures.Count ?? 1) - 1); OnPropertyChanged(); } }
             public float Rotation { get; set; }
             public float OppositeRotation => 360F - Rotation;
             public int XOffset => Sprite is not null ? X - Sprite.OriginX : X;

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -649,9 +649,9 @@ namespace UndertaleModLib.Models
         /// </summary>
         public class GameObject : UndertaleObjectLenCheck, RoomObject, INotifyPropertyChanged
         {
-            private UndertaleResourceById<UndertaleGameObject, UndertaleChunkOBJT> _ObjectDefinition = new UndertaleResourceById<UndertaleGameObject, UndertaleChunkOBJT>();
-            private UndertaleResourceById<UndertaleCode, UndertaleChunkCODE> _CreationCode = new UndertaleResourceById<UndertaleCode, UndertaleChunkCODE>();
-            private UndertaleResourceById<UndertaleCode, UndertaleChunkCODE> _PreCreateCode = new UndertaleResourceById<UndertaleCode, UndertaleChunkCODE>();
+            private UndertaleResourceById<UndertaleGameObject, UndertaleChunkOBJT> _objectDefinition = new();
+            private UndertaleResourceById<UndertaleCode, UndertaleChunkCODE> _creationCode = new();
+            private UndertaleResourceById<UndertaleCode, UndertaleChunkCODE> _preCreateCode = new();
 
             /// <summary>
             /// The x coordinate of this object.
@@ -666,7 +666,7 @@ namespace UndertaleModLib.Models
             /// <summary>
             /// The game object that is used.
             /// </summary>
-            public UndertaleGameObject ObjectDefinition { get => _ObjectDefinition.Resource; set { _ObjectDefinition.Resource = value; OnPropertyChanged(); } }
+            public UndertaleGameObject ObjectDefinition { get => _objectDefinition.Resource; set { _objectDefinition.Resource = value; OnPropertyChanged(); OnPropertyChanged("CurrentTexture"); } }
 
             /// <summary>
             /// The instance id of this object.
@@ -676,7 +676,7 @@ namespace UndertaleModLib.Models
             /// <summary>
             /// The creation code for this object.
             /// </summary>
-            public UndertaleCode CreationCode { get => _CreationCode.Resource; set { _CreationCode.Resource = value; OnPropertyChanged(); } }
+            public UndertaleCode CreationCode { get => _creationCode.Resource; set { _creationCode.Resource = value; OnPropertyChanged(); } }
 
             /// <summary>
             /// The x scale that's applied for this object.
@@ -699,7 +699,7 @@ namespace UndertaleModLib.Models
             /// <summary>
             /// The pre creation code of this object.
             /// </summary>
-            public UndertaleCode PreCreateCode { get => _PreCreateCode.Resource; set { _PreCreateCode.Resource = value; OnPropertyChanged(); } }
+            public UndertaleCode PreCreateCode { get => _preCreateCode.Resource; set { _preCreateCode.Resource = value; OnPropertyChanged(); } }
 
             /// <summary>
             /// The image speed of this object. Game Maker: Studio 2 only.
@@ -710,10 +710,12 @@ namespace UndertaleModLib.Models
             /// The image index of this object. Game Maker: Studio 2 only.
             /// </summary>
             public int ImageIndex { get; set; }
+
             /// <summary>
             /// A wrapper of <see cref="ImageIndex"/> that prevents using an out of bounds index.
             /// </summary>
             public int SafeImageIndex { get => ImageIndex; set { ImageIndex = Math.Clamp(value, 0, (ObjectDefinition?.Sprite?.Textures?.Count ?? 1) - 1); OnPropertyChanged(); } }
+
 
             public event PropertyChangedEventHandler PropertyChanged;
             protected void OnPropertyChanged([CallerMemberName] string name = null)
@@ -736,9 +738,9 @@ namespace UndertaleModLib.Models
             {
                 writer.Write(X);
                 writer.Write(Y);
-                writer.WriteUndertaleObject(_ObjectDefinition);
+                writer.WriteUndertaleObject(_objectDefinition);
                 writer.Write(InstanceID);
-                writer.WriteUndertaleObject(_CreationCode);
+                writer.WriteUndertaleObject(_creationCode);
                 writer.Write(ScaleX);
                 writer.Write(ScaleY);
                 if (writer.undertaleData.GMS2_2_2_302)
@@ -749,7 +751,7 @@ namespace UndertaleModLib.Models
                 writer.Write(Color);
                 writer.Write(Rotation);
                 if (writer.undertaleData.GeneralInfo.BytecodeVersion >= 16) // TODO: is that dependent on bytecode or something else?
-                    writer.WriteUndertaleObject(_PreCreateCode);         // Note: Appears in GM:S 1.4.9999 as well, so that's probably the closest it gets
+                    writer.WriteUndertaleObject(_preCreateCode);         // Note: Appears in GM:S 1.4.9999 as well, so that's probably the closest it gets
             }
 
             public void Unserialize(UndertaleReader reader)
@@ -761,9 +763,9 @@ namespace UndertaleModLib.Models
             {
                 X = reader.ReadInt32();
                 Y = reader.ReadInt32();
-                _ObjectDefinition = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleGameObject, UndertaleChunkOBJT>>();
+                _objectDefinition = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleGameObject, UndertaleChunkOBJT>>();
                 InstanceID = reader.ReadUInt32();
-                _CreationCode = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleCode, UndertaleChunkCODE>>();
+                _creationCode = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleCode, UndertaleChunkCODE>>();
                 ScaleX = reader.ReadSingle();
                 ScaleY = reader.ReadSingle();
                 if (length == 48)
@@ -775,7 +777,7 @@ namespace UndertaleModLib.Models
                 Color = reader.ReadUInt32();
                 Rotation = reader.ReadSingle();
                 if (reader.undertaleData.GeneralInfo.BytecodeVersion >= 16) // TODO: is that dependent on bytecode or something else?
-                    _PreCreateCode = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleCode, UndertaleChunkCODE>>(); // Note: Appears in GM:S 1.4.9999 as well, so that's probably the closest it gets
+                    _preCreateCode = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleCode, UndertaleChunkCODE>>(); // Note: Appears in GM:S 1.4.9999 as well, so that's probably the closest it gets
             }
 
             public override string ToString()

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -727,9 +727,23 @@ namespace UndertaleModLib.Models
             /// The opposite angle of the current rotation.
             /// </summary>
             public float OppositeRotation => 360F - (Rotation % 360);
+
+            /// <summary>
+            /// A horizontal offset used for proper game object display in the UndertaleModTool room editor.
+            /// </summary>
+            /// <remarks>
+            /// This attribute is UMT-only and does not exist in GameMaker.
+            /// </remarks>
             public int XOffset => ObjectDefinition?.Sprite != null
                                   ? X - ObjectDefinition.Sprite.OriginX + (ObjectDefinition.Sprite.Textures.ElementAtOrDefault(ImageIndex)?.Texture?.TargetX ?? 0)
                                   : X;
+
+            /// <summary>
+            /// A vertical offset used for proper game object display in the UndertaleModTool room editor.
+            /// </summary>
+            /// <remarks>
+            /// This attribute is UMT-only and does not exist in GameMaker.
+            /// </remarks>
             public int YOffset => ObjectDefinition?.Sprite != null
                                   ? Y - ObjectDefinition.Sprite.OriginY + (ObjectDefinition.Sprite.Textures.ElementAtOrDefault(ImageIndex)?.Texture?.TargetY ?? 0)
                                   : Y;
@@ -868,6 +882,22 @@ namespace UndertaleModLib.Models
             public uint Color { get; set; } = 0xFFFFFFFF;
 
             public UndertaleTexturePageItem Tpag => spriteMode ? SpriteDefinition?.Textures.FirstOrDefault()?.Texture : BackgroundDefinition?.Texture; // TODO: what happens on sprites with multiple textures?
+
+            /// <summary>
+            /// A horizontal offset used for proper tile display in the UndertaleModTool room editor.
+            /// </summary>
+            /// <remarks>
+            /// This attribute is UMT-only and does not exist in GameMaker.
+            /// </remarks>
+            public int XOffset => X + (Tpag?.TargetX ?? 0);
+
+            /// <summary>
+            /// A vertical offset used for proper tile display in the UndertaleModTool room editor.
+            /// </summary>
+            /// <remarks>
+            /// This attribute is UMT-only and does not exist in GameMaker.
+            /// </remarks>
+            public int YOffset => Y + (Tpag?.TargetY ?? 0);
 
             public event PropertyChangedEventHandler PropertyChanged;
             protected void OnPropertyChanged([CallerMemberName] string name = null)
@@ -1353,8 +1383,8 @@ namespace UndertaleModLib.Models
             public float SafeFrameIndex { get => FrameIndex; set { FrameIndex = Math.Clamp(value, 0, (Sprite?.Textures.Count ?? 1) - 1); OnPropertyChanged(); } }
             public float Rotation { get; set; }
             public float OppositeRotation => 360F - Rotation;
-            public int XOffset => Sprite is not null ? X - Sprite.OriginX : X;
-            public int YOffset => Sprite is not null ? Y - Sprite.OriginY : Y;
+            public int XOffset => X - (Sprite?.OriginX ?? 0);
+            public int YOffset => Y - (Sprite?.OriginY ?? 0);
 
             public event PropertyChangedEventHandler PropertyChanged;
             protected void OnPropertyChanged([CallerMemberName] string name = null)

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -86,7 +86,7 @@ namespace UndertaleModLib.Models
         /// </summary>
         public bool DrawBackgroundColor { get; set; } = true;
 
-        private UndertaleResourceById<UndertaleCode, UndertaleChunkCODE> _CreationCodeId = new UndertaleResourceById<UndertaleCode, UndertaleChunkCODE>();
+        private UndertaleResourceById<UndertaleCode, UndertaleChunkCODE> _CreationCodeId = new();
 
         /// <summary>
         /// The creation code of this room.
@@ -438,7 +438,7 @@ namespace UndertaleModLib.Models
             /// Whether this acts as a foreground.
             /// </summary>
             public bool Foreground { get; set; } = false;
-            private UndertaleResourceById<UndertaleBackground, UndertaleChunkBGND> _BackgroundDefinition = new UndertaleResourceById<UndertaleBackground, UndertaleChunkBGND>();
+            private UndertaleResourceById<UndertaleBackground, UndertaleChunkBGND> _BackgroundDefinition = new();
 
             /// <summary>
             /// The background asset this uses.
@@ -598,7 +598,7 @@ namespace UndertaleModLib.Models
             /// </summary>
             public int SpeedY { get; set; } = -1;
 
-            private UndertaleResourceById<UndertaleGameObject, UndertaleChunkOBJT> _ObjectId = new UndertaleResourceById<UndertaleGameObject, UndertaleChunkOBJT>();
+            private UndertaleResourceById<UndertaleGameObject, UndertaleChunkOBJT> _ObjectId = new();
 
             /// <summary>
             /// The object the view should follow.
@@ -795,8 +795,8 @@ namespace UndertaleModLib.Models
             /// Whether this tile is from an asset layer. Game Maker Studio: 2 exclusive.
             /// </summary>
             public bool _SpriteMode = false;
-            private UndertaleResourceById<UndertaleBackground, UndertaleChunkBGND> _BackgroundDefinition = new UndertaleResourceById<UndertaleBackground, UndertaleChunkBGND>();
-            private UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT> _SpriteDefinition = new UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT>();
+            private UndertaleResourceById<UndertaleBackground, UndertaleChunkBGND> _BackgroundDefinition = new();
+            private UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT> _SpriteDefinition = new();
 
             /// <summary>
             /// The x coordinate of the tile in the room.
@@ -1086,7 +1086,7 @@ namespace UndertaleModLib.Models
 
             public class LayerTilesData : LayerData, INotifyPropertyChanged
             {
-                private UndertaleResourceById<UndertaleBackground, UndertaleChunkBGND> _Background = new UndertaleResourceById<UndertaleBackground, UndertaleChunkBGND>(); // In GMS2 backgrounds are just tilesets
+                private UndertaleResourceById<UndertaleBackground, UndertaleChunkBGND> _Background = new(); // In GMS2 backgrounds are just tilesets
                 private uint _TilesX;
                 private uint _TilesY;
                 private uint[][] _TileData; // Each is simply an ID from the tileset/background/sprite
@@ -1172,7 +1172,7 @@ namespace UndertaleModLib.Models
             {
                 private Layer _ParentLayer;
 
-                private UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT> _Sprite = new UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT>(); // Apparently there's a mode where it's a background reference, but probably not necessary
+                private UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT> _Sprite = new(); // Apparently there's a mode where it's a background reference, but probably not necessary
                 private bool _TiledHorizontally;
                 private bool _TiledVertically;
                 private bool _Stretch;
@@ -1338,7 +1338,7 @@ namespace UndertaleModLib.Models
 
         public class SpriteInstance : UndertaleObject, INotifyPropertyChanged
         {
-            private UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT> _Sprite = new UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT>();
+            private UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT> _Sprite = new();
 
             public UndertaleString Name { get; set; }
             public UndertaleSprite Sprite { get => _Sprite.Resource; set { _Sprite.Resource = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Sprite))); } }
@@ -1400,7 +1400,7 @@ namespace UndertaleModLib.Models
 
         public class SequenceInstance : UndertaleObject, INotifyPropertyChanged
         {
-            private UndertaleResourceById<UndertaleSequence, UndertaleChunkSEQN> _Sequence = new UndertaleResourceById<UndertaleSequence, UndertaleChunkSEQN>();
+            private UndertaleResourceById<UndertaleSequence, UndertaleChunkSEQN> _Sequence = new();
 
             public UndertaleString Name { get; set; }
             public UndertaleSequence Sequence { get => _Sequence.Resource; set { _Sequence.Resource = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Sequence))); } }

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -883,22 +883,6 @@ namespace UndertaleModLib.Models
 
             public UndertaleTexturePageItem Tpag => spriteMode ? SpriteDefinition?.Textures.FirstOrDefault()?.Texture : BackgroundDefinition?.Texture; // TODO: what happens on sprites with multiple textures?
 
-            /// <summary>
-            /// A horizontal offset used for proper tile display in the UndertaleModTool room editor.
-            /// </summary>
-            /// <remarks>
-            /// This attribute is UMT-only and does not exist in GameMaker.
-            /// </remarks>
-            public int XOffset => X + (Tpag?.TargetX ?? 0);
-
-            /// <summary>
-            /// A vertical offset used for proper tile display in the UndertaleModTool room editor.
-            /// </summary>
-            /// <remarks>
-            /// This attribute is UMT-only and does not exist in GameMaker.
-            /// </remarks>
-            public int YOffset => Y + (Tpag?.TargetY ?? 0);
-
             public event PropertyChangedEventHandler PropertyChanged;
             protected void OnPropertyChanged([CallerMemberName] string name = null)
             {

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -486,6 +486,9 @@ namespace UndertaleModLib.Models
             /// </summary>
             public bool TiledVertically { get => TileY > 0; set { TileY = value ? 1 : 0; OnPropertyChanged(); } }
 
+            public int XOffset => X + (BackgroundDefinition?.Texture?.TargetX ?? 0);
+            public int YOffset => Y + (BackgroundDefinition?.Texture?.TargetY ?? 0);
+
             public event PropertyChangedEventHandler PropertyChanged;
             protected void OnPropertyChanged([CallerMemberName] string name = null)
             {
@@ -1206,6 +1209,9 @@ namespace UndertaleModLib.Models
                 public float AnimationSpeed { get; set; }
                 public AnimationSpeedType AnimationSpeedType { get; set; }
 
+                public float XOffset => (ParentLayer?.XOffset ?? 0) + (Sprite?.Textures.FirstOrDefault()?.Texture?.TargetX ?? 0);
+                public float YOffset => (ParentLayer?.YOffset ?? 0) + (Sprite?.Textures.FirstOrDefault()?.Texture?.TargetY ?? 0);
+
                 public event PropertyChangedEventHandler PropertyChanged;
                 protected void OnPropertyChanged([CallerMemberName] string name = null)
                 {
@@ -1367,8 +1373,12 @@ namespace UndertaleModLib.Models
             public float SafeFrameIndex { get => FrameIndex; set { FrameIndex = Math.Clamp(value, 0, (Sprite?.Textures.Count ?? 1) - 1); OnPropertyChanged(); } }
             public float Rotation { get; set; }
             public float OppositeRotation => 360F - Rotation;
-            public int XOffset => X - (Sprite?.OriginX ?? 0);
-            public int YOffset => Y - (Sprite?.OriginY ?? 0);
+            public int XOffset => Sprite is not null
+                                  ? X - Sprite.OriginX + (Sprite.Textures.ElementAtOrDefault((int)FrameIndex)?.Texture?.TargetX ?? 0)
+                                  : X;
+            public int YOffset => Sprite is not null
+                                  ? Y - Sprite.OriginY + (Sprite.Textures.ElementAtOrDefault((int)FrameIndex)?.Texture?.TargetY ?? 0)
+                                  : Y;
 
             public event PropertyChangedEventHandler PropertyChanged;
             protected void OnPropertyChanged([CallerMemberName] string name = null)

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -728,10 +728,25 @@ namespace UndertaleModLib.Models
             public int ImageIndex { get; set; }
 
             /// <summary>
-            /// A wrapper of <see cref="ImageIndex"/> that prevents using an out of bounds index.
+            /// A wrapper for <see cref="ImageIndex"/> that returns the value being wrapped around available frames of the sprite
             /// </summary>
-            public int SafeImageIndex { get => ImageIndex; set { ImageIndex = Math.Clamp(value, 0, (ObjectDefinition?.Sprite?.Textures.Count ?? 1) - 1); OnPropertyChanged(); } }
+            /// <remarks>
+            /// This attribute is UMT-only and does not exist in GameMaker.
+            /// </remarks>
+            public int WrappedImageIndex
+            { 
+                get
+                {
+                    if (ObjectDefinition?.Sprite is null)
+                        return 0;
 
+                    int count = ObjectDefinition.Sprite.Textures.Count;
+                    if (count == 0)
+                        return 0;
+
+                    return ((ImageIndex % count) + count) % count;
+                }
+            }
 
             public event PropertyChangedEventHandler PropertyChanged;
             protected void OnPropertyChanged([CallerMemberName] string name = null)
@@ -1383,7 +1398,20 @@ namespace UndertaleModLib.Models
             public float AnimationSpeed { get; set; }
             public AnimationSpeedType AnimationSpeedType { get; set; }
             public float FrameIndex { get; set; }
-            public float SafeFrameIndex { get => FrameIndex; set { FrameIndex = Math.Clamp(value, 0, (Sprite?.Textures.Count ?? 1) - 1); OnPropertyChanged(); } }
+            public int WrappedFrameIndex
+            {
+                get
+                {
+                    if (Sprite is null)
+                        return 0;
+
+                    int count = Sprite.Textures.Count;
+                    if (count == 0)
+                        return 0;
+
+                    return (((int)FrameIndex % count) + count) % count;
+                }
+            }
             public float Rotation { get; set; }
             public float OppositeRotation => 360F - Rotation;
             public int XOffset => Sprite is not null

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -486,7 +486,20 @@ namespace UndertaleModLib.Models
             /// </summary>
             public bool TiledVertically { get => TileY > 0; set { TileY = value ? 1 : 0; OnPropertyChanged(); } }
 
+            /// <summary>
+            /// A horizontal offset used for proper background display in the UndertaleModTool room editor.
+            /// </summary>
+            /// <remarks>
+            /// This attribute is UMT-only and does not exist in GameMaker.
+            /// </remarks>
             public int XOffset => X + (BackgroundDefinition?.Texture?.TargetX ?? 0);
+
+            /// <summary>
+            /// A vertical offset used for proper background display in the UndertaleModTool room editor.
+            /// </summary>
+            /// <remarks>
+            /// This attribute is UMT-only and does not exist in GameMaker.
+            /// </remarks>
             public int YOffset => Y + (BackgroundDefinition?.Texture?.TargetY ?? 0);
 
             public event PropertyChangedEventHandler PropertyChanged;

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -682,7 +682,7 @@ namespace UndertaleModLib.Models
             /// <summary>
             /// The game object that is used.
             /// </summary>
-            public UndertaleGameObject ObjectDefinition { get => _objectDefinition.Resource; set { _objectDefinition.Resource = value; OnPropertyChanged(); OnPropertyChanged("CurrentTexture"); } }
+            public UndertaleGameObject ObjectDefinition { get => _objectDefinition.Resource; set { _objectDefinition.Resource = value; OnPropertyChanged(); } }
 
             /// <summary>
             /// The instance id of this object.

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -794,9 +794,9 @@ namespace UndertaleModLib.Models
             /// <summary>
             /// Whether this tile is from an asset layer. Game Maker Studio: 2 exclusive.
             /// </summary>
-            public bool _SpriteMode = false;
-            private UndertaleResourceById<UndertaleBackground, UndertaleChunkBGND> _BackgroundDefinition = new();
-            private UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT> _SpriteDefinition = new();
+            public bool spriteMode = false;
+            private UndertaleResourceById<UndertaleBackground, UndertaleChunkBGND> _backgroundDefinition = new();
+            private UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT> _spriteDefinition = new();
 
             /// <summary>
             /// The x coordinate of the tile in the room.
@@ -811,18 +811,18 @@ namespace UndertaleModLib.Models
             /// <summary>
             /// From which tileset / background the tile stems from.
             /// </summary>
-            public UndertaleBackground BackgroundDefinition { get => _BackgroundDefinition.Resource; set { _BackgroundDefinition.Resource = value; OnPropertyChanged(); OnPropertyChanged("ObjectDefinition"); } }
+            public UndertaleBackground BackgroundDefinition { get => _backgroundDefinition.Resource; set { _backgroundDefinition.Resource = value; OnPropertyChanged(); OnPropertyChanged("ObjectDefinition"); } }
 
             /// <summary>
             /// From which sprite this tile stems from.
             /// </summary>
-            public UndertaleSprite SpriteDefinition { get => _SpriteDefinition.Resource; set { _SpriteDefinition.Resource = value; OnPropertyChanged(); OnPropertyChanged("ObjectDefinition"); } }
+            public UndertaleSprite SpriteDefinition { get => _spriteDefinition.Resource; set { _spriteDefinition.Resource = value; OnPropertyChanged(); OnPropertyChanged("ObjectDefinition"); } }
 
             /// <summary>
             /// From which object this tile stems from.
-            /// Will return a <see cref="UndertaleBackground"/> if <see cref="_SpriteMode"/> is disabled, a <see cref="UndertaleSprite"/> if it's enabled.
+            /// Will return a <see cref="UndertaleBackground"/> if <see cref="spriteMode"/> is disabled, a <see cref="UndertaleSprite"/> if it's enabled.
             /// </summary>
-            public UndertaleNamedResource ObjectDefinition { get => _SpriteMode ? SpriteDefinition : BackgroundDefinition; set { if (_SpriteMode) SpriteDefinition = (UndertaleSprite)value; else BackgroundDefinition = (UndertaleBackground)value; } }
+            public UndertaleNamedResource ObjectDefinition { get => spriteMode ? SpriteDefinition : BackgroundDefinition; set { if (spriteMode) SpriteDefinition = (UndertaleSprite)value; else BackgroundDefinition = (UndertaleBackground)value; } }
 
             /// <summary>
             /// The x coordinate of the tile in <see cref="ObjectDefinition"/>.
@@ -867,7 +867,7 @@ namespace UndertaleModLib.Models
             //TODO?
             public uint Color { get; set; } = 0xFFFFFFFF;
 
-            public UndertaleTexturePageItem Tpag => _SpriteMode ? SpriteDefinition?.Textures.FirstOrDefault()?.Texture : BackgroundDefinition?.Texture; // TODO: what happens on sprites with multiple textures?
+            public UndertaleTexturePageItem Tpag => spriteMode ? SpriteDefinition?.Textures.FirstOrDefault()?.Texture : BackgroundDefinition?.Texture; // TODO: what happens on sprites with multiple textures?
 
             public event PropertyChangedEventHandler PropertyChanged;
             protected void OnPropertyChanged([CallerMemberName] string name = null)
@@ -879,12 +879,12 @@ namespace UndertaleModLib.Models
             {
                 writer.Write(X);
                 writer.Write(Y);
-                if (_SpriteMode != (writer.undertaleData.GeneralInfo.Major >= 2))
+                if (spriteMode != (writer.undertaleData.GeneralInfo.Major >= 2))
                     throw new Exception("Unsupported in GMS" + writer.undertaleData.GeneralInfo.Major);
-                if (_SpriteMode)
-                    writer.WriteUndertaleObject(_SpriteDefinition);
+                if (spriteMode)
+                    writer.WriteUndertaleObject(_spriteDefinition);
                 else
-                    writer.WriteUndertaleObject(_BackgroundDefinition);
+                    writer.WriteUndertaleObject(_backgroundDefinition);
                 writer.Write(SourceX);
                 writer.Write(SourceY);
                 writer.Write(Width);
@@ -900,11 +900,11 @@ namespace UndertaleModLib.Models
             {
                 X = reader.ReadInt32();
                 Y = reader.ReadInt32();
-                _SpriteMode = reader.undertaleData.GeneralInfo.Major >= 2;
-                if (_SpriteMode)
-                    _SpriteDefinition = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT>>();
+                spriteMode = reader.undertaleData.GeneralInfo.Major >= 2;
+                if (spriteMode)
+                    _spriteDefinition = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT>>();
                 else
-                    _BackgroundDefinition = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleBackground, UndertaleChunkBGND>>();
+                    _backgroundDefinition = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleBackground, UndertaleChunkBGND>>();
                 SourceX = reader.ReadUInt32();
                 SourceY = reader.ReadUInt32();
                 Width = reader.ReadUInt32();

--- a/UndertaleModTool/Controls/UndertaleRoomRenderer.xaml
+++ b/UndertaleModTool/Controls/UndertaleRoomRenderer.xaml
@@ -112,7 +112,7 @@
                         <Rectangle.RenderTransform>
                             <TransformGroup>
                                 <!-- Giving names to transform elements prevents random "Cannot find governing FrameworkElement or FrameworkContentElement for target element." errors -->
-                                <TranslateTransform x:Name="transform0_0" X="{Binding X, Mode=OneTime}" Y="{Binding Y, Mode=OneTime}"/>
+                                <TranslateTransform x:Name="transform0_0" X="{Binding XOffset, Mode=OneTime}" Y="{Binding YOffset, Mode=OneTime}"/>
                                 <ScaleTransform x:Name="transform0_1" ScaleX="{Binding CalcScaleX, Mode=OneWay}" ScaleY="{Binding CalcScaleY, Mode=OneWay}"  CenterX="{Binding X, Mode=OneTime}" CenterY="{Binding Y, Mode=OneTime}"/>
                             </TransformGroup>
                         </Rectangle.RenderTransform>
@@ -210,7 +210,7 @@
                         <Rectangle.RenderTransform>
                             <TransformGroup>
                                 <ScaleTransform x:Name="transform3_0" ScaleX="{Binding CalcScaleX, Mode=OneWay}" ScaleY="{Binding CalcScaleY, Mode=OneWay}" CenterX="0" CenterY="0"/>
-                                <TranslateTransform x:Name="transform3_1" X="{Binding ParentLayer.XOffset, Mode=OneWay}" Y="{Binding ParentLayer.YOffset, Mode=OneWay}"/>
+                                <TranslateTransform x:Name="transform3_1" X="{Binding XOffset, Mode=OneWay}" Y="{Binding YOffset, Mode=OneWay}"/>
                             </TransformGroup>
                         </Rectangle.RenderTransform>
                         <Rectangle.Fill>

--- a/UndertaleModTool/Controls/UndertaleRoomRenderer.xaml
+++ b/UndertaleModTool/Controls/UndertaleRoomRenderer.xaml
@@ -136,7 +136,7 @@
                     </Rectangle>
                 </DataTemplate>
                 <DataTemplate DataType="{x:Type undertale:UndertaleRoom+GameObject}">
-                    <Rectangle Width="{Binding ObjectDefinition.Sprite.Textures[0].Texture.SourceWidth, Mode=OneTime}" Height="{Binding ObjectDefinition.Sprite.Textures[0].Texture.SourceHeight, Mode=OneTime}"
+                    <Rectangle Width="{Binding Fill.ImageSource.Width, RelativeSource={RelativeSource Self}, Mode=OneTime}" Height="{Binding Fill.ImageSource.Height, RelativeSource={RelativeSource Self}, Mode=OneTime}"
                                Opacity="{Binding Color, Mode=OneTime, Converter={StaticResource ColorToOpacityConverter}}">
                         <Rectangle.RenderTransform>
                             <TransformGroup>
@@ -175,7 +175,7 @@
                     </Rectangle>
                 </DataTemplate>
                 <DataTemplate DataType="{x:Type undertale:UndertaleRoom+SpriteInstance}">
-                    <Rectangle Width="{Binding Sprite.Textures[0].Texture.SourceWidth, Mode=OneTime}" Height="{Binding Sprite.Textures[0].Texture.SourceHeight, Mode=OneTime}"
+                    <Rectangle Width="{Binding Fill.ImageSource.Width, RelativeSource={RelativeSource Self}, Mode=OneTime}" Height="{Binding Fill.ImageSource.Height, RelativeSource={RelativeSource Self}, Mode=OneTime}"
                                Opacity="{Binding Color, Mode=OneTime, Converter={StaticResource ColorToOpacityConverter}}">
                         <Rectangle.RenderTransform>
                             <TransformGroup>

--- a/UndertaleModTool/Controls/UndertaleRoomRenderer.xaml
+++ b/UndertaleModTool/Controls/UndertaleRoomRenderer.xaml
@@ -163,7 +163,7 @@
                     <Rectangle Width="{Binding Width, Mode=OneTime}" Height="{Binding Height, Mode=OneTime}"
                                Opacity="{Binding Color, Mode=OneTime, Converter={StaticResource ColorToOpacityConverter}}">
                         <Rectangle.RenderTransform>
-                            <TranslateTransform x:Name="transform2_0" X="{Binding X, Mode=OneTime}" Y="{Binding Y, Mode=OneTime}"/>
+                            <TranslateTransform x:Name="transform2_0" X="{Binding XOffset, Mode=OneTime}" Y="{Binding YOffset, Mode=OneTime}"/>
                         </Rectangle.RenderTransform>
                         <Rectangle.Fill>
                             <ImageBrush

--- a/UndertaleModTool/Controls/UndertaleRoomRenderer.xaml
+++ b/UndertaleModTool/Controls/UndertaleRoomRenderer.xaml
@@ -152,7 +152,7 @@
                                 <ImageBrush.ImageSource>
                                     <MultiBinding Converter="{StaticResource CachedImageLoaderWithIndex}" Mode="OneTime">
                                         <Binding Path="ObjectDefinition.Sprite.Textures" Mode="OneTime"/>
-                                        <Binding Path="ImageIndex" Mode="OneTime"/>
+                                        <Binding Path="WrappedImageIndex" Mode="OneTime"/>
                                     </MultiBinding>
                                 </ImageBrush.ImageSource>
                             </ImageBrush>
@@ -191,7 +191,7 @@
                                 <ImageBrush.ImageSource>
                                     <MultiBinding Converter="{StaticResource CachedImageLoaderWithIndex}" Mode="OneTime">
                                         <Binding Path="Sprite.Textures" Mode="OneTime"/>
-                                        <Binding Path="FrameIndex" Mode="OneTime"/>
+                                        <Binding Path="WrappedFrameIndex" Mode="OneTime"/>
                                     </MultiBinding>
                                 </ImageBrush.ImageSource>
                             </ImageBrush>

--- a/UndertaleModTool/Controls/UndertaleRoomRenderer.xaml
+++ b/UndertaleModTool/Controls/UndertaleRoomRenderer.xaml
@@ -163,7 +163,7 @@
                     <Rectangle Width="{Binding Width, Mode=OneTime}" Height="{Binding Height, Mode=OneTime}"
                                Opacity="{Binding Color, Mode=OneTime, Converter={StaticResource ColorToOpacityConverter}}">
                         <Rectangle.RenderTransform>
-                            <TranslateTransform x:Name="transform2_0" X="{Binding XOffset, Mode=OneTime}" Y="{Binding YOffset, Mode=OneTime}"/>
+                            <TranslateTransform x:Name="transform2_0" X="{Binding X, Mode=OneTime}" Y="{Binding Y, Mode=OneTime}"/>
                         </Rectangle.RenderTransform>
                         <Rectangle.Fill>
                             <ImageBrush

--- a/UndertaleModTool/Controls/UndertaleRoomRenderer.xaml
+++ b/UndertaleModTool/Controls/UndertaleRoomRenderer.xaml
@@ -136,7 +136,7 @@
                     </Rectangle>
                 </DataTemplate>
                 <DataTemplate DataType="{x:Type undertale:UndertaleRoom+GameObject}">
-                    <Rectangle Width="{Binding Fill.ImageSource.Width, RelativeSource={RelativeSource Self}, Mode=OneTime}" Height="{Binding Fill.ImageSource.Height, RelativeSource={RelativeSource Self}, Mode=OneTime}"
+                    <Rectangle Width="{Binding Fill.ImageSource.Width, RelativeSource={RelativeSource Self}, Mode=OneWay}" Height="{Binding Fill.ImageSource.Height, RelativeSource={RelativeSource Self}, Mode=OneWay}"
                                Opacity="{Binding Color, Mode=OneTime, Converter={StaticResource ColorToOpacityConverter}}">
                         <Rectangle.RenderTransform>
                             <TransformGroup>
@@ -175,7 +175,7 @@
                     </Rectangle>
                 </DataTemplate>
                 <DataTemplate DataType="{x:Type undertale:UndertaleRoom+SpriteInstance}">
-                    <Rectangle Width="{Binding Fill.ImageSource.Width, RelativeSource={RelativeSource Self}, Mode=OneTime}" Height="{Binding Fill.ImageSource.Height, RelativeSource={RelativeSource Self}, Mode=OneTime}"
+                    <Rectangle Width="{Binding Fill.ImageSource.Width, RelativeSource={RelativeSource Self}, Mode=OneWay}" Height="{Binding Fill.ImageSource.Height, RelativeSource={RelativeSource Self}, Mode=OneWay}"
                                Opacity="{Binding Color, Mode=OneTime, Converter={StaticResource ColorToOpacityConverter}}">
                         <Rectangle.RenderTransform>
                             <TransformGroup>

--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -223,7 +223,7 @@ namespace UndertaleModTool
                 // (for example, tile 10055649 of "room_fire_core_topright")
                 // (both examples are from Undertale)
                 // This algorithm doesn't support that, so this tile will be processed by "CreateSpriteSource()"
-                if (w > data.Width || h > data.Height || x + w > data.Width || y + h > data.Height)
+                if (w > data.Width || h > data.Height || x < 0 || y < 0 || x + w > data.Width || y + h > data.Height)
                     return;
 
                 int bufferResLen = w * h * depth;

--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -119,8 +119,8 @@ namespace UndertaleModTool
 
                 if (isTile)
                 {
-                    diffW = (int)(tile.SourceX + texture.TargetX + tile.Width - texture.BoundingWidth);
-                    diffH = (int)(tile.SourceY + texture.TargetY + tile.Height - texture.BoundingHeight);
+                    diffW = (int)(tile.SourceX + tile.Width - texture.SourceWidth);
+                    diffH = (int)(tile.SourceY + tile.Height - texture.SourceHeight);
                     rect = new((int)(texture.SourceX + tile.SourceX), (int)(texture.SourceY + tile.SourceY), (int)tile.Width, (int)tile.Height);
                 }
                 else

--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -213,12 +213,12 @@ namespace UndertaleModTool
                 if (w == 0 || h == 0)
                     return;
 
-                /// Sometimes, tile size can be bigger than texture size
-                /// (for example, BG tile of "room_torielroom")
-                /// Also, it can be out of texture bounds
-                /// (for example, tile 10055649 of "room_fire_core_topright")
-                /// (both examples are from Undertale)
-                /// This algorithm doesn't support that, so this tile will be processed by "CreateSpriteSource()"
+                // Sometimes, tile size can be bigger than texture size
+                // (for example, BG tile of "room_torielroom")
+                // Also, it can be out of texture bounds
+                // (for example, tile 10055649 of "room_fire_core_topright")
+                // (both examples are from Undertale)
+                // This algorithm doesn't support that, so this tile will be processed by "CreateSpriteSource()"
                 if (w > data.Width || h > data.Height || x + w > data.Width || y + h > data.Height)
                     return;
 

--- a/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
@@ -39,10 +39,10 @@ using static UndertaleModTool.MainWindow.CodeEditorMode;
 
 namespace UndertaleModTool
 {
-    [SupportedOSPlatform("windows7.0")]
     /// <summary>
     /// Logika interakcji dla klasy UndertaleCodeEditor.xaml
     /// </summary>
+    [SupportedOSPlatform("windows7.0")]
     public partial class UndertaleCodeEditor : DataUserControl
     {
         private static MainWindow mainWindow = Application.Current.MainWindow as MainWindow;

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
@@ -1193,8 +1193,8 @@
                                             <Binding Path="TiledHorizontally" Mode="OneWay"/>
                                             <Binding Path="Stretch" Mode="OneWay"/>
                                             <!-- for notification only -->
-                                            <Binding RelativeSource="{RelativeSource AncestorType=Rectangle}" Path="XOffset" Mode="OneWay"/>
-                                            <Binding RelativeSource="{RelativeSource AncestorType=Rectangle}" Path="YOffset" Mode="OneWay"/>
+                                            <Binding Path="XOffset" Mode="OneWay"/>
+                                            <Binding Path="YOffset" Mode="OneWay"/>
                                             <Binding Path="ParentLayer.ParentRoom.Width" Mode="OneWay"/>
                                             <Binding Path="ParentLayer.ParentRoom.Height" Mode="OneWay"/>
                                             <Binding RelativeSource="{RelativeSource Self}" Path="ImageSource" Mode="OneWay"/>

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
@@ -571,7 +571,7 @@
                                     <RowDefinition Height="Auto"/>
                                 </Grid.RowDefinitions>
                                 <TextBlock Grid.Row="0" Grid.Column="0" Margin="3">Frame index</TextBlock>
-                                <TextBox Grid.Row="0" Grid.Column="2" Margin="3" Text="{Binding SafeImageIndex}"/>
+                                <TextBox Grid.Row="0" Grid.Column="2" Margin="3" Text="{Binding ImageIndex}"/>
 
                                 <TextBlock Grid.Row="1" Grid.Column="0" Margin="3">Image speed</TextBlock>
                                 <TextBox Grid.Row="1" Grid.Column="2" Margin="3" Text="{Binding ImageSpeed}"/>
@@ -959,7 +959,7 @@
                             </Grid>
 
                             <TextBlock Grid.Row="7" Grid.Column="0" Margin="3">Frame index</TextBlock>
-                            <TextBox Grid.Row="7" Grid.Column="2" Margin="3" Text="{Binding SafeFrameIndex}"/>
+                            <TextBox Grid.Row="7" Grid.Column="2" Margin="3" Text="{Binding FrameIndex}"/>
 
                             <TextBlock Grid.Row="8" Grid.Column="0" Margin="3">Rotation</TextBlock>
                             <TextBox Grid.Row="8" Grid.Column="2" Margin="3" Text="{Binding Rotation}"/>
@@ -1098,7 +1098,7 @@
                                     <ImageBrush.ImageSource>
                                         <MultiBinding Converter="{StaticResource CachedImageLoaderWithIndex}">
                                             <Binding Path="ObjectDefinition.Sprite.Textures" Mode="OneWay"/>
-                                            <Binding Path="ImageIndex" Mode="OneWay"/>
+                                            <Binding Path="WrappedImageIndex" Mode="OneWay"/>
                                         </MultiBinding>
                                     </ImageBrush.ImageSource>
                                 </ImageBrush>
@@ -1153,7 +1153,7 @@
                                     <ImageBrush.ImageSource>
                                         <MultiBinding Converter="{StaticResource CachedImageLoaderWithIndex}">
                                             <Binding Path="Sprite.Textures" Mode="OneWay"/>
-                                            <Binding Path="FrameIndex" Mode="OneWay"/>
+                                            <Binding Path="WrappedFrameIndex" Mode="OneWay"/>
                                         </MultiBinding>
                                     </ImageBrush.ImageSource>
                                 </ImageBrush>

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
@@ -1110,7 +1110,7 @@
                                    MouseDown="Rectangle_MouseDown" MouseMove="Rectangle_MouseMove" MouseUp="Rectangle_MouseUp"
                                    Opacity="{Binding Color, Mode=OneWay, Converter={StaticResource ColorToOpacityConverter}}">
                             <Rectangle.RenderTransform>
-                                <TranslateTransform x:Name="transform2_0" X="{Binding X, Mode=OneWay}" Y="{Binding Y, Mode=OneWay}"/>
+                                <TranslateTransform x:Name="transform2_0" X="{Binding XOffset, Mode=OneWay}" Y="{Binding YOffset, Mode=OneWay}"/>
                             </Rectangle.RenderTransform>
                             <Rectangle.Style>
                                 <Style BasedOn="{StaticResource NearestNeighbor}"/>

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
@@ -1078,7 +1078,7 @@
                         </Rectangle>
                     </DataTemplate>
                     <DataTemplate DataType="{x:Type undertale:UndertaleRoom+GameObject}">
-                        <Rectangle Width="{Binding ObjectDefinition.Sprite.Textures[0].Texture.SourceWidth, Mode=OneWay}" Height="{Binding ObjectDefinition.Sprite.Textures[0].Texture.SourceHeight, Mode=OneWay}"
+                        <Rectangle Width="{Binding Fill.ImageSource.Width, RelativeSource={RelativeSource Self}, Mode=OneWay}" Height="{Binding Fill.ImageSource.Height, RelativeSource={RelativeSource Self}, Mode=OneWay}"
                                    MouseDown="Rectangle_MouseDown" MouseMove="Rectangle_MouseMove" MouseUp="Rectangle_MouseUp"
                                    Opacity="{Binding Color, Mode=OneWay, Converter={StaticResource ColorToOpacityConverter}}">
                             <Rectangle.Style>
@@ -1133,7 +1133,7 @@
                         </Rectangle>
                     </DataTemplate>
                     <DataTemplate DataType="{x:Type undertale:UndertaleRoom+SpriteInstance}">
-                        <Rectangle Width="{Binding Sprite.Textures[0].Texture.SourceWidth, Mode=OneWay}" Height="{Binding Sprite.Textures[0].Texture.SourceHeight, Mode=OneWay}"
+                        <Rectangle Width="{Binding Fill.ImageSource.Width, RelativeSource={RelativeSource Self}, Mode=OneWay}" Height="{Binding Fill.ImageSource.Height, RelativeSource={RelativeSource Self}, Mode=OneWay}"
                                    MouseDown="Rectangle_MouseDown" MouseMove="Rectangle_MouseMove" MouseUp="Rectangle_MouseUp"
                                    Opacity="{Binding Color, Mode=OneWay, Converter={StaticResource ColorToOpacityConverter}}">
                             <Rectangle.Style>

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
@@ -1110,7 +1110,7 @@
                                    MouseDown="Rectangle_MouseDown" MouseMove="Rectangle_MouseMove" MouseUp="Rectangle_MouseUp"
                                    Opacity="{Binding Color, Mode=OneWay, Converter={StaticResource ColorToOpacityConverter}}">
                             <Rectangle.RenderTransform>
-                                <TranslateTransform x:Name="transform2_0" X="{Binding XOffset, Mode=OneWay}" Y="{Binding YOffset, Mode=OneWay}"/>
+                                <TranslateTransform x:Name="transform2_0" X="{Binding X, Mode=OneWay}" Y="{Binding Y, Mode=OneWay}"/>
                             </Rectangle.RenderTransform>
                             <Rectangle.Style>
                                 <Style BasedOn="{StaticResource NearestNeighbor}"/>

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
@@ -1047,7 +1047,7 @@
                             <Rectangle.RenderTransform>
                                 <TransformGroup>
                                     <!-- Giving names to transform elements prevents random "Cannot find governing FrameworkElement or FrameworkContentElement for target element." errors -->
-                                    <TranslateTransform x:Name="transform0_0" X="{Binding X, Mode=OneWay}" Y="{Binding Y, Mode=OneWay}"/>
+                                    <TranslateTransform x:Name="transform0_0" X="{Binding XOffset, Mode=OneWay}" Y="{Binding YOffset, Mode=OneWay}"/>
                                     <ScaleTransform x:Name="transform0_1" ScaleX="{Binding CalcScaleX, Mode=OneWay}" ScaleY="{Binding CalcScaleY, Mode=OneWay}" CenterX="0" CenterY="0"/>
                                 </TransformGroup>
                             </Rectangle.RenderTransform>
@@ -1069,8 +1069,8 @@
                                             <Binding Path="Stretch" Mode="OneWay"/>
                                             <!-- for notification only -->
                                             <Binding RelativeSource="{RelativeSource Self}" Path="ImageSource" Mode="OneWay"/>
-                                            <Binding Path="X" Mode="OneWay"/>
-                                            <Binding Path="Y" Mode="OneWay"/>
+                                            <Binding Path="XOffset" Mode="OneWay"/>
+                                            <Binding Path="YOffset" Mode="OneWay"/>
                                         </MultiBinding>
                                     </ImageBrush.Viewport>
                                 </ImageBrush>
@@ -1173,7 +1173,7 @@
                             <Rectangle.RenderTransform>
                                 <TransformGroup>
                                     <ScaleTransform x:Name="transform3_0" ScaleX="{Binding CalcScaleX, Mode=OneWay}" ScaleY="{Binding CalcScaleY, Mode=OneWay}" CenterX="0" CenterY="0"/>
-                                    <TranslateTransform x:Name="transform3_1" X="{Binding ParentLayer.XOffset, Mode=OneWay}" Y="{Binding ParentLayer.YOffset, Mode=OneWay}"/>
+                                    <TranslateTransform x:Name="transform3_1" X="{Binding XOffset, Mode=OneWay}" Y="{Binding YOffset, Mode=OneWay}"/>
                                 </TransformGroup>
                             </Rectangle.RenderTransform>
                             <Rectangle.Style>
@@ -1193,8 +1193,8 @@
                                             <Binding Path="TiledHorizontally" Mode="OneWay"/>
                                             <Binding Path="Stretch" Mode="OneWay"/>
                                             <!-- for notification only -->
-                                            <Binding RelativeSource="{RelativeSource AncestorType=Rectangle}" Path="DataContext.ParentLayer.XOffset" Mode="OneWay"/>
-                                            <Binding RelativeSource="{RelativeSource AncestorType=Rectangle}" Path="DataContext.ParentLayer.YOffset" Mode="OneWay"/>
+                                            <Binding RelativeSource="{RelativeSource AncestorType=Rectangle}" Path="XOffset" Mode="OneWay"/>
+                                            <Binding RelativeSource="{RelativeSource AncestorType=Rectangle}" Path="YOffset" Mode="OneWay"/>
                                             <Binding Path="ParentLayer.ParentRoom.Width" Mode="OneWay"/>
                                             <Binding Path="ParentLayer.ParentRoom.Height" Mode="OneWay"/>
                                             <Binding RelativeSource="{RelativeSource Self}" Path="ImageSource" Mode="OneWay"/>

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -1543,11 +1543,11 @@ namespace UndertaleModTool
                 UndertaleTexturePageItem texture = obj switch
                 {
                     Background bg => bg.BackgroundDefinition?.Texture,
-                    GameObject gameObj => gameObj.ObjectDefinition?.Sprite?.Textures[gameObj.ImageIndex].Texture,
+                    GameObject gameObj => gameObj.ObjectDefinition?.Sprite?.Textures[gameObj.WrappedImageIndex].Texture,
 
                     // GMS 2+
                     Layer.LayerBackgroundData bgData => bgData.Sprite?.Textures[0].Texture,
-                    SpriteInstance sprite => sprite.Sprite?.Textures[(int)sprite.FrameIndex].Texture,
+                    SpriteInstance sprite => sprite.Sprite?.Textures[sprite.WrappedFrameIndex].Texture,
                     _ => null
                 };
 

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -1698,7 +1698,7 @@ namespace UndertaleModTool
 
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
-            if (values.Any(x => x is null))
+            if (values.Any(x => x is null || x == DependencyProperty.UnsetValue))
                 return null;
 
             bool isGMS2 = ((RoomEntryFlags)values[1]).HasFlag(RoomEntryFlags.IsGMS2);

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -1859,10 +1859,10 @@ namespace UndertaleModTool
                 texture = bg.BackgroundDefinition.Texture;
 
                 bg.UpdateStretch();
-                offsetV = bg.Y * (1 / bg.CalcScaleY);
-                offsetH = bg.X * (1 / bg.CalcScaleX);
-                xOffset = bg.X;
-                yOffset = bg.Y;
+                offsetV = bg.YOffset * (1 / bg.CalcScaleY);
+                offsetH = bg.XOffset * (1 / bg.CalcScaleX);
+                xOffset = bg.XOffset;
+                yOffset = bg.YOffset;
                 roomWidth = System.Convert.ToDouble(bg.ParentRoom.Width);
                 roomHeight = System.Convert.ToDouble(bg.ParentRoom.Height);
             }

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -1543,11 +1543,11 @@ namespace UndertaleModTool
                 UndertaleTexturePageItem texture = obj switch
                 {
                     Background bg => bg.BackgroundDefinition?.Texture,
-                    GameObject gameObj => gameObj.ObjectDefinition?.Sprite?.Textures[0].Texture,
+                    GameObject gameObj => gameObj.ObjectDefinition?.Sprite?.Textures[gameObj.ImageIndex].Texture,
 
                     // GMS 2+
                     Layer.LayerBackgroundData bgData => bgData.Sprite?.Textures[0].Texture,
-                    SpriteInstance sprite => sprite.Sprite?.Textures[0].Texture,
+                    SpriteInstance sprite => sprite.Sprite?.Textures[(int)sprite.FrameIndex].Texture,
                     _ => null
                 };
 

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -316,7 +316,7 @@ namespace UndertaleModTool
                     {
                         X = other.X,
                         Y = other.Y,
-                        _SpriteMode = other._SpriteMode,
+                        spriteMode = other.spriteMode,
                         ObjectDefinition = other.ObjectDefinition,
                         SourceX = other.SourceX,
                         SourceY = other.SourceY,
@@ -409,7 +409,7 @@ namespace UndertaleModTool
                     {
                         X = other.X,
                         Y = other.Y,
-                        _SpriteMode = other._SpriteMode,
+                        spriteMode = other.spriteMode,
                         ObjectDefinition = other.ObjectDefinition,
                         SourceX = other.SourceX,
                         SourceY = other.SourceY,
@@ -487,7 +487,7 @@ namespace UndertaleModTool
                 {
                     X = (int)gridMouse.X,
                     Y = (int)gridMouse.Y,
-                    _SpriteMode = otherTile._SpriteMode,
+                    spriteMode = otherTile.spriteMode,
                     ObjectDefinition = otherTile.ObjectDefinition,
                     SpriteDefinition = otherTile.SpriteDefinition,
                     SourceX = otherTile.SourceX,
@@ -1192,7 +1192,7 @@ namespace UndertaleModTool
                     var obj = new Tile();
                     obj.X = other.X;
                     obj.Y = other.Y;
-                    obj._SpriteMode = other._SpriteMode;
+                    obj.spriteMode = other.spriteMode;
                     obj.ObjectDefinition = other.ObjectDefinition;
                     obj.SourceX = other.SourceX;
                     obj.SourceY = other.SourceY;
@@ -1303,7 +1303,7 @@ namespace UndertaleModTool
 
                 // add tile to list
                 var tile = new Tile { InstanceID = mainWindow.Data.GeneralInfo.LastTile++ };
-                tile._SpriteMode = true;
+                tile.spriteMode = true;
                 layer.AssetsData.LegacyTiles.Add(tile);
                 roomObjDict.TryAdd(tile.InstanceID, layer);
 


### PR DESCRIPTION
1. **All room objects _(game object instances, tile instances, backgrounds, etc.)_ with textures that have non-zero target coordinates are now displayed properly _(`TargetX` and `TargetY` are used now)_.**
2. Added `XOffset` and `YOffset` properties to `Background`, `SpriteInstance` and `LayerBackgroundData`.
3. Frame index of `GameObject` and `SpriteInstance` is now used in much more places: objects render size, `GenerateSpriteCache()`, `XOffset` and `YOffset`.
4. Frame index UI field doesn't limit the value to the bounds.
5. Frame index wrappers are changed from `SafeImageIndex`/`SafeFrameIndex` to `WrappedImageIndex`/`WrappedFrameIndex` - now it's a read-only property that wraps frame index value to a valid array index.
_For example - if sprite has 3 frames, and image index is 4, then it will return 1 - second frame._
6. Removed redundant null checks on sprite `Textures` _(`Textures` can't be null)_.
7. Renamed some private fields so that they comply with the naming convention _(`_PrivateBackingField` -> `_privateBackingField`)_.
8. Fixed tiles texture cropping.
9. Fixed room objects pasting _(with `Ctrl+V`)_.
10. Extracted common code of `PaintObjects()` and `Command_Paste()`, and made new `AddObjectCopy()` method from it.
11. Made room object pasting error messages more polite.
12. Simplified some `new T()` expressions _(`new ClassWithLongName()` -> `new()`)_.
13. Set proper default values for `SpriteInstance` to simplify new instance creation.