### PR TITLE
Optimize TexData (mostly QoiConverter)

### DIFF
--- a/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
+++ b/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
@@ -106,6 +106,7 @@ namespace UndertaleModLib.Models
             /// <summary>
             /// The PNG image data of the texture.
             /// </summary>
+            [Obsolete($"{nameof(TextureBlob)} is obsolete. Use {nameof(Image)} instead.", false)]
             public byte[] TextureBlob {
                 get {
                     using MemoryStream final = new();

--- a/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
+++ b/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
@@ -107,8 +107,10 @@ namespace UndertaleModLib.Models
             /// The PNG image data of the texture.
             /// </summary>
             [Obsolete($"{nameof(TextureBlob)} is obsolete. Use {nameof(Image)} instead.", false)]
-            public byte[] TextureBlob {
-                get {
+            public byte[] TextureBlob
+            {
+                get
+                {
                     using MemoryStream final = new();
                     Image.Save(final, ImageFormat.Png);
                     return final.ToArray();

--- a/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
+++ b/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
@@ -146,9 +146,7 @@ namespace UndertaleModLib.Models
                     }
                     else
                     {
-                        // Encode the PNG data back to QOI
-                        writer.Write(QoiConverter.GetArrayFromImage(TextureWorker.GetImageFromByteArray(TextureBlob),
-                            writer.undertaleData.GM2022_3 ? 0 : 4));
+                        writer.Write(QoiConverter.GetSpanFromImage(Image, writer.undertaleData.GM2022_3 ? 0 : 4));
                     }
                 }
                 else
@@ -186,10 +184,8 @@ namespace UndertaleModLib.Models
                         reader.undertaleData.UseQoiFormat = true;
                         reader.undertaleData.UseBZipFormat = false;
 
-                        using MemoryStream ms = new MemoryStream(reader.Buffer);
-                        ms.Seek(reader.Offset, SeekOrigin.Begin);
-                        Image = QoiConverter.GetImageFromStream(ms);
-                        reader.Offset = (int)ms.Position;
+                        Image = QoiConverter.GetImageFromSpan(reader.Buffer.AsSpan()[reader.Offset..], out int dataLength);
+                        reader.Offset += dataLength;
                         return;
                     }
                     else

--- a/UndertaleModLib/Models/UndertaleTexturePageItem.cs
+++ b/UndertaleModLib/Models/UndertaleTexturePageItem.cs
@@ -145,7 +145,7 @@ namespace UndertaleModLib.Models
                 g.DrawImage(finalImage, SourceX, SourceY);
                 g.Dispose();
 
-                TexturePage.TextureData.TextureBlob = TextureWorker.GetImageBytes(embImage);
+                TexturePage.TextureData.Image = embImage;
                 worker.Cleanup();
             }
 

--- a/UndertaleModLib/Util/BufferBinaryWriter.cs
+++ b/UndertaleModLib/Util/BufferBinaryWriter.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -84,6 +86,17 @@ namespace UndertaleModLib.Util
         {
             ResizeToFit((int)(offset + value.Length));
             Buffer.BlockCopy(value.GetBuffer(), 0, buffer, (int)offset, (int)value.Length);
+            offset += value.Length;
+        }
+
+        public void Write(Span<byte> value)
+        {
+            ResizeToFit((int)offset + value.Length);
+            // basically reimplements Buffer.BlockCopy but using Span as the source
+            ref byte valueRef = ref MemoryMarshal.GetReference(value);
+            ref byte bufferRef =
+                ref Unsafe.AddByteOffset(ref MemoryMarshal.GetArrayDataReference(buffer), (nuint)offset);
+            Unsafe.CopyBlock(ref bufferRef, ref valueRef, (uint)value.Length);
             offset += value.Length;
         }
 

--- a/UndertaleModLib/Util/BufferBinaryWriter.cs
+++ b/UndertaleModLib/Util/BufferBinaryWriter.cs
@@ -80,6 +80,13 @@ namespace UndertaleModLib.Util
             offset += value.Length;
         }
 
+        public void Write(MemoryStream value)
+        {
+            ResizeToFit((int)(offset + value.Length));
+            Buffer.BlockCopy(value.GetBuffer(), 0, buffer, (int)offset, (int)value.Length);
+            offset += value.Length;
+        }
+
         public void Write(char[] value)
         {
             ResizeToFit((int)offset + value.Length);

--- a/UndertaleModLib/Util/QoiConverter.cs
+++ b/UndertaleModLib/Util/QoiConverter.cs
@@ -179,9 +179,10 @@ namespace UndertaleModLib.Util
         /// <param name="padding">The amount of bytes of padding that should be used.</param>
         /// <returns>A QOI Image as a byte array.</returns>
         /// <exception cref="Exception">If there was an error with stride width.</exception>
-        public unsafe static Span<byte> GetSpanFromImage(Bitmap bmp, int padding = 4)
-        {
-            byte[] res = new byte[(bmp.Width * bmp.Height * 4 * 12) + padding]; // default capacity
+        public unsafe static Span<byte> GetSpanFromImage(Bitmap bmp, int padding = 4) {
+            const int maxChunkSize = 5; // according to the QOI spec: https://qoiformat.org/qoi-specification.pdf
+            const int headerSize = 12;
+            byte[] res = new byte[bmp.Width * bmp.Height * maxChunkSize + headerSize + padding]; // default capacity
             // Little-endian QOIF image magic
             res[0] = (byte)'f';
             res[1] = (byte)'i';
@@ -199,7 +200,7 @@ namespace UndertaleModLib.Util
             byte* bmpPtr = (byte*)data.Scan0;
             byte* bmpEnd = bmpPtr + (4 * bmp.Width * bmp.Height);
 
-            int resPos = 12;
+            int resPos = headerSize;
             byte r = 0, g = 0, b = 0, a = 255;
             int run = 0;
             int v = 0, vPrev = 0xff;
@@ -295,7 +296,7 @@ namespace UndertaleModLib.Util
             resPos += padding;
 
             // Write final length
-            int length = resPos - 12;
+            int length = resPos - headerSize;
             res[8] = (byte)(length & 0xff);
             res[9] = (byte)((length >> 8) & 0xff);
             res[10] = (byte)((length >> 16) & 0xff);

--- a/UndertaleModLib/Util/QoiConverter.cs
+++ b/UndertaleModLib/Util/QoiConverter.cs
@@ -46,14 +46,23 @@ namespace UndertaleModLib.Util
         /// <param name="bytes">The span to create the PNG image from.</param>
         /// <returns>The QOI image as a PNG.</returns>
         /// <exception cref="Exception">If there is an invalid QOIF magic header or there was an error with stride width.</exception>
-        public unsafe static Bitmap GetImageFromSpan(ReadOnlySpan<byte> bytes) {
+        public static Bitmap GetImageFromSpan(ReadOnlySpan<byte> bytes) => GetImageFromSpan(bytes, out _);
+
+        /// <summary>
+        /// Creates a Bitmap from a <see cref="ReadOnlySpan"/>.
+        /// </summary>
+        /// <param name="bytes">The span to create the PNG image from.</param>
+        /// <param name="length">The total amount of data read from the span.</param>
+        /// <returns>The QOI image as a PNG.</returns>
+        /// <exception cref="Exception">If there is an invalid QOIF magic header or there was an error with stride width.</exception>
+        public unsafe static Bitmap GetImageFromSpan(ReadOnlySpan<byte> bytes, out int length) {
             ReadOnlySpan<byte> header = bytes[..12];
             if (header[0] != (byte)'f' || header[1] != (byte)'i' || header[2] != (byte)'o' || header[3] != (byte)'q')
                 throw new Exception("Invalid little-endian QOIF image magic");
 
             int width = header[4] + (header[5] << 8);
             int height = header[6] + (header[7] << 8);
-            int length = header[8] + (header[9] << 8) + (header[10] << 16) + (header[11] << 24);
+            length = header[8] + (header[9] << 8) + (header[10] << 16) + (header[11] << 24);
 
             ReadOnlySpan<byte> pixelData = bytes.Slice(12, length);
 

--- a/UndertaleModLib/Util/QoiConverter.cs
+++ b/UndertaleModLib/Util/QoiConverter.cs
@@ -159,6 +159,7 @@ namespace UndertaleModLib.Util
 
             bmp.UnlockBits(data);
 
+            length += header.Length;
             return bmp;
         }
 

--- a/UndertaleModLib/Util/QoiConverter.cs
+++ b/UndertaleModLib/Util/QoiConverter.cs
@@ -25,7 +25,7 @@ namespace UndertaleModLib.Util
         private const byte QOI_MASK_4 = 0xf0;
 
         /// <summary>
-        /// Creates a Bitmap from a <see cref="Stream"/>.
+        /// Creates a <see cref="Bitmap"/> from a <see cref="Stream"/>.
         /// </summary>
         /// <param name="s">The stream to create the PNG image from.</param>
         /// <returns>The QOI image as a PNG.</returns>
@@ -42,18 +42,18 @@ namespace UndertaleModLib.Util
         }
 
         /// <summary>
-        /// Creates a Bitmap from a <see cref="ReadOnlySpan"/>.
+        /// Creates a <see cref="Bitmap"/> from a <see cref="ReadOnlySpan"/>.
         /// </summary>
-        /// <param name="bytes">The span to create the PNG image from.</param>
+        /// <param name="bytes">The <see cref="Span"/> to create the PNG image from.</param>
         /// <returns>The QOI image as a PNG.</returns>
         /// <exception cref="Exception">If there is an invalid QOIF magic header or there was an error with stride width.</exception>
         public static Bitmap GetImageFromSpan(ReadOnlySpan<byte> bytes) => GetImageFromSpan(bytes, out _);
 
         /// <summary>
-        /// Creates a Bitmap from a <see cref="ReadOnlySpan"/>.
+        /// Creates a <see cref="Bitmap"/> from a <see cref="ReadOnlySpan"/>.
         /// </summary>
-        /// <param name="bytes">The span to create the PNG image from.</param>
-        /// <param name="length">The total amount of data read from the span.</param>
+        /// <param name="bytes">The <see cref="Span"/> to create the PNG image from.</param>
+        /// <param name="length">The total amount of data read from the <see cref="Span"/>.</param>
         /// <returns>The QOI image as a PNG.</returns>
         /// <exception cref="Exception">If there is an invalid QOIF magic header or there was an error with stride width.</exception>
         public unsafe static Bitmap GetImageFromSpan(ReadOnlySpan<byte> bytes, out int length)
@@ -164,18 +164,18 @@ namespace UndertaleModLib.Util
         }
 
         /// <summary>
-        /// Creates a QOI image as a byte array from a Bitmap.
+        /// Creates a QOI image as a byte array from a <see cref="Bitmap"/>.
         /// </summary>
-        /// <param name="bmp">The bitmap to create the QOI image from.</param>
+        /// <param name="bmp">The <see cref="Bitmap"/> to create the QOI image from.</param>
         /// <param name="padding">The amount of bytes of padding that should be used.</param>
         /// <returns>A QOI Image as a byte array.</returns>
         /// <exception cref="Exception">If there was an error with stride width.</exception>
         public static byte[] GetArrayFromImage(Bitmap bmp, int padding = 4) => GetSpanFromImage(bmp, padding).ToArray();
 
         /// <summary>
-        /// Creates a QOI image as a span of bytes from a Bitmap.
+        /// Creates a QOI image as a <see cref="Span"/> from a <see cref="Bitmap"/>.
         /// </summary>
-        /// <param name="bmp">The bitmap to create the QOI image from.</param>
+        /// <param name="bmp">The <see cref="Bitmap"/> to create the QOI image from.</param>
         /// <param name="padding">The amount of bytes of padding that should be used.</param>
         /// <returns>A QOI Image as a byte array.</returns>
         /// <exception cref="Exception">If there was an error with stride width.</exception>

--- a/UndertaleModLib/Util/QoiConverter.cs
+++ b/UndertaleModLib/Util/QoiConverter.cs
@@ -30,7 +30,8 @@ namespace UndertaleModLib.Util
         /// <param name="s">The stream to create the PNG image from.</param>
         /// <returns>The QOI image as a PNG.</returns>
         /// <exception cref="Exception">If there is an invalid QOIF magic header or there was an error with stride width.</exception>
-        public static Bitmap GetImageFromStream(Stream s) {
+        public static Bitmap GetImageFromStream(Stream s)
+        {
             Span<byte> header = stackalloc byte[12];
             s.Read(header);
             int length = header[8] + (header[9] << 8) + (header[10] << 16) + (header[11] << 24);
@@ -55,7 +56,8 @@ namespace UndertaleModLib.Util
         /// <param name="length">The total amount of data read from the span.</param>
         /// <returns>The QOI image as a PNG.</returns>
         /// <exception cref="Exception">If there is an invalid QOIF magic header or there was an error with stride width.</exception>
-        public unsafe static Bitmap GetImageFromSpan(ReadOnlySpan<byte> bytes, out int length) {
+        public unsafe static Bitmap GetImageFromSpan(ReadOnlySpan<byte> bytes, out int length)
+        {
             ReadOnlySpan<byte> header = bytes[..12];
             if (header[0] != (byte)'f' || header[1] != (byte)'i' || header[2] != (byte)'o' || header[3] != (byte)'q')
                 throw new Exception("Invalid little-endian QOIF image magic");

--- a/UndertaleModLib/Util/TextureWorker.cs
+++ b/UndertaleModLib/Util/TextureWorker.cs
@@ -24,7 +24,8 @@ namespace UndertaleModLib.Util
 
         public Bitmap GetEmbeddedTexture(UndertaleEmbeddedTexture embeddedTexture)
         {
-            lock (embeddedDictionary) {
+            lock (embeddedDictionary)
+            {
                 if(!embeddedDictionary.ContainsKey(embeddedTexture))
                     embeddedDictionary[embeddedTexture] = embeddedTexture.TextureData.Image;
                 return embeddedDictionary[embeddedTexture];

--- a/UndertaleModLib/Util/TextureWorker.cs
+++ b/UndertaleModLib/Util/TextureWorker.cs
@@ -24,10 +24,9 @@ namespace UndertaleModLib.Util
 
         public Bitmap GetEmbeddedTexture(UndertaleEmbeddedTexture embeddedTexture)
         {
-            lock (embeddedDictionary)
-            {
-                if (!embeddedDictionary.ContainsKey(embeddedTexture))
-                    embeddedDictionary[embeddedTexture] = GetImageFromByteArray(embeddedTexture.TextureData.TextureBlob);
+            lock (embeddedDictionary) {
+                if(!embeddedDictionary.ContainsKey(embeddedTexture))
+                    embeddedDictionary[embeddedTexture] = embeddedTexture.TextureData.Image;
                 return embeddedDictionary[embeddedTexture];
             }
         }

--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -158,7 +158,6 @@ namespace UndertaleModTool
 
         public static Bitmap CreateSpriteBitmap(Rectangle rect, in UndertaleTexturePageItem texture, int diffW = 0, int diffH = 0, bool isTile = false)
         {
-            using MemoryStream stream = new(texture.TexturePage.TextureData.TextureBlob);
             Bitmap spriteBMP = new(rect.Width, rect.Height);
 
             rect.Width -= (diffW > 0) ? diffW : 0;
@@ -166,11 +165,8 @@ namespace UndertaleModTool
             int x = isTile ? texture.TargetX : 0;
             int y = isTile ? texture.TargetY : 0;
 
-            using (Graphics g = Graphics.FromImage(spriteBMP))
-            {
-                using Image img = Image.FromStream(stream); // "ImageConverter.ConvertFrom()" does the same, except it doesn't explicitly dispose MemoryStream
-                g.DrawImage(img, new Rectangle(x, y, rect.Width, rect.Height), rect, GraphicsUnit.Pixel);
-            }
+            using Graphics g = Graphics.FromImage(spriteBMP);
+            g.DrawImage(texture.TexturePage.TextureData.Image, new Rectangle(x, y, rect.Width, rect.Height), rect, GraphicsUnit.Pixel);
 
             return spriteBMP;
         }

--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
@@ -58,11 +58,7 @@ namespace UndertaleModTool
                         MessageBox.Show("WARNING: texture page dimensions are not powers of 2. Sprite blurring is very likely in game.", "Unexpected texture dimensions", MessageBoxButton.OK, MessageBoxImage.Warning);
                     }
 
-                    using (var stream = new MemoryStream())
-                    {
-                        bmp.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
-                        target.TextureData.TextureBlob = stream.ToArray();
-                    }
+                    target.TextureData.Image = bmp;
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Optimizes QoiConverter, makes TexData store a bitmap instead of PNG byte array and replaces most TextureBlob usages with a direct reference to the bitmap
The memory usage deserializing QOI images is drastically lower:
![image](https://user-images.githubusercontent.com/30120687/166817067-55d17513-607c-4f01-91e4-1c7efcbc781e.png)

~~There isn't much that can be optimized in the serialization but it's still a bit better:~~
<details>
<summary>old screenshot</summary>

![image](https://user-images.githubusercontent.com/30120687/166817188-a19ff1ca-464e-43e5-b573-6c4d89508d88.png)
</details>

Memory usage here is also way lower in serialization now (about 40MB, instead of 380MB on a random 4K wallpaper image)