### PR TITLE
Fix wrong StopUpdater return type

### DIFF
--- a/UndertaleModLib/Scripting/IScriptInterface.cs
+++ b/UndertaleModLib/Scripting/IScriptInterface.cs
@@ -544,9 +544,9 @@ namespace UndertaleModLib.Scripting
         /// Obsolete.
         /// </summary>
         [Obsolete("Use StopProgressBarUpdater instead!")]
-        sealed void StopUpdater ()
+        sealed Task StopUpdater ()
         {
-            StopProgressBarUpdater();
+            return StopProgressBarUpdater();
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
This fixes a wrong StopUpdater return type and thus makes some legacy scripts not crash.

### Caveats
None