### PR TITLE
Revert TextureBlob deprecation

### DIFF
--- a/UndertaleModLib/Models/UndertaleTexturePageItem.cs
+++ b/UndertaleModLib/Models/UndertaleTexturePageItem.cs
@@ -145,7 +145,7 @@ namespace UndertaleModLib.Models
                 g.DrawImage(finalImage, SourceX, SourceY);
                 g.Dispose();
 
-                TexturePage.TextureData.Image = embImage;
+                TexturePage.TextureData.TextureBlob = TextureWorker.GetImageBytes(embImage);
                 worker.Cleanup();
             }
 

--- a/UndertaleModLib/Util/TextureWorker.cs
+++ b/UndertaleModLib/Util/TextureWorker.cs
@@ -26,8 +26,8 @@ namespace UndertaleModLib.Util
         {
             lock (embeddedDictionary)
             {
-                if(!embeddedDictionary.ContainsKey(embeddedTexture))
-                    embeddedDictionary[embeddedTexture] = embeddedTexture.TextureData.Image;
+                if (!embeddedDictionary.ContainsKey(embeddedTexture))
+                    embeddedDictionary[embeddedTexture] = GetImageFromByteArray(embeddedTexture.TextureData.TextureBlob);
                 return embeddedDictionary[embeddedTexture];
             }
         }

--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -158,6 +158,7 @@ namespace UndertaleModTool
 
         public static Bitmap CreateSpriteBitmap(Rectangle rect, in UndertaleTexturePageItem texture, int diffW = 0, int diffH = 0, bool isTile = false)
         {
+            using MemoryStream stream = new(texture.TexturePage.TextureData.TextureBlob);
             Bitmap spriteBMP = new(rect.Width, rect.Height);
 
             rect.Width -= (diffW > 0) ? diffW : 0;
@@ -165,8 +166,11 @@ namespace UndertaleModTool
             int x = isTile ? texture.TargetX : 0;
             int y = isTile ? texture.TargetY : 0;
 
-            using Graphics g = Graphics.FromImage(spriteBMP);
-            g.DrawImage(texture.TexturePage.TextureData.Image, new Rectangle(x, y, rect.Width, rect.Height), rect, GraphicsUnit.Pixel);
+            using (Graphics g = Graphics.FromImage(spriteBMP))
+            {
+                using Image img = Image.FromStream(stream); // "ImageConverter.ConvertFrom()" does the same, except it doesn't explicitly dispose MemoryStream
+                g.DrawImage(img, new Rectangle(x, y, rect.Width, rect.Height), rect, GraphicsUnit.Pixel);
+            }
 
             return spriteBMP;
         }

--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
@@ -58,7 +58,11 @@ namespace UndertaleModTool
                         MessageBox.Show("WARNING: texture page dimensions are not powers of 2. Sprite blurring is very likely in game.", "Unexpected texture dimensions", MessageBoxButton.OK, MessageBoxImage.Warning);
                     }
 
-                    target.TextureData.Image = bmp;
+                    using (var stream = new MemoryStream())
+                    {
+                        bmp.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
+                        target.TextureData.TextureBlob = stream.ToArray();
+                    }
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Description
reverts TextureBlob deprecation from PR #886 as it's causing issues

### Caveats
increased memory usage during (de)serialization

### Notes
tested by me on Undertale 1.00 and Will You Snail? 1.42
tested by @Miepee on AM2R, DRC2 and a few others