### PR TITLE
Sprite origin fixes (and more)

### DIFF
--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -182,7 +182,7 @@ namespace UndertaleModLib.Models
                 return _layers?.Where(l => l.LayerType is LayerType.Background
                                         && l.BackgroundData.Sprite is null
                                         && l.BackgroundData.Color != 0)
-                               .OrderBy(l => l.LayerDepth ?? 0)
+                               .OrderBy(l => l.LayerDepth)
                                .FirstOrDefault();
             }
         }

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -425,8 +425,22 @@ namespace UndertaleModLib.Models
             /// </summary>
             public UndertaleRoom ParentRoom { get => _ParentRoom; set { _ParentRoom = value; OnPropertyChanged(); UpdateStretch(); } }
 
-            //TODO:
+            /// <summary>
+            /// The calculated horizontal render scale for the background texture.<br/>
+            /// Used in the UndertaleModTool room editor.
+            /// </summary>
+            /// <remarks>
+            /// This attribute is UMT-only and does not exist in GameMaker.
+            /// </remarks>
             public float CalcScaleX { get; set; } = 1;
+
+            /// <summary>
+            /// The calculated vertical render scale for the background texture.<br/>
+            /// Used in the UndertaleModTool room editor.
+            /// </summary>
+            /// <remarks>
+            /// This attribute is UMT-only and does not exist in GameMaker.
+            /// </remarks>
             public float CalcScaleY { get; set; } = 1;
 
             /// <summary>

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -768,7 +768,7 @@ namespace UndertaleModLib.Models
             /// This attribute is UMT-only and does not exist in GameMaker.
             /// </remarks>
             public int SpriteXOffset => ObjectDefinition?.Sprite != null
-                                        ? ObjectDefinition.Sprite.OriginXWrapper + (ObjectDefinition.Sprite.Textures.ElementAtOrDefault(ImageIndex)?.Texture?.TargetX ?? 0)
+                                        ? (-1 * ObjectDefinition.Sprite.OriginXWrapper) + (ObjectDefinition.Sprite.Textures.ElementAtOrDefault(ImageIndex)?.Texture?.TargetX ?? 0)
                                         : 0;
 
             /// <summary>
@@ -779,7 +779,7 @@ namespace UndertaleModLib.Models
             /// This attribute is UMT-only and does not exist in GameMaker.
             /// </remarks>
             public int SpriteYOffset => ObjectDefinition?.Sprite != null
-                                        ? ObjectDefinition.Sprite.OriginYWrapper + (ObjectDefinition.Sprite.Textures.ElementAtOrDefault(ImageIndex)?.Texture?.TargetY ?? 0)
+                                        ? (-1 * ObjectDefinition.Sprite.OriginYWrapper) + (ObjectDefinition.Sprite.Textures.ElementAtOrDefault(ImageIndex)?.Texture?.TargetY ?? 0)
                                         : 0;
             /// <summary>
             /// A horizontal offset used for proper game object position display in the UndertaleModTool room editor.
@@ -787,7 +787,7 @@ namespace UndertaleModLib.Models
             /// <remarks>
             /// This attribute is UMT-only and does not exist in GameMaker.
             /// </remarks>
-            public int XOffset => X - SpriteXOffset;
+            public int XOffset => X + SpriteXOffset;
 
             /// <summary>
             /// A vertical offset used for proper game object display in the UndertaleModTool room editor.
@@ -795,7 +795,7 @@ namespace UndertaleModLib.Models
             /// <remarks>
             /// This attribute is UMT-only and does not exist in GameMaker.
             /// </remarks>
-            public int YOffset => Y - SpriteYOffset;
+            public int YOffset => Y + SpriteYOffset;
 
             public void Serialize(UndertaleWriter writer)
             {
@@ -1440,13 +1440,13 @@ namespace UndertaleModLib.Models
             public float OppositeRotation => 360F - Rotation;
 
             public int SpriteXOffset => Sprite != null
-                                        ? Sprite.OriginXWrapper + (Sprite.Textures.ElementAtOrDefault(WrappedFrameIndex)?.Texture?.TargetX ?? 0)
+                                        ? (-1 * Sprite.OriginXWrapper) + (Sprite.Textures.ElementAtOrDefault(WrappedFrameIndex)?.Texture?.TargetX ?? 0)
                                         : 0;
             public int SpriteYOffset => Sprite != null
-                                        ? Sprite.OriginYWrapper + (Sprite.Textures.ElementAtOrDefault(WrappedFrameIndex)?.Texture?.TargetY ?? 0)
+                                        ? (-1 * Sprite.OriginYWrapper) + (Sprite.Textures.ElementAtOrDefault(WrappedFrameIndex)?.Texture?.TargetY ?? 0)
                                         : 0;
-            public int XOffset => X - SpriteXOffset;
-            public int YOffset => Y - SpriteYOffset;
+            public int XOffset => X + SpriteXOffset;
+            public int YOffset => Y + SpriteYOffset;
 
             public event PropertyChangedEventHandler PropertyChanged;
             protected void OnPropertyChanged([CallerMemberName] string name = null)

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -170,9 +170,9 @@ namespace UndertaleModLib.Models
 
         /// <summary>
         /// The layer containing the background color.<br/>
-        /// Used by "BGColorConverter" of the UndertaleModTool room editor.
         /// </summary>
         /// <remarks>
+        /// Used by "BGColorConverter" of the UndertaleModTool room editor.
         /// This attribute is UMT-only and does not exist in GameMaker.
         /// </remarks>
         public Layer BGColorLayer
@@ -427,8 +427,7 @@ namespace UndertaleModLib.Models
             private UndertaleRoom _ParentRoom;
 
             /// <summary>
-            /// The room parent this background belongs to.<br/>
-            /// Set by <see cref="SetupRoom(bool)"/>.
+            /// The room parent this background belongs to.
             /// </summary>
             /// <remarks>
             /// This attribute is UMT-only and does not exist in GameMaker.
@@ -436,19 +435,19 @@ namespace UndertaleModLib.Models
             public UndertaleRoom ParentRoom { get => _ParentRoom; set { _ParentRoom = value; OnPropertyChanged(); UpdateStretch(); } }
 
             /// <summary>
-            /// The calculated horizontal render scale for the background texture.<br/>
-            /// Used in the UndertaleModTool room editor.
+            /// The calculated horizontal render scale for the background texture.
             /// </summary>
             /// <remarks>
+            /// Used in the room editor.<br/>
             /// This attribute is UMT-only and does not exist in GameMaker.
             /// </remarks>
             public float CalcScaleX { get; set; } = 1;
 
             /// <summary>
-            /// The calculated vertical render scale for the background texture.<br/>
-            /// Used in the UndertaleModTool room editor.
+            /// The calculated vertical render scale for the background texture.
             /// </summary>
             /// <remarks>
+            /// Used in the room editor.<br/>
             /// This attribute is UMT-only and does not exist in GameMaker.
             /// </remarks>
             public float CalcScaleY { get; set; } = 1;
@@ -517,7 +516,7 @@ namespace UndertaleModLib.Models
             public bool TiledVertically { get => TileY > 0; set { TileY = value ? 1 : 0; OnPropertyChanged(); } }
 
             /// <summary>
-            /// A horizontal offset used for proper background display in the UndertaleModTool room editor.
+            /// A horizontal offset used for proper background display in the room editor.
             /// </summary>
             /// <remarks>
             /// This attribute is UMT-only and does not exist in GameMaker.
@@ -525,7 +524,7 @@ namespace UndertaleModLib.Models
             public int XOffset => X + (BackgroundDefinition?.Texture?.TargetX ?? 0);
 
             /// <summary>
-            /// A vertical offset used for proper background display in the UndertaleModTool room editor.
+            /// A vertical offset used for proper background display in the room editor.
             /// </summary>
             /// <remarks>
             /// This attribute is UMT-only and does not exist in GameMaker.
@@ -794,10 +793,10 @@ namespace UndertaleModLib.Models
             public float OppositeRotation => 360F - (Rotation % 360);
 
             /// <summary>
-            /// A horizontal offset relative to top-left corner of the game object.<br/>
-            /// Used for proper game object rotation display in the UndertaleModTool room editor and in <see cref="XOffset"/>.
+            /// A horizontal offset relative to top-left corner of the game object.
             /// </summary>
             /// <remarks>
+            /// Used for proper game object rotation display in the room editor and in <see cref="XOffset"/>.<br/>
             /// This attribute is UMT-only and does not exist in GameMaker.
             /// </remarks>
             public int SpriteXOffset => ObjectDefinition?.Sprite != null
@@ -805,17 +804,17 @@ namespace UndertaleModLib.Models
                                         : 0;
 
             /// <summary>
-            /// A vertical offset relative to top-left corner of the game object.<br/>
-            /// Used for proper game object rotation display in the UndertaleModTool room editor and in <see cref="YOffset"/>.
+            /// A vertical offset relative to top-left corner of the game object.
             /// </summary>
             /// <remarks>
+            /// Used for proper game object rotation display in the room editor and in <see cref="YOffset"/>.<br/>
             /// This attribute is UMT-only and does not exist in GameMaker.
             /// </remarks>
             public int SpriteYOffset => ObjectDefinition?.Sprite != null
                                         ? (-1 * ObjectDefinition.Sprite.OriginYWrapper) + (ObjectDefinition.Sprite.Textures.ElementAtOrDefault(ImageIndex)?.Texture?.TargetY ?? 0)
                                         : 0;
             /// <summary>
-            /// A horizontal offset used for proper game object position display in the UndertaleModTool room editor.
+            /// A horizontal offset used for proper game object position display in the room editor.
             /// </summary>
             /// <remarks>
             /// This attribute is UMT-only and does not exist in GameMaker.
@@ -823,7 +822,7 @@ namespace UndertaleModLib.Models
             public int XOffset => X + SpriteXOffset;
 
             /// <summary>
-            /// A vertical offset used for proper game object display in the UndertaleModTool room editor.
+            /// A vertical offset used for proper game object display in the room editor.
             /// </summary>
             /// <remarks>
             /// This attribute is UMT-only and does not exist in GameMaker.
@@ -921,7 +920,7 @@ namespace UndertaleModLib.Models
 
             /// <summary>
             /// From which object this tile stems from.<br/>
-            /// Will return a <see cref="UndertaleBackground"/> if <see cref="spriteMode"/> is true, a <see cref="UndertaleSprite"/> if it's false.
+            /// Will return a <see cref="UndertaleBackground"/> if <see cref="spriteMode"/> is <see langword="true"/>, a <see cref="UndertaleSprite"/> if it's <see langword="false"/>.
             /// </summary>
             public UndertaleNamedResource ObjectDefinition { get => spriteMode ? SpriteDefinition : BackgroundDefinition; set { if (spriteMode) SpriteDefinition = (UndertaleSprite)value; else BackgroundDefinition = (UndertaleBackground)value; } }
 
@@ -969,7 +968,7 @@ namespace UndertaleModLib.Models
             public uint Color { get; set; } = 0xFFFFFFFF;
 
             /// <summary>
-            /// Returns a texture page item of the tile.
+            /// Returns the texture page item of the tile.
             /// </summary>
             /// <remarks>
             /// This attribute is UMT-only and does not exist in GameMaker.

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -761,14 +761,33 @@ namespace UndertaleModLib.Models
             public float OppositeRotation => 360F - (Rotation % 360);
 
             /// <summary>
-            /// A horizontal offset used for proper game object display in the UndertaleModTool room editor.
+            /// A horizontal offset relative to top-left corner of the game object.<br/>
+            /// Used for proper game object rotation display in the UndertaleModTool room editor and in <see cref="XOffset"/>.
             /// </summary>
             /// <remarks>
             /// This attribute is UMT-only and does not exist in GameMaker.
             /// </remarks>
-            public int XOffset => ObjectDefinition?.Sprite != null
-                                  ? X - ObjectDefinition.Sprite.OriginX + (ObjectDefinition.Sprite.Textures.ElementAtOrDefault(ImageIndex)?.Texture?.TargetX ?? 0)
-                                  : X;
+            public int SpriteXOffset => ObjectDefinition?.Sprite != null
+                                        ? ObjectDefinition.Sprite.OriginXWrapper + (ObjectDefinition.Sprite.Textures.ElementAtOrDefault(ImageIndex)?.Texture?.TargetX ?? 0)
+                                        : 0;
+
+            /// <summary>
+            /// A vertical offset relative to top-left corner of the game object.<br/>
+            /// Used for proper game object rotation display in the UndertaleModTool room editor and in <see cref="YOffset"/>.
+            /// </summary>
+            /// <remarks>
+            /// This attribute is UMT-only and does not exist in GameMaker.
+            /// </remarks>
+            public int SpriteYOffset => ObjectDefinition?.Sprite != null
+                                        ? ObjectDefinition.Sprite.OriginYWrapper + (ObjectDefinition.Sprite.Textures.ElementAtOrDefault(ImageIndex)?.Texture?.TargetY ?? 0)
+                                        : 0;
+            /// <summary>
+            /// A horizontal offset used for proper game object position display in the UndertaleModTool room editor.
+            /// </summary>
+            /// <remarks>
+            /// This attribute is UMT-only and does not exist in GameMaker.
+            /// </remarks>
+            public int XOffset => X - SpriteXOffset;
 
             /// <summary>
             /// A vertical offset used for proper game object display in the UndertaleModTool room editor.
@@ -776,9 +795,7 @@ namespace UndertaleModLib.Models
             /// <remarks>
             /// This attribute is UMT-only and does not exist in GameMaker.
             /// </remarks>
-            public int YOffset => ObjectDefinition?.Sprite != null
-                                  ? Y - ObjectDefinition.Sprite.OriginY + (ObjectDefinition.Sprite.Textures.ElementAtOrDefault(ImageIndex)?.Texture?.TargetY ?? 0)
-                                  : Y;
+            public int YOffset => Y - SpriteYOffset;
 
             public void Serialize(UndertaleWriter writer)
             {
@@ -1238,8 +1255,14 @@ namespace UndertaleModLib.Models
                 public float AnimationSpeed { get; set; }
                 public AnimationSpeedType AnimationSpeedType { get; set; }
 
-                public float XOffset => (ParentLayer?.XOffset ?? 0) + (Sprite?.Textures.FirstOrDefault()?.Texture?.TargetX ?? 0);
-                public float YOffset => (ParentLayer?.YOffset ?? 0) + (Sprite?.Textures.FirstOrDefault()?.Texture?.TargetY ?? 0);
+                public float XOffset => (ParentLayer?.XOffset ?? 0) +
+                                        (Sprite is not null
+                                         ? (Sprite.Textures.FirstOrDefault()?.Texture?.TargetX ?? 0) - Sprite.OriginXWrapper
+                                         : 0);
+                public float YOffset => (ParentLayer?.YOffset ?? 0) +
+                                        (Sprite is not null
+                                         ? (Sprite.Textures.FirstOrDefault()?.Texture?.TargetY ?? 0) - Sprite.OriginYWrapper
+                                         : 0);
 
                 public event PropertyChangedEventHandler PropertyChanged;
                 protected void OnPropertyChanged([CallerMemberName] string name = null)
@@ -1415,12 +1438,15 @@ namespace UndertaleModLib.Models
             }
             public float Rotation { get; set; }
             public float OppositeRotation => 360F - Rotation;
-            public int XOffset => Sprite is not null
-                                  ? X - Sprite.OriginX + (Sprite.Textures.ElementAtOrDefault((int)FrameIndex)?.Texture?.TargetX ?? 0)
-                                  : X;
-            public int YOffset => Sprite is not null
-                                  ? Y - Sprite.OriginY + (Sprite.Textures.ElementAtOrDefault((int)FrameIndex)?.Texture?.TargetY ?? 0)
-                                  : Y;
+
+            public int SpriteXOffset => Sprite != null
+                                        ? Sprite.OriginXWrapper + (Sprite.Textures.ElementAtOrDefault(WrappedFrameIndex)?.Texture?.TargetX ?? 0)
+                                        : 0;
+            public int SpriteYOffset => Sprite != null
+                                        ? Sprite.OriginYWrapper + (Sprite.Textures.ElementAtOrDefault(WrappedFrameIndex)?.Texture?.TargetY ?? 0)
+                                        : 0;
+            public int XOffset => X - SpriteXOffset;
+            public int YOffset => Y - SpriteYOffset;
 
             public event PropertyChangedEventHandler PropertyChanged;
             protected void OnPropertyChanged([CallerMemberName] string name = null)

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -500,7 +500,7 @@ namespace UndertaleModLib.Models
             public bool Stretch { get => _Stretch; set { _Stretch = value; OnPropertyChanged(); UpdateStretch(); } }
 
             /// <summary>
-            /// A wrapper of <see cref="TileX"/> that indicates whether this background is tiled horizontally.
+            /// Indicates whether this background is tiled horizontally.
             /// </summary>
             /// <remarks>
             /// This attribute is UMT-only and does not exist in GameMaker.
@@ -508,7 +508,7 @@ namespace UndertaleModLib.Models
             public bool TiledHorizontally { get => TileX > 0; set { TileX = value ? 1 : 0; OnPropertyChanged(); } }
 
             /// <summary>
-            /// A wrapper of <see cref="TileY"/> that indicates whether this background is tiled vertically.
+            /// Indicates whether this background is tiled vertically.
             /// </summary>
             /// <remarks>
             /// This attribute is UMT-only and does not exist in GameMaker.
@@ -785,7 +785,7 @@ namespace UndertaleModLib.Models
             }
 
             /// <summary>
-            /// A wrapper of <see cref="Rotation"/> that returns an opposite angle of the current rotation.
+            /// The opposite angle of the current rotation.
             /// </summary>
             /// <remarks>
             /// This attribute is UMT-only and does not exist in GameMaker.

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -166,20 +166,26 @@ namespace UndertaleModLib.Models
         /// </summary>
         public UndertaleSimpleList<UndertaleResourceById<UndertaleSequence, UndertaleChunkSEQN>> Sequences { get; private set; } = new UndertaleSimpleList<UndertaleResourceById<UndertaleSequence, UndertaleChunkSEQN>>();
 
-        private Layer GetBGColorLayer()
-        {
-            return _layers?.Where(l => l.LayerType is LayerType.Background
-                                    && l.BackgroundData.Sprite is null
-                                    && l.BackgroundData.Color != 0)
-                           .OrderBy(l => l?.LayerDepth ?? 0)
-                           .FirstOrDefault();
-        }
         public void UpdateBGColorLayer() => OnPropertyChanged("BGColorLayer");
 
         /// <summary>
-        /// The layer containing the background color.
+        /// The layer containing the background color.<br/>
+        /// Used by "BGColorConverter" of the UndertaleModTool room editor.
         /// </summary>
-        public Layer BGColorLayer => GetBGColorLayer();
+        /// <remarks>
+        /// This attribute is UMT-only and does not exist in GameMaker.
+        /// </remarks>
+        public Layer BGColorLayer
+        {
+            get
+            {
+                return _layers?.Where(l => l.LayerType is LayerType.Background
+                                        && l.BackgroundData.Sprite is null
+                                        && l.BackgroundData.Color != 0)
+                               .OrderBy(l => l?.LayerDepth ?? 0)
+                               .FirstOrDefault();
+            }
+        }
 
         public event PropertyChangedEventHandler PropertyChanged;
         protected void OnPropertyChanged([CallerMemberName] string name = null)
@@ -421,8 +427,12 @@ namespace UndertaleModLib.Models
             private UndertaleRoom _ParentRoom;
 
             /// <summary>
-            /// The room parent this background belongs to.
+            /// The room parent this background belongs to.<br/>
+            /// Set by <see cref="SetupRoom(bool)"/>.
             /// </summary>
+            /// <remarks>
+            /// This attribute is UMT-only and does not exist in GameMaker.
+            /// </remarks>
             public UndertaleRoom ParentRoom { get => _ParentRoom; set { _ParentRoom = value; OnPropertyChanged(); UpdateStretch(); } }
 
             /// <summary>
@@ -491,13 +501,19 @@ namespace UndertaleModLib.Models
             public bool Stretch { get => _Stretch; set { _Stretch = value; OnPropertyChanged(); UpdateStretch(); } }
 
             /// <summary>
-            /// Whether this background is tiled horizontally.
+            /// A wrapper of <see cref="TileX"/> that indicates whether this background is tiled horizontally.
             /// </summary>
+            /// <remarks>
+            /// This attribute is UMT-only and does not exist in GameMaker.
+            /// </remarks>
             public bool TiledHorizontally { get => TileX > 0; set { TileX = value ? 1 : 0; OnPropertyChanged(); } }
 
             /// <summary>
-            /// Whether this background is tiled vertically.
+            /// A wrapper of <see cref="TileY"/> that indicates whether this background is tiled vertically.
             /// </summary>
+            /// <remarks>
+            /// This attribute is UMT-only and does not exist in GameMaker.
+            /// </remarks>
             public bool TiledVertically { get => TileY > 0; set { TileY = value ? 1 : 0; OnPropertyChanged(); } }
 
             /// <summary>
@@ -770,8 +786,11 @@ namespace UndertaleModLib.Models
             }
 
             /// <summary>
-            /// The opposite angle of the current rotation.
+            /// A wrapper of <see cref="Rotation"/> that returns an opposite angle of the current rotation.
             /// </summary>
+            /// <remarks>
+            /// This attribute is UMT-only and does not exist in GameMaker.
+            /// </remarks>
             public float OppositeRotation => 360F - (Rotation % 360);
 
             /// <summary>
@@ -869,9 +888,14 @@ namespace UndertaleModLib.Models
         public class Tile : UndertaleObject, RoomObject, INotifyPropertyChanged
         {
             /// <summary>
-            /// Whether this tile is from an asset layer. Game Maker Studio: 2 exclusive.
+            /// Whether this tile is from an asset layer.<br/>
+            /// Equals true if it's Game Maker Studio: 2.
             /// </summary>
+            /// <remarks>
+            /// This attribute is UMT-only and does not exist in GameMaker.
+            /// </remarks>
             public bool spriteMode = false;
+
             private UndertaleResourceById<UndertaleBackground, UndertaleChunkBGND> _backgroundDefinition = new();
             private UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT> _spriteDefinition = new();
 
@@ -896,8 +920,8 @@ namespace UndertaleModLib.Models
             public UndertaleSprite SpriteDefinition { get => _spriteDefinition.Resource; set { _spriteDefinition.Resource = value; OnPropertyChanged(); OnPropertyChanged("ObjectDefinition"); } }
 
             /// <summary>
-            /// From which object this tile stems from.
-            /// Will return a <see cref="UndertaleBackground"/> if <see cref="spriteMode"/> is disabled, a <see cref="UndertaleSprite"/> if it's enabled.
+            /// From which object this tile stems from.<br/>
+            /// Will return a <see cref="UndertaleBackground"/> if <see cref="spriteMode"/> is true, a <see cref="UndertaleSprite"/> if it's false.
             /// </summary>
             public UndertaleNamedResource ObjectDefinition { get => spriteMode ? SpriteDefinition : BackgroundDefinition; set { if (spriteMode) SpriteDefinition = (UndertaleSprite)value; else BackgroundDefinition = (UndertaleBackground)value; } }
 
@@ -944,6 +968,12 @@ namespace UndertaleModLib.Models
             //TODO?
             public uint Color { get; set; } = 0xFFFFFFFF;
 
+            /// <summary>
+            /// Returns a texture page item of the tile.
+            /// </summary>
+            /// <remarks>
+            /// This attribute is UMT-only and does not exist in GameMaker.
+            /// </remarks>
             public UndertaleTexturePageItem Tpag => spriteMode ? SpriteDefinition?.Textures.FirstOrDefault()?.Texture : BackgroundDefinition?.Texture; // TODO: what happens on sprites with multiple textures?
 
             public event PropertyChangedEventHandler PropertyChanged;

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -182,7 +182,7 @@ namespace UndertaleModLib.Models
                 return _layers?.Where(l => l.LayerType is LayerType.Background
                                         && l.BackgroundData.Sprite is null
                                         && l.BackgroundData.Color != 0)
-                               .OrderBy(l => l?.LayerDepth ?? 0)
+                               .OrderBy(l => l.LayerDepth ?? 0)
                                .FirstOrDefault();
             }
         }
@@ -796,7 +796,7 @@ namespace UndertaleModLib.Models
             /// A horizontal offset relative to top-left corner of the game object.
             /// </summary>
             /// <remarks>
-            /// Used for proper game object rotation display in the room editor and in <see cref="XOffset"/>.<br/>
+            /// Used for proper game object rotation display in the room editor and for determining <see cref="XOffset"/>.<br/>
             /// This attribute is UMT-only and does not exist in GameMaker.
             /// </remarks>
             public int SpriteXOffset => ObjectDefinition?.Sprite != null
@@ -807,7 +807,7 @@ namespace UndertaleModLib.Models
             /// A vertical offset relative to top-left corner of the game object.
             /// </summary>
             /// <remarks>
-            /// Used for proper game object rotation display in the room editor and in <see cref="YOffset"/>.<br/>
+            /// Used for proper game object rotation display in the room editor and for determining <see cref="YOffset"/>.<br/>
             /// This attribute is UMT-only and does not exist in GameMaker.
             /// </remarks>
             public int SpriteYOffset => ObjectDefinition?.Sprite != null
@@ -888,7 +888,7 @@ namespace UndertaleModLib.Models
         {
             /// <summary>
             /// Whether this tile is from an asset layer.<br/>
-            /// Equals true if it's Game Maker Studio: 2.
+            /// <see langword="true"/> for GameMaker Studio: 2 games, otherwise <see langword="false"/>.
             /// </summary>
             /// <remarks>
             /// This attribute is UMT-only and does not exist in GameMaker.

--- a/UndertaleModLib/Models/UndertaleSprite.cs
+++ b/UndertaleModLib/Models/UndertaleSprite.cs
@@ -115,6 +115,42 @@ namespace UndertaleModLib.Models
         public int OriginY { get; set; }
 
         /// <summary>
+        /// A <see cref="OriginX"/> wrapper than also sets horizontal origin of <see cref="V2Sequence"/>.
+        /// </summary>
+        /// <remarks>
+        /// This attribute is used only in UndertaleModTool and doesn't exist in GameMaker.
+        /// </remarks>
+        public int OriginXWrapper
+        {
+            get => OriginX;
+            set
+            {
+                OriginX = value;
+
+                if (IsSpecialType && SVersion > 1 && V2Sequence is not null)
+                    V2Sequence.OriginX = value;
+            }
+        }
+
+        /// <summary>
+        /// A <see cref="OriginY"/> wrapper than also sets vertical origin of <see cref="V2Sequence"/>.
+        /// </summary>
+        /// <remarks>
+        /// This attribute is used only in UndertaleModTool and doesn't exist in GameMaker.
+        /// </remarks>
+        public int OriginYWrapper
+        {
+            get => OriginY;
+            set
+            {
+                OriginY = value;
+
+                if (IsSpecialType && SVersion > 1 && V2Sequence is not null)
+                    V2Sequence.OriginY = value;
+            }
+        }
+
+        /// <summary>
         /// The frames of the sprite.
         /// </summary>
         public UndertaleSimpleList<TextureEntry> Textures { get; private set; } = new UndertaleSimpleList<TextureEntry>();

--- a/UndertaleModLib/Models/UndertaleSprite.cs
+++ b/UndertaleModLib/Models/UndertaleSprite.cs
@@ -115,7 +115,7 @@ namespace UndertaleModLib.Models
         public int OriginY { get; set; }
 
         /// <summary>
-        /// A <see cref="OriginX"/> wrapper than also sets horizontal origin of <see cref="V2Sequence"/>.
+        /// A <see cref="OriginX"/> wrapper that also sets <see cref="V2Sequence.OriginX"/> accordingly.
         /// </summary>
         /// <remarks>
         /// This attribute is used only in UndertaleModTool and doesn't exist in GameMaker.
@@ -133,7 +133,7 @@ namespace UndertaleModLib.Models
         }
 
         /// <summary>
-        /// A <see cref="OriginY"/> wrapper than also sets vertical origin of <see cref="V2Sequence"/>.
+        /// A <see cref="OriginY"/> wrapper that also sets <see cref="V2Sequence.OriginY"/> accordingly.
         /// </summary>
         /// <remarks>
         /// This attribute is used only in UndertaleModTool and doesn't exist in GameMaker.

--- a/UndertaleModLib/Models/UndertaleSprite.cs
+++ b/UndertaleModLib/Models/UndertaleSprite.cs
@@ -441,7 +441,7 @@ namespace UndertaleModLib.Models
                         break;
                     case SpriteType.SWF:
                         {
-                            //// ATTENTION: This code does not work all the time for some reason. ////
+                            //// TODO: This code does not work all the time for some reason. ////
 
                             SWFVersion = reader.ReadInt32();
                             Util.DebugUtil.Assert(SWFVersion == 8 || SWFVersion == 7, "Invalid SWF sprite format, expected 7 or 8, got " + SWFVersion);

--- a/UndertaleModTool/Controls/UndertaleRoomRenderer.xaml
+++ b/UndertaleModTool/Controls/UndertaleRoomRenderer.xaml
@@ -141,7 +141,9 @@
                                Opacity="{Binding Color, Mode=OneTime, Converter={StaticResource ColorToOpacityConverter}}">
                         <Rectangle.RenderTransform>
                             <TransformGroup>
-                                <ScaleTransform x:Name="transform1_0" ScaleX="{Binding ScaleX, Mode=OneTime}" ScaleY="{Binding ScaleY, Mode=OneTime}"/>
+                                <ScaleTransform x:Name="transform1_0" ScaleX="{Binding ScaleX, Mode=OneTime}" ScaleY="{Binding ScaleY, Mode=OneTime}"
+                                                CenterX="{Binding SpriteXOffset, Converter={StaticResource NegateNumberConverter}, Mode=OneTime}"
+                                                CenterY="{Binding SpriteYOffset, Converter={StaticResource NegateNumberConverter}, Mode=OneTime}"/>
                                 <RotateTransform x:Name="transform1_1" Angle="{Binding OppositeRotation, Mode=OneTime}"
                                                  CenterX="{Binding SpriteXOffset, Converter={StaticResource NegateNumberConverter}, Mode=OneTime}"
                                                  CenterY="{Binding SpriteYOffset, Converter={StaticResource NegateNumberConverter}, Mode=OneTime}"/>
@@ -182,7 +184,9 @@
                                Opacity="{Binding Color, Mode=OneTime, Converter={StaticResource ColorToOpacityConverter}}">
                         <Rectangle.RenderTransform>
                             <TransformGroup>
-                                <ScaleTransform x:Name="transform4_0" ScaleX="{Binding ScaleX, Mode=OneTime}" ScaleY="{Binding ScaleY, Mode=OneTime}"/>
+                                <ScaleTransform x:Name="transform4_0" ScaleX="{Binding ScaleX, Mode=OneTime}" ScaleY="{Binding ScaleY, Mode=OneTime}"
+                                                CenterX="{Binding SpriteXOffset, Converter={StaticResource NegateNumberConverter}, Mode=OneTime}"
+                                                CenterY="{Binding SpriteYOffset, Converter={StaticResource NegateNumberConverter}, Mode=OneTime}"/>
                                 <RotateTransform x:Name="transform4_1" Angle="{Binding OppositeRotation, Mode=OneTime}"
                                                  CenterX="{Binding SpriteXOffset, Converter={StaticResource NegateNumberConverter}, Mode=OneTime}"
                                                  CenterY="{Binding SpriteYOffset, Converter={StaticResource NegateNumberConverter}, Mode=OneTime}"/>

--- a/UndertaleModTool/Controls/UndertaleRoomRenderer.xaml
+++ b/UndertaleModTool/Controls/UndertaleRoomRenderer.xaml
@@ -27,6 +27,7 @@
         <local:TileLayerTemplateSelector x:Key="TileLayerTemplateSelector"/>
         <local:TileRectanglesConverter x:Key="TileRectanglesConverter"/>
         <local:CachedImageLoaderWithIndex x:Key="CachedImageLoaderWithIndex"/>
+        <local:NegateNumberConverter x:Key="NegateNumberConverter"/>
         <CompositeCollection x:Key="AllObjectsGMS1">
             <CollectionContainer Collection="{Binding Source={x:Reference RoomRenderer}, Path=DataContext.Backgrounds}"/>
             <CollectionContainer Collection="{Binding Source={x:Reference RoomRenderer}, Path=DataContext.Tiles}"/>
@@ -141,7 +142,9 @@
                         <Rectangle.RenderTransform>
                             <TransformGroup>
                                 <ScaleTransform x:Name="transform1_0" ScaleX="{Binding ScaleX, Mode=OneTime}" ScaleY="{Binding ScaleY, Mode=OneTime}"/>
-                                <RotateTransform x:Name="transform1_1" CenterX="{Binding X, Mode=OneTime}" CenterY="{Binding Y, Mode=OneTime}" Angle="{Binding OppositeRotation, Mode=OneTime}"/>
+                                <RotateTransform x:Name="transform1_1" Angle="{Binding OppositeRotation, Mode=OneTime}"
+                                                 CenterX="{Binding SpriteXOffset, Converter={StaticResource NegateNumberConverter}, Mode=OneTime}"
+                                                 CenterY="{Binding SpriteYOffset, Converter={StaticResource NegateNumberConverter}, Mode=OneTime}"/>
                                 <TranslateTransform x:Name="transform1_2" X="{Binding XOffset, Mode=OneTime}" Y="{Binding YOffset, Mode=OneTime}"/>
                             </TransformGroup>
                         </Rectangle.RenderTransform>
@@ -180,7 +183,9 @@
                         <Rectangle.RenderTransform>
                             <TransformGroup>
                                 <ScaleTransform x:Name="transform4_0" ScaleX="{Binding ScaleX, Mode=OneTime}" ScaleY="{Binding ScaleY, Mode=OneTime}"/>
-                                <RotateTransform x:Name="transform4_1" CenterX="{Binding X, Mode=OneTime}" CenterY="{Binding Y, Mode=OneTime}" Angle="{Binding OppositeRotation, Mode=OneTime}"/>
+                                <RotateTransform x:Name="transform4_1" Angle="{Binding OppositeRotation, Mode=OneTime}"
+                                                 CenterX="{Binding SpriteXOffset, Converter={StaticResource NegateNumberConverter}, Mode=OneTime}"
+                                                 CenterY="{Binding SpriteYOffset, Converter={StaticResource NegateNumberConverter}, Mode=OneTime}"/>
                                 <TranslateTransform x:Name="transform4_2" X="{Binding XOffset, Mode=OneTime}" Y="{Binding YOffset, Mode=OneTime}"/>
                             </TransformGroup>
                         </Rectangle.RenderTransform>

--- a/UndertaleModTool/Converters/NegateNumberConverter.cs
+++ b/UndertaleModTool/Converters/NegateNumberConverter.cs
@@ -11,7 +11,7 @@ namespace UndertaleModTool
             double num;
             try
             {
-                num = System.Convert.ToDouble(value);
+                num = -1 * System.Convert.ToDouble(value);
             }
             catch
             {

--- a/UndertaleModTool/Converters/NegateNumberConverter.cs
+++ b/UndertaleModTool/Converters/NegateNumberConverter.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace UndertaleModTool
+{
+    public class NegateNumberConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            double num;
+            try
+            {
+                num = System.Convert.ToDouble(value);
+            }
+            catch
+            {
+                return null;
+            }
+
+            if (parameter is string par)
+            {
+                object res = null;
+
+                try
+                {
+                    res = par switch
+                    {
+                        "sbyte" => (sbyte)num,
+                        "short" => (short)num,
+                        "int" => (int)num,
+                        "long" => (long)num,
+                        "float" => (float)num,
+                        "decimal" => (decimal)num,
+                        _ => null
+                    };
+                }
+                catch { }
+
+                return res; 
+            }
+            else
+                return num;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -284,7 +284,7 @@ namespace UndertaleModTool
             if (values[0] is null) // tile
                 return null;
 
-            if ((uint)values[3] == 0 || (uint)values[4] == 0) // width, height
+            if ((uint)values[1] == 0 || (uint)values[2] == 0) // width, height
                 return null;
 
             return loader.Convert(values[0], null, "tile", null);

--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -21,6 +21,9 @@ using static UndertaleModLib.Models.UndertaleRoom;
 
 namespace UndertaleModTool
 {
+    // TODO: "Bitmap" is Windows-only.
+
+    #pragma warning disable CA1416
     public class UndertaleCachedImageLoader : IValueConverter
     {
         [DllImport("gdi32.dll", EntryPoint = "DeleteObject")]
@@ -523,4 +526,5 @@ namespace UndertaleModTool
             return spriteSrc;
         }
     }
+    #pragma warning restore CA1416
 }

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
@@ -1084,7 +1084,9 @@
                             </Rectangle.Style>
                             <Rectangle.RenderTransform>
                                 <TransformGroup>
-                                    <ScaleTransform x:Name="transform1_0" ScaleX="{Binding ScaleX, Mode=OneWay}" ScaleY="{Binding ScaleY, Mode=OneWay}"/>
+                                    <ScaleTransform x:Name="transform1_0" ScaleX="{Binding ScaleX, Mode=OneWay}" ScaleY="{Binding ScaleY, Mode=OneWay}"
+                                                    CenterX="{Binding SpriteXOffset, Converter={StaticResource NegateNumberConverter}, Mode=OneWay}"
+                                                    CenterY="{Binding SpriteYOffset, Converter={StaticResource NegateNumberConverter}, Mode=OneWay}"/>
                                     <RotateTransform x:Name="transform1_1" Angle="{Binding OppositeRotation, Mode=OneWay}"
                                                      CenterX="{Binding SpriteXOffset, Converter={StaticResource NegateNumberConverter}, Mode=OneWay}"
                                                      CenterY="{Binding SpriteYOffset, Converter={StaticResource NegateNumberConverter}, Mode=OneWay}"/>
@@ -1141,7 +1143,9 @@
                             </Rectangle.Style>
                             <Rectangle.RenderTransform>
                                 <TransformGroup>
-                                    <ScaleTransform x:Name="transform4_0" ScaleX="{Binding ScaleX, Mode=OneWay}" ScaleY="{Binding ScaleY, Mode=OneWay}"/>
+                                    <ScaleTransform x:Name="transform4_0" ScaleX="{Binding ScaleX, Mode=OneWay}" ScaleY="{Binding ScaleY, Mode=OneWay}"
+                                                    CenterX="{Binding SpriteXOffset, Converter={StaticResource NegateNumberConverter}, Mode=OneWay}"
+                                                    CenterY="{Binding SpriteYOffset, Converter={StaticResource NegateNumberConverter}, Mode=OneWay}"/>
                                     <RotateTransform x:Name="transform4_1" Angle="{Binding OppositeRotation, Mode=OneWay}"
                                                      CenterX="{Binding SpriteXOffset, Converter={StaticResource NegateNumberConverter}, Mode=OneWay}"
                                                      CenterY="{Binding SpriteYOffset, Converter={StaticResource NegateNumberConverter}, Mode=OneWay}"/>

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
@@ -13,9 +13,6 @@
         <local:UndertaleCachedImageLoader x:Key="UndertaleCachedImageLoader"/>
         <local:ColorConverter x:Key="ColorConverter"/>
         <local:SimplePointsDisplayConverter x:Key="SimplePointsDisplayConverter"/>
-        <local:ObjCenterXConverter x:Key="ObjCenterXConverter" />
-        <local:ObjXOffsetConverter x:Key="ObjXOffsetConverter" />
-        <local:ObjCenterYConverter x:Key="ObjCenterYConverter" />
         <local:LayerFlattenerConverter x:Key="LayerFlattenerConverter" />
         <local:IsGMS2Converter x:Key="IsGMS2Converter" />
         <local:BGColorConverter x:Key="BGColorConverter"/>
@@ -32,6 +29,7 @@
         <local:TileRectanglesConverter x:Key="TileRectanglesConverter"/>
         <local:CachedImageLoaderWithIndex x:Key="CachedImageLoaderWithIndex"/>
         <local:DataFieldOneTimeConverter x:Key="DataFieldOneTimeConverter"/>
+        <local:NegateNumberConverter x:Key="NegateNumberConverter"/>
         <CompositeCollection x:Key="AllObjectsGMS1">
             <CollectionContainer Collection="{Binding Source={x:Reference RoomEditor}, Path=DataContext.Backgrounds}"/>
             <CollectionContainer Collection="{Binding Source={x:Reference RoomEditor}, Path=DataContext.Tiles}"/>
@@ -1087,7 +1085,9 @@
                             <Rectangle.RenderTransform>
                                 <TransformGroup>
                                     <ScaleTransform x:Name="transform1_0" ScaleX="{Binding ScaleX, Mode=OneWay}" ScaleY="{Binding ScaleY, Mode=OneWay}"/>
-                                    <RotateTransform x:Name="transform1_1" Angle="{Binding OppositeRotation, Mode=OneWay}"/>
+                                    <RotateTransform x:Name="transform1_1" Angle="{Binding OppositeRotation, Mode=OneWay}"
+                                                     CenterX="{Binding SpriteXOffset, Converter={StaticResource NegateNumberConverter}, Mode=OneWay}"
+                                                     CenterY="{Binding SpriteYOffset, Converter={StaticResource NegateNumberConverter}, Mode=OneWay}"/>
                                     <TranslateTransform x:Name="transform1_2" X="{Binding XOffset, Mode=OneWay}" Y="{Binding YOffset, Mode=OneWay}"/>
                                 </TransformGroup>
                             </Rectangle.RenderTransform>
@@ -1142,7 +1142,9 @@
                             <Rectangle.RenderTransform>
                                 <TransformGroup>
                                     <ScaleTransform x:Name="transform4_0" ScaleX="{Binding ScaleX, Mode=OneWay}" ScaleY="{Binding ScaleY, Mode=OneWay}"/>
-                                    <RotateTransform x:Name="transform4_1" Angle="{Binding OppositeRotation, Mode=OneWay}"/>
+                                    <RotateTransform x:Name="transform4_1" Angle="{Binding OppositeRotation, Mode=OneWay}"
+                                                     CenterX="{Binding SpriteXOffset, Converter={StaticResource NegateNumberConverter}, Mode=OneWay}"
+                                                     CenterY="{Binding SpriteYOffset, Converter={StaticResource NegateNumberConverter}, Mode=OneWay}"/>
                                     <TranslateTransform x:Name="transform4_2" X="{Binding XOffset, Mode=OneWay}" Y="{Binding YOffset, Mode=OneWay}"/>
                                 </TransformGroup>
                             </Rectangle.RenderTransform>

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
@@ -920,7 +920,7 @@
                             <local:UndertaleStringReference Grid.Row="0" Grid.Column="2" Margin="3" ObjectReference="{Binding Name}"/>
 
                             <TextBlock Grid.Row="1" Grid.Column="0" Margin="3">Definition</TextBlock>
-                            <local:UndertaleObjectReference Grid.Row="1" Grid.Column="2" Margin="3" ObjectReference="{Binding Sprite}" ObjectType="{x:Type undertale:UndertaleGameObject}" CanRemove="False"/>
+                            <local:UndertaleObjectReference Grid.Row="1" Grid.Column="2" Margin="3" ObjectReference="{Binding Sprite}" ObjectType="{x:Type undertale:UndertaleSprite}" CanRemove="False"/>
 
                             <TextBlock Grid.Row="2" Grid.Column="0" Margin="3">Position</TextBlock>
                             <Grid Grid.Row="2" Grid.Column="2">
@@ -1124,10 +1124,12 @@
                                     <ImageBrush.ImageSource>
                                         <MultiBinding Converter="{StaticResource CachedTileImageLoader}">
                                             <Binding Mode="OneTime"/>
-                                            <Binding Path="SourceX" Mode="OneWay"/>
-                                            <Binding Path="SourceY" Mode="OneWay"/>
                                             <Binding Path="Width" Mode="OneWay"/>
                                             <Binding Path="Height" Mode="OneWay"/>
+                                            <!-- for notification only -->
+                                            <Binding Path="Tpag" Mode="OneWay"/>
+                                            <Binding Path="SourceX" Mode="OneWay"/>
+                                            <Binding Path="SourceY" Mode="OneWay"/>
                                         </MultiBinding>
                                     </ImageBrush.ImageSource>
                                 </ImageBrush>

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -1586,64 +1586,6 @@ namespace UndertaleModTool
         }
     }
 
-
-    [ValueConversion(typeof(ObservableCollection<GameObject>), typeof(int))]
-    public class ObjCenterXConverter : IValueConverter
-    {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            GameObject obj = value as GameObject;
-            if (obj == null)
-                return 0;
-            if (obj.ObjectDefinition == null || obj.ObjectDefinition.Sprite == null)
-                return obj.X;
-            return (obj.X + (obj.ObjectDefinition.Sprite.OriginX * obj.ScaleX));
-        }
-
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            throw new NotImplementedException();
-        }
-    }
-
-    [ValueConversion(typeof(ObservableCollection<GameObject>), typeof(int))]
-    public class ObjXOffsetConverter : IValueConverter
-    {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            GameObject obj = value as GameObject;
-            if (obj == null)
-                return 0;
-            if (obj.ObjectDefinition == null || obj.ObjectDefinition.Sprite == null)
-                return obj.X;
-            return obj.X + obj.ObjectDefinition.Sprite.OriginX;
-        }
-
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            throw new NotImplementedException();
-        }
-    }
-
-    [ValueConversion(typeof(ObservableCollection<GameObject>), typeof(int))]
-    public class ObjCenterYConverter : IValueConverter
-    {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            GameObject obj = value as GameObject;
-            if (obj == null)
-                return 0;
-            if (obj.ObjectDefinition == null || obj.ObjectDefinition.Sprite == null)
-                return obj.Y;
-            return (obj.Y + (obj.ObjectDefinition.Sprite.OriginY * obj.ScaleY));
-        }
-
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            throw new NotImplementedException();
-        }
-    }
-
     public class LayerDataTemplateSelector : DataTemplateSelector
     {
         public DataTemplate InstancesDataTemplate { get; set; }

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -43,7 +43,7 @@ namespace UndertaleModTool
                 new FrameworkPropertyMetadata(null));
 
         public static readonly PropertyInfo visualOffProp = typeof(Canvas).GetProperty("VisualOffset", BindingFlags.NonPublic | BindingFlags.Instance);
-        private static MainWindow mainWindow = Application.Current.MainWindow as MainWindow;
+        private static readonly MainWindow mainWindow = Application.Current.MainWindow as MainWindow;
 
         public UndertalePath PreviewPath
         {

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -1298,14 +1298,14 @@ namespace UndertaleModTool
                 // add pointer list if one doesn't already exist
                 layer.AssetsData.Sprites ??= new UndertalePointerList<SpriteInstance>();
                 
-                SpriteInstance sprInst = new();
-                string sprName = "graphic_" + ((uint)new Random().Next(-int.MaxValue, int.MaxValue)).ToString("X8");
-                sprInst.Name = new UndertaleString(sprName);
+                SpriteInstance spriteInstance = new();
+                string spriteName = "graphic_" + ((uint)new Random().Next(-int.MaxValue, int.MaxValue)).ToString("X8");
+                spriteInstance.Name = new UndertaleString(spriteName);
 
-                layer.AssetsData.Sprites.Add(sprInst);
-                sprInstDict.TryAdd(sprInst, layer);
+                layer.AssetsData.Sprites.Add(spriteInstance);
+                sprInstDict.TryAdd(spriteInstance, layer);
 
-                SelectObject(sprInst);
+                SelectObject(spriteInstance);
             }
         }
 

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -1297,13 +1297,15 @@ namespace UndertaleModTool
             {
                 // add pointer list if one doesn't already exist
                 layer.AssetsData.Sprites ??= new UndertalePointerList<SpriteInstance>();
+                
+                SpriteInstance sprInst = new();
+                string sprName = "graphic_" + ((uint)new Random().Next(-int.MaxValue, int.MaxValue)).ToString("X8");
+                sprInst.Name = new UndertaleString(sprName);
 
-                // add tile to list
-                var spriteinstance = new SpriteInstance();
-                layer.AssetsData.Sprites.Add(spriteinstance);
-                sprInstDict.TryAdd(spriteinstance, layer);
+                layer.AssetsData.Sprites.Add(sprInst);
+                sprInstDict.TryAdd(sprInst, layer);
 
-                SelectObject(spriteinstance);
+                SelectObject(sprInst);
             }
         }
 

--- a/UndertaleModTool/Editors/UndertaleSpriteEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleSpriteEditor.xaml
@@ -100,8 +100,8 @@
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
-            <TextBox Grid.Column="0" Margin="3" Text="{Binding OriginX}"/>
-            <TextBox Grid.Column="1" Margin="3" Text="{Binding OriginY}"/>
+            <TextBox Grid.Column="0" Margin="3" Text="{Binding OriginXWrapper}"/>
+            <TextBox Grid.Column="1" Margin="3" Text="{Binding OriginYWrapper}"/>
         </Grid>
 
         <TextBlock Grid.Row="10" Grid.Column="0" Margin="3">Textures</TextBlock>

--- a/UndertaleModTool/MainWindow.xaml
+++ b/UndertaleModTool/MainWindow.xaml
@@ -233,7 +233,7 @@
                                 </HierarchicalDataTemplate>
                             </TreeViewItem.ItemTemplate>
                         </TreeViewItem>
-                        <TreeViewItem Header="Backgrounds &amp; Tile sets" ItemsSource="{Binding Backgrounds, Converter={StaticResource FilteredViewConverter}}" Visibility="{Binding Backgrounds, Converter={StaticResource VisibleIfNotNull}}">
+                        <TreeViewItem Name="BackgroundsItemsList" Header="Backgrounds &amp; Tile sets" ItemsSource="{Binding Backgrounds, Converter={StaticResource FilteredViewConverter}}" Visibility="{Binding Backgrounds, Converter={StaticResource VisibleIfNotNull}}">
                             <TreeViewItem.ItemTemplate>
                                 <HierarchicalDataTemplate DataType="{x:Type undertale:UndertaleBackground}">
                                     <TextBlock Text="{Binding Name.Content}" />

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -593,6 +593,10 @@ namespace UndertaleModTool
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(FilePath)));
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsGMS2)));
 
+            BackgroundsItemsList.Header = IsGMS2 == Visibility.Visible
+                                          ? "Tile sets"
+                                          : "Backgrounds & Tile sets";
+
             CurrentTab = null;
             Tabs.Clear();
             Highlighted = new DescriptionView("Welcome to UndertaleModTool!", "New file created, have fun making a game out of nothing\nI TOLD YOU to open a data.win, not create a new file! :P");
@@ -930,6 +934,10 @@ namespace UndertaleModTool
                         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(FilePath)));
                         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsGMS2)));
 
+                        BackgroundsItemsList.Header = IsGMS2 == Visibility.Visible
+                                                      ? "Tile sets"
+                                                      : "Backgrounds & Tile sets";
+
                         #pragma warning disable CA1416
                         UndertaleCodeEditor.gettext = null;
                         UndertaleCodeEditor.gettextJSON = null;
@@ -939,7 +947,6 @@ namespace UndertaleModTool
                         OpenInTab(Highlighted);
                         SelectionHistory.Clear();
                         ClosedTabsHistory.Clear();
-
                     }
                     else
                     {


### PR DESCRIPTION
Room editor changes:

1. **Position of rotated/scaled `GameObject` and `SpriteInstance` are now properly displayed.**
2. **Sprite origin fields in the sprite editor now work _(with sprite origin wrappers)_.**
3. Added descriptions to some properties _(and modified existing)_.
4. Removed redundant converters: `ObjCenterXConverter`, `ObjCenterYConverter` and `ObjXOffsetConverter`.
5. Added `NegateNumberConverter`.
6. Suppressed `Bitmap`-related warnings in _"UndertaleCachedImageLoader.cs"_ and replaced with TODO.
7. _"Backgrounds & tile sets"_ item title changes to _"Tile sets"_ on GMS 2 games.
8. **Fixed bug that prevented adding sprite to a new sprite instance.**
9. New sprite instances have unique names _("graphic_XXXXXXXX", as in GameMaker Studio: 2)_.
10. Tiles are now properly updating on their sprite change.
11. Removed `GetBGColorLayer()` and integrated its contents into `BGColorLayer`.

Closes #623