### PR TITLE
Revert qoi changes

### DIFF
--- a/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
+++ b/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
@@ -111,11 +111,6 @@ namespace UndertaleModLib.Models
             {
                 get
                 {
-                    // for whatever weird reason the getter is called before the setter
-                    // even tho the getter shouldn't be called at all...
-                    // TODO: investigate why this happens
-                    if (Image is null)
-                        return Array.Empty<byte>();
                     using MemoryStream final = new();
                     Image.Save(final, ImageFormat.Png);
                     return final.ToArray();

--- a/UndertaleModLib/Models/UndertaleTexturePageItem.cs
+++ b/UndertaleModLib/Models/UndertaleTexturePageItem.cs
@@ -145,7 +145,7 @@ namespace UndertaleModLib.Models
                 g.DrawImage(finalImage, SourceX, SourceY);
                 g.Dispose();
 
-                TexturePage.TextureData.Image = embImage;
+                TexturePage.TextureData.TextureBlob = TextureWorker.GetImageBytes(embImage);
                 worker.Cleanup();
             }
 

--- a/UndertaleModLib/Util/BufferBinaryWriter.cs
+++ b/UndertaleModLib/Util/BufferBinaryWriter.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -79,24 +77,6 @@ namespace UndertaleModLib.Util
         {
             ResizeToFit((int)offset + value.Length);
             Buffer.BlockCopy(value, 0, buffer, (int)offset, value.Length);
-            offset += value.Length;
-        }
-
-        public void Write(MemoryStream value)
-        {
-            ResizeToFit((int)(offset + value.Length));
-            Buffer.BlockCopy(value.GetBuffer(), 0, buffer, (int)offset, (int)value.Length);
-            offset += value.Length;
-        }
-
-        public void Write(Span<byte> value)
-        {
-            ResizeToFit((int)offset + value.Length);
-            // basically reimplements Buffer.BlockCopy but using Span as the source
-            ref byte valueRef = ref MemoryMarshal.GetReference(value);
-            ref byte bufferRef =
-                ref Unsafe.AddByteOffset(ref MemoryMarshal.GetArrayDataReference(buffer), (nuint)offset);
-            Unsafe.CopyBlock(ref bufferRef, ref valueRef, (uint)value.Length);
             offset += value.Length;
         }
 

--- a/UndertaleModLib/Util/QoiConverter.cs
+++ b/UndertaleModLib/Util/QoiConverter.cs
@@ -25,48 +25,24 @@ namespace UndertaleModLib.Util
         private const byte QOI_MASK_4 = 0xf0;
 
         /// <summary>
-        /// Creates a <see cref="Bitmap"/> from a <see cref="Stream"/>.
+        /// Creates a Bitmap from a <see cref="Stream"/>.
         /// </summary>
         /// <param name="s">The stream to create the PNG image from.</param>
         /// <returns>The QOI image as a PNG.</returns>
         /// <exception cref="Exception">If there is an invalid QOIF magic header or there was an error with stride width.</exception>
-        public static Bitmap GetImageFromStream(Stream s)
+        public unsafe static Bitmap GetImageFromStream(Stream s)
         {
-            Span<byte> header = stackalloc byte[12];
-            s.Read(header);
-            int length = header[8] + (header[9] << 8) + (header[10] << 16) + (header[11] << 24);
-            byte[] bytes = new byte[12 + length];
-            s.Position -= 12;
-            s.Read(bytes, 0, bytes.Length);
-            return GetImageFromSpan(bytes);
-        }
-
-        /// <summary>
-        /// Creates a <see cref="Bitmap"/> from a <see cref="ReadOnlySpan"/>.
-        /// </summary>
-        /// <param name="bytes">The <see cref="Span"/> to create the PNG image from.</param>
-        /// <returns>The QOI image as a PNG.</returns>
-        /// <exception cref="Exception">If there is an invalid QOIF magic header or there was an error with stride width.</exception>
-        public static Bitmap GetImageFromSpan(ReadOnlySpan<byte> bytes) => GetImageFromSpan(bytes, out _);
-
-        /// <summary>
-        /// Creates a <see cref="Bitmap"/> from a <see cref="ReadOnlySpan"/>.
-        /// </summary>
-        /// <param name="bytes">The <see cref="Span"/> to create the PNG image from.</param>
-        /// <param name="length">The total amount of data read from the <see cref="Span"/>.</param>
-        /// <returns>The QOI image as a PNG.</returns>
-        /// <exception cref="Exception">If there is an invalid QOIF magic header or there was an error with stride width.</exception>
-        public unsafe static Bitmap GetImageFromSpan(ReadOnlySpan<byte> bytes, out int length)
-        {
-            ReadOnlySpan<byte> header = bytes[..12];
+            byte[] header = new byte[12];
+            s.Read(header, 0, 12);
             if (header[0] != (byte)'f' || header[1] != (byte)'i' || header[2] != (byte)'o' || header[3] != (byte)'q')
                 throw new Exception("Invalid little-endian QOIF image magic");
 
             int width = header[4] + (header[5] << 8);
             int height = header[6] + (header[7] << 8);
-            length = header[8] + (header[9] << 8) + (header[10] << 16) + (header[11] << 24);
+            int length = header[8] + (header[9] << 8) + (header[10] << 16) + (header[11] << 24);
 
-            ReadOnlySpan<byte> pixelData = bytes.Slice(12, length);
+            byte[] pixelData = new byte[length];
+            s.Read(pixelData, 0, length);
 
             Bitmap bmp = new Bitmap(width, height, PixelFormat.Format32bppArgb);
 
@@ -80,7 +56,7 @@ namespace UndertaleModLib.Util
             int pos = 0;
             int run = 0;
             byte r = 0, g = 0, b = 0, a = 255;
-            Span<byte> index = stackalloc byte[64 * 4];
+            byte[] index = new byte[64 * 4];
             while (bmpPtr < bmpEnd)
             {
                 if (run > 0)
@@ -159,30 +135,19 @@ namespace UndertaleModLib.Util
 
             bmp.UnlockBits(data);
 
-            length += header.Length;
             return bmp;
         }
 
         /// <summary>
-        /// Creates a QOI image as a byte array from a <see cref="Bitmap"/>.
+        /// Creates a QOI image as a byte array from a Bitmap.
         /// </summary>
-        /// <param name="bmp">The <see cref="Bitmap"/> to create the QOI image from.</param>
+        /// <param name="bmp">The bitmap to create the QOI image from.</param>
         /// <param name="padding">The amount of bytes of padding that should be used.</param>
         /// <returns>A QOI Image as a byte array.</returns>
         /// <exception cref="Exception">If there was an error with stride width.</exception>
-        public static byte[] GetArrayFromImage(Bitmap bmp, int padding = 4) => GetSpanFromImage(bmp, padding).ToArray();
-
-        /// <summary>
-        /// Creates a QOI image as a <see cref="Span"/> from a <see cref="Bitmap"/>.
-        /// </summary>
-        /// <param name="bmp">The <see cref="Bitmap"/> to create the QOI image from.</param>
-        /// <param name="padding">The amount of bytes of padding that should be used.</param>
-        /// <returns>A QOI Image as a byte array.</returns>
-        /// <exception cref="Exception">If there was an error with stride width.</exception>
-        public unsafe static Span<byte> GetSpanFromImage(Bitmap bmp, int padding = 4) {
-            const int maxChunkSize = 5; // according to the QOI spec: https://qoiformat.org/qoi-specification.pdf
-            const int headerSize = 12;
-            byte[] res = new byte[bmp.Width * bmp.Height * maxChunkSize + headerSize + padding]; // default capacity
+        public unsafe static byte[] GetArrayFromImage(Bitmap bmp, int padding = 4)
+        {
+            byte[] res = new byte[(bmp.Width * bmp.Height * 4 * 12) + padding]; // default capacity
             // Little-endian QOIF image magic
             res[0] = (byte)'f';
             res[1] = (byte)'i';
@@ -200,11 +165,11 @@ namespace UndertaleModLib.Util
             byte* bmpPtr = (byte*)data.Scan0;
             byte* bmpEnd = bmpPtr + (4 * bmp.Width * bmp.Height);
 
-            int resPos = headerSize;
+            int resPos = 12;
             byte r = 0, g = 0, b = 0, a = 255;
             int run = 0;
             int v = 0, vPrev = 0xff;
-            Span<int> index = stackalloc int[64];
+            int[] index = new int[64];
             while (bmpPtr < bmpEnd)
             {
                 b = *bmpPtr;
@@ -296,13 +261,13 @@ namespace UndertaleModLib.Util
             resPos += padding;
 
             // Write final length
-            int length = resPos - headerSize;
+            int length = resPos - 12;
             res[8] = (byte)(length & 0xff);
             res[9] = (byte)((length >> 8) & 0xff);
             res[10] = (byte)((length >> 16) & 0xff);
             res[11] = (byte)((length >> 24) & 0xff);
 
-            return res.AsSpan()[..resPos];
+            return res[..resPos];
         }
     }
 }

--- a/UndertaleModLib/Util/TextureWorker.cs
+++ b/UndertaleModLib/Util/TextureWorker.cs
@@ -26,8 +26,8 @@ namespace UndertaleModLib.Util
         {
             lock (embeddedDictionary)
             {
-                if(!embeddedDictionary.ContainsKey(embeddedTexture))
-                    embeddedDictionary[embeddedTexture] = embeddedTexture.TextureData.Image;
+                if (!embeddedDictionary.ContainsKey(embeddedTexture))
+                    embeddedDictionary[embeddedTexture] = GetImageFromByteArray(embeddedTexture.TextureData.TextureBlob);
                 return embeddedDictionary[embeddedTexture];
             }
         }

--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -158,6 +158,7 @@ namespace UndertaleModTool
 
         public static Bitmap CreateSpriteBitmap(Rectangle rect, in UndertaleTexturePageItem texture, int diffW = 0, int diffH = 0, bool isTile = false)
         {
+            using MemoryStream stream = new(texture.TexturePage.TextureData.TextureBlob);
             Bitmap spriteBMP = new(rect.Width, rect.Height);
 
             rect.Width -= (diffW > 0) ? diffW : 0;
@@ -165,8 +166,11 @@ namespace UndertaleModTool
             int x = isTile ? texture.TargetX : 0;
             int y = isTile ? texture.TargetY : 0;
 
-            using Graphics g = Graphics.FromImage(spriteBMP);
-            g.DrawImage(texture.TexturePage.TextureData.Image, new Rectangle(x, y, rect.Width, rect.Height), rect, GraphicsUnit.Pixel);
+            using (Graphics g = Graphics.FromImage(spriteBMP))
+            {
+                using Image img = Image.FromStream(stream); // "ImageConverter.ConvertFrom()" does the same, except it doesn't explicitly dispose MemoryStream
+                g.DrawImage(img, new Rectangle(x, y, rect.Width, rect.Height), rect, GraphicsUnit.Pixel);
+            }
 
             return spriteBMP;
         }

--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
@@ -58,7 +58,11 @@ namespace UndertaleModTool
                         MessageBox.Show("WARNING: texture page dimensions are not powers of 2. Sprite blurring is very likely in game.", "Unexpected texture dimensions", MessageBoxButton.OK, MessageBoxImage.Warning);
                     }
 
-                    target.TextureData.Image = bmp;
+                    using (var stream = new MemoryStream())
+                    {
+                        bmp.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
+                        target.TextureData.TextureBlob = stream.ToArray();
+                    }
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Description
Revert #886 and #892. While the benefit of them reducing memory usage drastically is nice, they currently break and/or crash a lot of functionality, due to barely any testing done.

### Caveats
Bring memory usage from qoi converting back into potential gigabytes again.