### PR TITLE
Show git commit+branch for debug builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -332,3 +332,4 @@ ASALocalRun/
 Test/Test - Backup.csproj
 UndertaleModLib/UndertaleModLib - Backup.csproj
 UndertaleModTests/UndertaleModTests - Backup.csproj
+UndertaleModLib/gitversion.txt

--- a/UndertaleModLib/UndertaleModLib.csproj
+++ b/UndertaleModLib/UndertaleModLib.csproj
@@ -35,4 +35,17 @@
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
   </ItemGroup>
+  <ItemGroup>
+    <None Remove="version.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="gitversion.txt" />
+    <EmbeddedResource Include="gitversion.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
+  </ItemGroup>
+  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+    <!-- puts the git commit name and branch name into gitversion.txt which is an embedded resource -->
+    <Exec Command="( git describe --always --dirty &amp;&amp; git rev-parse --abbrev-ref HEAD  ) &gt; &quot;$(ProjectDir)/gitversion.txt&quot;" />
+  </Target>
 </Project>

--- a/UndertaleModLib/Util/GitVersion.cs
+++ b/UndertaleModLib/Util/GitVersion.cs
@@ -1,0 +1,76 @@
+using System.Diagnostics;
+using System.IO;
+
+namespace UndertaleModLib.Util;
+
+/// <summary>
+/// Includes miscellaneous git information about the project to compile.
+/// <b>Only intended for Debug use!</b>
+/// </summary>
+public static class GitVersion
+{
+    /// <summary>
+    /// The constant for the git executable.
+    /// </summary>
+    private const string Git = "git";
+
+    /// <summary>
+    /// The constant to receive commit name.
+    /// </summary>
+    private const string GitCommit = "describe --always --dirty";
+
+    /// <summary>
+    /// The constant to receive branch name.
+    /// </summary>
+    private const string GitBranch = "rev-parse --abbrev-ref HEAD";
+
+    /// <summary>
+    /// Gets and returns the git commit and branch name.
+    /// </summary>
+    /// <returns>The git commit and branch name.</returns>
+    public static string GetGitVersion()
+    {
+        string commitOutput;
+        string branchOutput;
+
+        try
+        {
+            // Start git, get the commit number and assign that to commitOutput
+            using (Process process = new Process())
+            {
+                process.StartInfo.FileName = Git;
+                process.StartInfo.Arguments = GitCommit;
+                process.StartInfo.RedirectStandardOutput = true;
+                process.StartInfo.CreateNoWindow = true;
+                process.Start();
+                StreamReader reader = process.StandardOutput;
+                string output = reader.ReadToEnd();
+                commitOutput = output.Trim();
+                process.WaitForExit();
+            }
+
+            // Start git, get the branch name and assign that to branchOutput
+            using (Process process = new Process())
+            {
+                process.StartInfo.FileName = Git;
+                process.StartInfo.Arguments = GitBranch;
+                process.StartInfo.RedirectStandardOutput = true;
+                process.StartInfo.CreateNoWindow = true;
+                process.Start();
+                StreamReader reader = process.StandardOutput;
+                string output = reader.ReadToEnd();
+                branchOutput = output.Trim();
+                process.WaitForExit();
+            }
+        }
+        // If git can't be found, assign default values
+        catch
+        {
+            commitOutput = branchOutput = "unavailable";
+        }
+
+        // return combined commit + branch
+        string finalGitVersion = $"{commitOutput} ({branchOutput})";
+        return finalGitVersion;
+    }
+}

--- a/UndertaleModLib/Util/GitVersion.cs
+++ b/UndertaleModLib/Util/GitVersion.cs
@@ -13,21 +13,6 @@ namespace UndertaleModLib.Util;
 public static class GitVersion
 {
     /// <summary>
-    /// The constant for the git executable.
-    /// </summary>
-    private const string Git = "git";
-
-    /// <summary>
-    /// The constant to receive commit name.
-    /// </summary>
-    private const string GitCommit = "describe --always --dirty";
-
-    /// <summary>
-    /// The constant to receive branch name.
-    /// </summary>
-    private const string GitBranch = "rev-parse --abbrev-ref HEAD";
-
-    /// <summary>
     /// Gets and returns the git commit and branch name.
     /// </summary>
     /// <returns>The git commit and branch name.</returns>

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -27,6 +27,7 @@ using UndertaleModLib.Decompiler;
 using UndertaleModLib.Models;
 using UndertaleModLib.ModelsDebug;
 using UndertaleModLib.Scripting;
+using UndertaleModLib.Util;
 using UndertaleModTool.Windows;
 using System.IO.Pipes;
 using Ookii.Dialogs.Wpf;
@@ -93,7 +94,7 @@ namespace UndertaleModTool
             else if (obj is UndertaleNamedResource namedRes)
             {
                 string content = namedRes.Name?.Content;
-                
+
                 string header = obj switch
                 {
                     UndertaleAudioGroup => "Audio Group",
@@ -301,7 +302,13 @@ namespace UndertaleModTool
 
         // Version info
         public static string Edition = "";
+
+        // On debug, build with git versions. Otherwise, use the provided release version.
+#if DEBUG
+        public static string Version = GitVersion.GetGitVersion();
+#else
         public static string Version = Assembly.GetExecutingAssembly().GetName().Version.ToString() + (Edition != "" ? "-" + Edition : "");
+#endif
 
         public MainWindow()
         {
@@ -313,7 +320,7 @@ namespace UndertaleModTool
             SelectionHistory.Clear();
             ClosedTabsHistory.Clear();
 
-            TitleMain = "UndertaleModTool by krzys_h v" + Version;
+            TitleMain = "UndertaleModTool by krzys_h v:" + Version;
 
             CanSave = false;
             CanSafelySave = false;
@@ -1732,7 +1739,7 @@ namespace UndertaleModTool
             if (Highlighted is UndertaleObject obj)
                 DeleteItem(obj);
         }
-        
+
         private void MenuItem_Add_Click(object sender, RoutedEventArgs e)
         {
             object source = null;
@@ -2517,7 +2524,12 @@ namespace UndertaleModTool
             httpClient = new();
             httpClient.DefaultRequestHeaders.Accept.Clear();
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github.v3+json"));
-            httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("UndertaleModTool", Version));
+
+            // remove the invalid characters (everything within square brackets) from the version string.
+            // Probably needs to be expanded later, these are just the ones I know of.
+            Regex invalidChars = new Regex(@"[  ()]");
+            string version = invalidChars.Replace(Version, "");
+            httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("UndertaleModTool", version));
 
             double bytesToMB = 1024 * 1024;
 
@@ -3231,7 +3243,7 @@ result in loss of work.");
                         Tabs[i].TabIndex = i;
 
                     // if closing the currently open tab
-                    if (currIndex == tabIndex)                            
+                    if (currIndex == tabIndex)
                     {
                         // and if that tab is not the last
                         if (Tabs.Count > 1 && tabIndex < Tabs.Count - 1)


### PR DESCRIPTION
This PR makes it so that debug builds now have `commitName (branchName)` as their version.
The method responsible for that is located in "lib" so other tools (like cli or custom ones) can benefit from that utility as well.
Release build:
![image](https://user-images.githubusercontent.com/38186597/166744002-f8704514-4163-4e02-a008-677f3d63d0b9.png)

Debug build:
![image](https://user-images.githubusercontent.com/38186597/166743917-e319bd63-8e37-4748-821e-24bf0e3774ae.png)

Fixes #883 
