### PR TITLE
Use inheritdoc on inherited attributes in models

### DIFF
--- a/UndertaleModLib/Models/UndertaleBackground.cs
+++ b/UndertaleModLib/Models/UndertaleBackground.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace UndertaleModLib.Models
 {
@@ -28,13 +23,16 @@ namespace UndertaleModLib.Models
             /// </summary>
             public uint ID { get => _ID; set { _ID = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ID))); } }
 
+            /// <inheritdoc />
             public event PropertyChangedEventHandler PropertyChanged;
 
+            /// <inheritdoc />
             public void Serialize(UndertaleWriter writer)
             {
                 writer.Write(ID);
             }
 
+            /// <inheritdoc />
             public void Unserialize(UndertaleReader reader)
             {
                 ID = reader.ReadUInt32();
@@ -122,6 +120,7 @@ namespace UndertaleModLib.Models
         /// </summary>
         public List<TileID> GMS2TileIds { get; set; } = new List<TileID>();
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.WriteUndertaleString(Name);
@@ -148,6 +147,7 @@ namespace UndertaleModLib.Models
             }
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             Name = reader.ReadUndertaleString();
@@ -177,6 +177,7 @@ namespace UndertaleModLib.Models
             }
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return Name.Content + " (" + GetType().Name + ")";

--- a/UndertaleModLib/Models/UndertaleEmbeddedAudio.cs
+++ b/UndertaleModLib/Models/UndertaleEmbeddedAudio.cs
@@ -1,11 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace UndertaleModLib.Models
 {
@@ -25,18 +19,21 @@ namespace UndertaleModLib.Models
         /// </summary>
         public byte[] Data { get; set; } = Array.Empty<byte>();
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.Write((uint)Data.Length);
             writer.Write(Data);
         }
 
+        /// <inheritdoc />
         public void SerializePadding(UndertaleWriter writer)
         {
             while (writer.Position % 4 != 0)
                 writer.Write((byte)0);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             uint len = reader.ReadUInt32();
@@ -44,6 +41,7 @@ namespace UndertaleModLib.Models
             Util.DebugUtil.Assert(Data.Length == len);
         }
 
+        /// <inheritdoc />
         public void UnserializePadding(UndertaleReader reader)
         {
             while (reader.Position % 4 != 0)
@@ -51,6 +49,7 @@ namespace UndertaleModLib.Models
                     throw new IOException("Padding error!");
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             try

--- a/UndertaleModLib/Models/UndertaleEmbeddedImage.cs
+++ b/UndertaleModLib/Models/UndertaleEmbeddedImage.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace UndertaleModLib.Models
+﻿namespace UndertaleModLib.Models
 {
     // Not to be confused with the other "embedded" resources, this is a bit separate.
     // GMS2 only, see https://github.com/krzys-h/UndertaleModTool/issues/4#issuecomment-421844420 for rough structure, but doesn't appear commonly used
@@ -13,22 +7,21 @@ namespace UndertaleModLib.Models
         public UndertaleString Name { get; set; }
         public UndertaleTexturePageItem TextureEntry { get; set; }
 
-        public UndertaleEmbeddedImage()
-        {
-        }
-
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.WriteUndertaleString(Name);
             writer.WriteUndertaleObjectPointer(TextureEntry);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             Name = reader.ReadUndertaleString();
             TextureEntry = reader.ReadUndertaleObjectPointer<UndertaleTexturePageItem>();
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return Name.Content + " (" + GetType().Name + ")";

--- a/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
+++ b/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
@@ -1,13 +1,11 @@
 ﻿using ICSharpCode.SharpZipLib.BZip2;
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using UndertaleModLib.Util;
 
 namespace UndertaleModLib.Models
@@ -24,7 +22,7 @@ namespace UndertaleModLib.Models
         public UndertaleString Name { get; set; }
 
         /// <summary>
-        /// Whether or not this embedded texture is scaled.
+        /// Whether or not this embedded texture is scaled. TODO: i think this is wrong?
         /// </summary>
         public uint Scaled { get; set; } = 0;
 
@@ -41,6 +39,7 @@ namespace UndertaleModLib.Models
         /// </summary>
         public TexData TextureData { get; set; } = new TexData();
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.Write(Scaled);
@@ -51,6 +50,7 @@ namespace UndertaleModLib.Models
             writer.WriteUndertaleObjectPointer(TextureData);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             Scaled = reader.ReadUInt32();
@@ -87,6 +87,7 @@ namespace UndertaleModLib.Models
             reader.ReadUndertaleObject(TextureData);
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             if (Name != null)
@@ -108,12 +109,14 @@ namespace UndertaleModLib.Models
             /// </summary>
             public byte[] TextureBlob { get => _TextureBlob; set { _TextureBlob = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(TextureBlob))); } }
 
+            /// <inheritdoc />
             public event PropertyChangedEventHandler PropertyChanged;
 
             private static readonly byte[] PNGHeader = new byte[8] { 137, 80, 78, 71, 13, 10, 26, 10 };
             private static readonly byte[] QOIandBZipHeader = new byte[4] { 50, 122, 111, 113 };
             private static readonly byte[] QOIHeader = new byte[4] { 102, 105, 111, 113 };
 
+            /// <inheritdoc />
             public void Serialize(UndertaleWriter writer)
             {
                 if (writer.undertaleData.UseQoiFormat)
@@ -143,6 +146,7 @@ namespace UndertaleModLib.Models
                     writer.Write(TextureBlob);
             }
 
+            /// <inheritdoc />
             public void Unserialize(UndertaleReader reader)
             {
                 uint startAddress = reader.Position;

--- a/UndertaleModLib/Models/UndertaleFilterEffect.cs
+++ b/UndertaleModLib/Models/UndertaleFilterEffect.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace UndertaleModLib.Models
+﻿namespace UndertaleModLib.Models
 {
     [PropertyChanged.AddINotifyPropertyChangedInterface]
     public class UndertaleFilterEffect : UndertaleNamedResource
@@ -12,18 +6,21 @@ namespace UndertaleModLib.Models
         public UndertaleString Name { get; set; }
         public UndertaleString Value { get; set; }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.WriteUndertaleString(Name);
             writer.WriteUndertaleString(Value);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             Name = reader.ReadUndertaleString();
             Value = reader.ReadUndertaleString();
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return Name.Content + " (" + GetType().Name + ")";

--- a/UndertaleModLib/Models/UndertaleFont.cs
+++ b/UndertaleModLib/Models/UndertaleFont.cs
@@ -1,9 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace UndertaleModLib.Models
 {
@@ -133,6 +128,7 @@ namespace UndertaleModLib.Models
 
             public UndertaleSimpleListShort<GlyphKerning> Kerning { get; set; } = new UndertaleSimpleListShort<GlyphKerning>();
 
+            /// <inheritdoc />
             public void Serialize(UndertaleWriter writer)
             {
                 writer.Write(Character);
@@ -145,6 +141,7 @@ namespace UndertaleModLib.Models
                 writer.WriteUndertaleObject(Kerning);
             }
 
+            /// <inheritdoc />
             public void Unserialize(UndertaleReader reader)
             {
                 Character = reader.ReadUInt16();
@@ -162,12 +159,14 @@ namespace UndertaleModLib.Models
                 public short Other;
                 public short Amount;
 
+                /// <inheritdoc />
                 public void Serialize(UndertaleWriter writer)
                 {
                     writer.Write(Other);
                     writer.Write(Amount);
                 }
 
+                /// <inheritdoc />
                 public void Unserialize(UndertaleReader reader)
                 {
                     Other = reader.ReadInt16();
@@ -176,6 +175,7 @@ namespace UndertaleModLib.Models
             }
         }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.WriteUndertaleString(Name);
@@ -207,6 +207,7 @@ namespace UndertaleModLib.Models
             writer.WriteUndertaleObject(Glyphs);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             Name = reader.ReadUndertaleString();
@@ -238,6 +239,7 @@ namespace UndertaleModLib.Models
             Glyphs = reader.ReadUndertaleObject<UndertalePointerList<Glyph>>();
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return Name.Content + " (" + GetType().Name + ")";

--- a/UndertaleModLib/Models/UndertaleGlobalInit.cs
+++ b/UndertaleModLib/Models/UndertaleGlobalInit.cs
@@ -20,13 +20,16 @@ namespace UndertaleModLib.Models
         /// </summary>
         public UndertaleCode Code { get => _Code.Resource; set { _Code.Resource = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Code))); } }
 
+        /// <inheritdoc />
         public event PropertyChangedEventHandler PropertyChanged;
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             _Code.Serialize(writer);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             _Code = new UndertaleResourceById<UndertaleCode, UndertaleChunkCODE>();

--- a/UndertaleModLib/Models/UndertalePath.cs
+++ b/UndertaleModLib/Models/UndertalePath.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace UndertaleModLib.Models
+﻿namespace UndertaleModLib.Models
 {
     [PropertyChanged.AddINotifyPropertyChangedInterface]
     public class UndertalePath : UndertaleNamedResource
@@ -23,6 +16,7 @@ namespace UndertaleModLib.Models
             public float Y { get; set; }
             public float Speed { get; set; }
 
+            /// <inheritdoc />
             public void Serialize(UndertaleWriter writer)
             {
                 writer.Write(X);
@@ -30,6 +24,7 @@ namespace UndertaleModLib.Models
                 writer.Write(Speed);
             }
 
+            /// <inheritdoc />
             public void Unserialize(UndertaleReader reader)
             {
                 X = reader.ReadSingle();
@@ -38,6 +33,7 @@ namespace UndertaleModLib.Models
             }
         }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.WriteUndertaleString(Name);
@@ -47,6 +43,7 @@ namespace UndertaleModLib.Models
             writer.WriteUndertaleObject(Points);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             Name = reader.ReadUndertaleString();
@@ -56,6 +53,7 @@ namespace UndertaleModLib.Models
             Points = reader.ReadUndertaleObject<UndertaleSimpleList<PathPoint>>();
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return Name.Content + " (" + GetType().Name + ")";

--- a/UndertaleModLib/Models/UndertaleScript.cs
+++ b/UndertaleModLib/Models/UndertaleScript.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.ComponentModel;
 
 namespace UndertaleModLib.Models
 {
@@ -27,10 +22,12 @@ namespace UndertaleModLib.Models
         /// <summary>
         /// Whether or not this script is a constructor.
         /// </summary>
-        public bool IsConstructor { get; set; } = false;
+        public bool IsConstructor { get; set; }
 
+        /// <inheritdoc />
         public event PropertyChangedEventHandler PropertyChanged;
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.WriteUndertaleString(Name);
@@ -40,6 +37,7 @@ namespace UndertaleModLib.Models
                 writer.WriteUndertaleObject(_Code);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             Name = reader.ReadUndertaleString();
@@ -52,6 +50,7 @@ namespace UndertaleModLib.Models
             _Code.UnserializeById(reader, id);
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return Name.Content + " (" + GetType().Name + ")";

--- a/UndertaleModLib/Models/UndertaleSequence.cs
+++ b/UndertaleModLib/Models/UndertaleSequence.cs
@@ -1,10 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace UndertaleModLib.Models
 {
@@ -31,6 +27,7 @@ namespace UndertaleModLib.Models
         public UndertaleSimpleList<Track> Tracks { get; set; }
         public Dictionary<int, UndertaleString> FunctionIDs { get; set; }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.WriteUndertaleString(Name);
@@ -56,6 +53,7 @@ namespace UndertaleModLib.Models
             Moments.Serialize(writer);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             Name = reader.ReadUndertaleString();
@@ -90,6 +88,7 @@ namespace UndertaleModLib.Models
             public bool Disabled { get; set; }
             public Dictionary<int, T> Channels { get; set; }
 
+            /// <inheritdoc />
             public void Serialize(UndertaleWriter writer)
             {
                 writer.Write(Key);
@@ -104,6 +103,7 @@ namespace UndertaleModLib.Models
                 }
             }
 
+            /// <inheritdoc />
             public void Unserialize(UndertaleReader reader)
             {
                 Key = reader.ReadSingle();
@@ -126,23 +126,26 @@ namespace UndertaleModLib.Models
         {
             public UndertaleSimpleListString Messages;
 
+            /// <inheritdoc />
             public void Serialize(UndertaleWriter writer)
             {
                 Messages.Serialize(writer);
             }
 
+            /// <inheritdoc />
             public void Unserialize(UndertaleReader reader)
             {
                 Messages = new UndertaleSimpleListString();
                 Messages.Unserialize(reader);
             }
         }
-        
+
         public class Moment : UndertaleObject
         {
             public int InternalCount; // Should be 0 if none, 1 if there's a message?
             public UndertaleString Event;
 
+            /// <inheritdoc />
             public void Serialize(UndertaleWriter writer)
             {
                 writer.Write(InternalCount);
@@ -150,6 +153,7 @@ namespace UndertaleModLib.Models
                     writer.WriteUndertaleString(Event);
             }
 
+            /// <inheritdoc />
             public void Unserialize(UndertaleReader reader)
             {
                 InternalCount = reader.ReadInt32();
@@ -172,6 +176,7 @@ namespace UndertaleModLib.Models
 
             public UndertaleString GMAnimCurveString;
 
+            /// <inheritdoc />
             public void Serialize(UndertaleWriter writer)
             {
                 writer.WriteUndertaleString(ModelName);
@@ -238,6 +243,7 @@ namespace UndertaleModLib.Models
                 }
             }
 
+            /// <inheritdoc />
             public void Unserialize(UndertaleReader reader)
             {
                 // This reads the string content immediately, if necessary (which it should be)
@@ -322,12 +328,14 @@ namespace UndertaleModLib.Models
 
         public class TrackKeyframes : UndertaleObject
         {
+            /// <inheritdoc />
             public virtual void Serialize(UndertaleWriter writer)
             {
                 while (writer.Position % 4 != 0)
                     writer.Write((byte)0);
             }
 
+            /// <inheritdoc />
             public virtual void Unserialize(UndertaleReader reader)
             {
                 while (reader.Position % 4 != 0)
@@ -340,11 +348,13 @@ namespace UndertaleModLib.Models
         {
             public T Resource { get; set; }
 
+            /// <inheritdoc />
             public virtual void Serialize(UndertaleWriter writer)
             {
                 Resource.Serialize(writer);
             }
 
+            /// <inheritdoc />
             public virtual void Unserialize(UndertaleReader reader)
             {
                 Resource = new T();
@@ -358,6 +368,7 @@ namespace UndertaleModLib.Models
             {
                 public int Mode { get; set; }
 
+                /// <inheritdoc />
                 public override void Serialize(UndertaleWriter writer)
                 {
                     base.Serialize(writer);
@@ -365,6 +376,7 @@ namespace UndertaleModLib.Models
                     writer.Write(Mode);
                 }
 
+                /// <inheritdoc />
                 public override void Unserialize(UndertaleReader reader)
                 {
                     base.Unserialize(reader);
@@ -376,12 +388,14 @@ namespace UndertaleModLib.Models
 
             public UndertaleSimpleList<Keyframe<Data>> List;
 
+            /// <inheritdoc />
             public override void Serialize(UndertaleWriter writer)
             {
                 base.Serialize(writer);
                 List.Serialize(writer);
             }
 
+            /// <inheritdoc />
             public override void Unserialize(UndertaleReader reader)
             {
                 base.Unserialize(reader);
@@ -395,12 +409,14 @@ namespace UndertaleModLib.Models
             public class Data : ResourceData<UndertaleResourceById<UndertaleGameObject, UndertaleChunkOBJT>> { }
             public UndertaleSimpleList<Keyframe<Data>> List;
 
+            /// <inheritdoc />
             public override void Serialize(UndertaleWriter writer)
             {
                 base.Serialize(writer);
                 List.Serialize(writer);
             }
 
+            /// <inheritdoc />
             public override void Unserialize(UndertaleReader reader)
             {
                 base.Unserialize(reader);
@@ -414,12 +430,14 @@ namespace UndertaleModLib.Models
             public class Data : ResourceData<UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT>> { }
             public UndertaleSimpleList<Keyframe<Data>> List;
 
+            /// <inheritdoc />
             public override void Serialize(UndertaleWriter writer)
             {
                 base.Serialize(writer);
                 List.Serialize(writer);
             }
 
+            /// <inheritdoc />
             public override void Unserialize(UndertaleReader reader)
             {
                 base.Unserialize(reader);
@@ -433,12 +451,14 @@ namespace UndertaleModLib.Models
             public class Data : ResourceData<UndertaleResourceById<UndertaleSequence, UndertaleChunkSEQN>> { }
             public UndertaleSimpleList<Keyframe<Data>> List;
 
+            /// <inheritdoc />
             public override void Serialize(UndertaleWriter writer)
             {
                 base.Serialize(writer);
                 List.Serialize(writer);
             }
 
+            /// <inheritdoc />
             public override void Unserialize(UndertaleReader reader)
             {
                 base.Unserialize(reader);
@@ -451,11 +471,13 @@ namespace UndertaleModLib.Models
         {
             public int Value { get; set; }
 
+            /// <inheritdoc />
             public void Serialize(UndertaleWriter writer)
             {
                 writer.Write(Value);
             }
 
+            /// <inheritdoc />
             public void Unserialize(UndertaleReader reader)
             {
                 Value = reader.ReadInt32();
@@ -466,12 +488,14 @@ namespace UndertaleModLib.Models
         {
             public UndertaleSimpleList<Keyframe<SpriteFramesData>> List;
 
+            /// <inheritdoc />
             public override void Serialize(UndertaleWriter writer)
             {
                 base.Serialize(writer);
                 List.Serialize(writer);
             }
 
+            /// <inheritdoc />
             public override void Unserialize(UndertaleReader reader)
             {
                 base.Unserialize(reader);
@@ -484,11 +508,13 @@ namespace UndertaleModLib.Models
         {
             public int Value { get; set; }
 
+            /// <inheritdoc />
             public void Serialize(UndertaleWriter writer)
             {
                 writer.Write(Value);
             }
 
+            /// <inheritdoc />
             public void Unserialize(UndertaleReader reader)
             {
                 Value = reader.ReadInt32();
@@ -499,12 +525,14 @@ namespace UndertaleModLib.Models
         {
             public UndertaleSimpleList<Keyframe<BoolData>> List;
 
+            /// <inheritdoc />
             public override void Serialize(UndertaleWriter writer)
             {
                 base.Serialize(writer);
                 List.Serialize(writer);
             }
 
+            /// <inheritdoc />
             public override void Unserialize(UndertaleReader reader)
             {
                 base.Unserialize(reader);
@@ -517,11 +545,13 @@ namespace UndertaleModLib.Models
         {
             public UndertaleString Value { get; set; }
 
+            /// <inheritdoc />
             public void Serialize(UndertaleWriter writer)
             {
                 writer.WriteUndertaleString(Value);
             }
 
+            /// <inheritdoc />
             public void Unserialize(UndertaleReader reader)
             {
                 Value = reader.ReadUndertaleString();
@@ -532,12 +562,14 @@ namespace UndertaleModLib.Models
         {
             public UndertaleSimpleList<Keyframe<StringData>> List;
 
+            /// <inheritdoc />
             public override void Serialize(UndertaleWriter writer)
             {
                 base.Serialize(writer);
                 List.Serialize(writer);
             }
 
+            /// <inheritdoc />
             public override void Unserialize(UndertaleReader reader)
             {
                 base.Unserialize(reader);
@@ -551,7 +583,8 @@ namespace UndertaleModLib.Models
             public bool IsCurveEmbedded { get; set; }
             public UndertaleAnimationCurve EmbeddedAnimCurve { get; set; }
             public UndertaleResourceById<UndertaleAnimationCurve, UndertaleChunkACRV> AssetAnimCurve { get; set; }
-            
+
+            /// <inheritdoc />
             public virtual void Serialize(UndertaleWriter writer)
             {
                 writer.Write(IsCurveEmbedded);
@@ -566,6 +599,7 @@ namespace UndertaleModLib.Models
                 }
             }
 
+            /// <inheritdoc />
             public virtual void Unserialize(UndertaleReader reader)
             {
                 if (reader.ReadBoolean())
@@ -591,12 +625,14 @@ namespace UndertaleModLib.Models
         {
             public int Value { get; set; }
 
+            /// <inheritdoc />
             public override void Serialize(UndertaleWriter writer)
             {
                 writer.Write(Value);
                 base.Serialize(writer);
             }
 
+            /// <inheritdoc />
             public override void Unserialize(UndertaleReader reader)
             {
                 Value = reader.ReadInt32();
@@ -609,6 +645,7 @@ namespace UndertaleModLib.Models
             public UndertaleSimpleList<Keyframe<IntData>> List;
             public int Interpolation;
 
+            /// <inheritdoc />
             public override void Serialize(UndertaleWriter writer)
             {
                 base.Serialize(writer);
@@ -618,6 +655,7 @@ namespace UndertaleModLib.Models
                 List.Serialize(writer);
             }
 
+            /// <inheritdoc />
             public override void Unserialize(UndertaleReader reader)
             {
                 base.Unserialize(reader);
@@ -633,12 +671,14 @@ namespace UndertaleModLib.Models
         {
             public float Value { get; set; }
 
+            /// <inheritdoc />
             public override void Serialize(UndertaleWriter writer)
             {
                 writer.Write(Value);
                 base.Serialize(writer);
             }
 
+            /// <inheritdoc />
             public override void Unserialize(UndertaleReader reader)
             {
                 Value = reader.ReadSingle();
@@ -651,6 +691,7 @@ namespace UndertaleModLib.Models
             public UndertaleSimpleList<Keyframe<RealData>> List;
             public int Interpolation;
 
+            /// <inheritdoc />
             public override void Serialize(UndertaleWriter writer)
             {
                 base.Serialize(writer);
@@ -660,6 +701,7 @@ namespace UndertaleModLib.Models
                 List.Serialize(writer);
             }
 
+            /// <inheritdoc />
             public override void Unserialize(UndertaleReader reader)
             {
                 base.Unserialize(reader);

--- a/UndertaleModLib/Models/UndertaleShader.cs
+++ b/UndertaleModLib/Models/UndertaleShader.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.ComponentModel;
-
-namespace UndertaleModLib.Models
+﻿namespace UndertaleModLib.Models
 {
     /// <summary>
     /// A shader entry for a data file.
@@ -24,11 +17,13 @@ namespace UndertaleModLib.Models
             /// </summary>
             public UndertaleString Name { get; set; }
 
+            /// <inheritdoc />
             public void Serialize(UndertaleWriter writer)
             {
                 writer.WriteUndertaleString(Name);
             }
 
+            /// <inheritdoc />
             public void Unserialize(UndertaleReader reader)
             {
                 Name = reader.ReadUndertaleString();
@@ -47,10 +42,12 @@ namespace UndertaleModLib.Models
         /// </summary>
         public ShaderType Type { get; set; }
 
+        //TODO: these all should get renamed properly akin to naming conventions.
         /// <summary>
         /// The GLSL ES vertex code this shader uses.
         /// </summary>
         public UndertaleString GLSL_ES_Vertex { get; set; }
+
 
         /// <summary>
         /// The GLSL ES fragment code this shader uses.

--- a/UndertaleModLib/Models/UndertaleShader.cs
+++ b/UndertaleModLib/Models/UndertaleShader.cs
@@ -102,6 +102,7 @@ namespace UndertaleModLib.Models
             Cg_PS3_PixelData = new UndertaleRawShaderData();
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return Name.Content + " (" + GetType().Name + ")";
@@ -124,6 +125,7 @@ namespace UndertaleModLib.Models
             }
         }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.WriteUndertaleString(Name);
@@ -210,6 +212,7 @@ namespace UndertaleModLib.Models
             }
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             Name = reader.ReadUndertaleString();

--- a/UndertaleModLib/Models/UndertaleSound.cs
+++ b/UndertaleModLib/Models/UndertaleSound.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace UndertaleModLib.Models
 {
@@ -63,7 +59,7 @@ namespace UndertaleModLib.Models
         /// </summary>
         /// <remarks>The exact way this works is unknown. But following values are possible:
         /// <c>Chorus</c>, <c>Echo</c>, <c>Flanger</c>, <c>Reverb</c>, <c>Gargle</c>, all possible to be combined with one another.</remarks>
-        public uint Effects { get; set; } = 0;
+        public uint Effects { get; set; }
 
         /// <summary>
         /// The volume the audio entry is played at.
@@ -103,8 +99,10 @@ namespace UndertaleModLib.Models
         /// </summary>
         public int GroupID { get => _AudioGroup.CachedId; set { _AudioGroup.CachedId = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(GroupID))); } }
 
+        /// <inheritdoc />
         public event PropertyChangedEventHandler PropertyChanged;
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.WriteUndertaleString(Name);
@@ -125,6 +123,7 @@ namespace UndertaleModLib.Models
                 writer.Write(_AudioFile.CachedId);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             Name = reader.ReadUndertaleString();
@@ -157,6 +156,7 @@ namespace UndertaleModLib.Models
             }
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return Name.Content + " (" + GetType().Name + ")";
@@ -174,16 +174,19 @@ namespace UndertaleModLib.Models
         /// </summary>
         public UndertaleString Name { get; set; }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.WriteUndertaleString(Name);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             Name = reader.ReadUndertaleString();
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return Name.Content + " (" + GetType().Name + ")";

--- a/UndertaleModLib/Models/UndertaleSprite.cs
+++ b/UndertaleModLib/Models/UndertaleSprite.cs
@@ -1,12 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace UndertaleModLib.Models
 {
@@ -23,6 +20,7 @@ namespace UndertaleModLib.Models
         public int PageHeight { get; set; }
         public byte[] PNGBlob { get; set; }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.Write(PageWidth);
@@ -31,6 +29,7 @@ namespace UndertaleModLib.Models
             writer.Write(PNGBlob);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             PageWidth = reader.ReadInt32();
@@ -38,6 +37,7 @@ namespace UndertaleModLib.Models
             PNGBlob = reader.ReadBytes(reader.ReadInt32());
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return $"UndertaleSpineTextureEntry ({PageWidth};{PageHeight})";
@@ -99,8 +99,14 @@ namespace UndertaleModLib.Models
         /// </summary>
         public bool Preload { get; set; }
 
-
+        /// <summary>
+        /// The bounding box mode of the sprite. TODO: double check if the possible values here are automatic, full image and manual
+        /// </summary>
         public uint BBoxMode { get; set; }
+
+        /// <summary>
+        /// The separation mask type this sprite has.
+        /// </summary>
         public SepMaskType SepMasks { get; set; }
 
 
@@ -185,8 +191,10 @@ namespace UndertaleModLib.Models
 
         public NineSlice V3NineSlice;
 
+        /// <inheritdoc />
         public event PropertyChangedEventHandler PropertyChanged;
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return Name.Content + " (" + GetType().Name + ")";
@@ -234,11 +242,13 @@ namespace UndertaleModLib.Models
         {
             public UndertaleTexturePageItem Texture { get; set; }
 
+            /// <inheritdoc />
             public void Serialize(UndertaleWriter writer)
             {
                 writer.WriteUndertaleObjectPointer(Texture);
             }
 
+            /// <inheritdoc />
             public void Unserialize(UndertaleReader reader)
             {
                 Texture = reader.ReadUndertaleObjectPointer<UndertaleTexturePageItem>();
@@ -260,6 +270,7 @@ namespace UndertaleModLib.Models
             }
         }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.WriteUndertaleString(Name);
@@ -429,6 +440,7 @@ namespace UndertaleModLib.Models
             return blob;
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             Name = reader.ReadUndertaleString();
@@ -587,11 +599,13 @@ namespace UndertaleModLib.Models
             return dataBytes;
         }
 
+        /// <inheritdoc />
         public void SerializePrePadding(UndertaleWriter writer)
         {
             writer.Align(4);
         }
 
+        /// <inheritdoc />
         public void UnserializePrePadding(UndertaleReader reader)
         {
             reader.Align(4);
@@ -616,6 +630,7 @@ namespace UndertaleModLib.Models
                 Hide = 4
             }
 
+            /// <inheritdoc />
             public void Serialize(UndertaleWriter writer)
             {
                 writer.Write(Left);
@@ -627,6 +642,7 @@ namespace UndertaleModLib.Models
                     writer.Write((int)TileModes[i]);
             }
 
+            /// <inheritdoc />
             public void Unserialize(UndertaleReader reader)
             {
                 Left = reader.ReadInt32();
@@ -641,15 +657,15 @@ namespace UndertaleModLib.Models
     }
 
     /// <summary>
-    /// Some dirty hacks to make SWF work, they'll be removed later.
+    /// Some dirty hacks to make SWF work, they'll be removed later. TODO:
     /// </summary>
     public static class UndertaleYYSWFUtils
     {
         /// <summary>
         /// Reads an object ignoring the Reader's object pool.
         /// </summary>
-        /// <typeparam name="T">UndertaleObject's child</typeparam>
-        /// <param name="reader">An instance of UndertaleReader</param>
+        /// <typeparam name="T"><see cref="UndertaleObject"/>'s child.</typeparam>
+        /// <param name="reader">An instance of <see cref="UndertaleReader"/>.</param>
         /// <returns>The object</returns>
         public static T ReadUndertaleObjectNoPool<T>(this UndertaleReader reader) where T : UndertaleObject, new()
         {
@@ -667,6 +683,7 @@ namespace UndertaleModLib.Models
         public int[] Additive { get; set; }
         public int[] Multiply { get; set; }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             foreach (int v in Additive)
@@ -675,6 +692,7 @@ namespace UndertaleModLib.Models
                 writer.Write(v);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             Additive = new int[MATRIX_SIZE];
@@ -692,12 +710,14 @@ namespace UndertaleModLib.Models
         private const int MATRIX_SIZE = 9;
         public float[] Values { get; set; }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             foreach (float v in Values)
                 writer.Write(v);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             Values = new float[MATRIX_SIZE];
@@ -720,6 +740,7 @@ namespace UndertaleModLib.Models
         public float MinY { get; set; }
         public float MaxY { get; set; }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.Write(CharID);
@@ -734,6 +755,7 @@ namespace UndertaleModLib.Models
             writer.WriteUndertaleObject(TransformationMatrix);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             CharID = reader.ReadInt32();
@@ -758,6 +780,7 @@ namespace UndertaleModLib.Models
         public float MinY { get; set; }
         public float MaxY { get; set; }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.Write(FrameObjects.Count);
@@ -771,6 +794,7 @@ namespace UndertaleModLib.Models
             }
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             int ii = reader.ReadInt32();
@@ -792,6 +816,7 @@ namespace UndertaleModLib.Models
     {
         public byte[] RLEData { get; set; } // heavily compressed and pre-processed!
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             /*
@@ -811,6 +836,7 @@ namespace UndertaleModLib.Models
             writer.Align(4);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             int rlelen = reader.ReadInt32();
@@ -864,6 +890,7 @@ namespace UndertaleModLib.Models
         public byte Blue { get; set; }
         public byte Alpha { get; set; }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.Write(Red);
@@ -872,6 +899,7 @@ namespace UndertaleModLib.Models
             writer.Write(Alpha);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             Red = reader.ReadByte();
@@ -890,6 +918,7 @@ namespace UndertaleModLib.Models
         public byte Blue { get; set; }
         public byte Alpha { get; set; }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.Write(Ratio);
@@ -899,6 +928,7 @@ namespace UndertaleModLib.Models
             writer.Write(Alpha);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             Ratio = reader.ReadInt32();
@@ -916,6 +946,7 @@ namespace UndertaleModLib.Models
         public UndertaleYYSWFMatrix33 TransformationMatrix { get; set; }
         public UndertaleSimpleList<UndertaleYYSWFGradientRecord> Records { get; set; }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.Write((int)GradientFillType);
@@ -923,6 +954,7 @@ namespace UndertaleModLib.Models
             writer.WriteUndertaleObject(Records);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             GradientFillType = (UndertaleYYSWFGradientFillType)reader.ReadInt32();
@@ -943,6 +975,7 @@ namespace UndertaleModLib.Models
         public int CharID { get; set; }
         public UndertaleYYSWFMatrix33 TransformationMatrix { get; set; }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.Write((int)BitmapFillType);
@@ -950,6 +983,7 @@ namespace UndertaleModLib.Models
             writer.WriteUndertaleObject(TransformationMatrix);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             BitmapFillType = (UndertaleYYSWFBitmapFillType)reader.ReadInt32();
@@ -966,6 +1000,7 @@ namespace UndertaleModLib.Models
         public UndertaleYYSWFGradientFillData GradientFillData { get; set; }
         public UndertaleYYSWFSolidFillData SolidFillData { get; set; }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.Write((int)Type);
@@ -997,6 +1032,7 @@ namespace UndertaleModLib.Models
             }
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             Type = (UndertaleYYSWFFillType)reader.ReadInt32();
@@ -1038,6 +1074,7 @@ namespace UndertaleModLib.Models
         public byte Blue { get; set; }
         public byte Alpha { get; set; }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.Write(Red);
@@ -1046,6 +1083,7 @@ namespace UndertaleModLib.Models
             writer.Write(Alpha);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             Red = reader.ReadByte();
@@ -1054,6 +1092,7 @@ namespace UndertaleModLib.Models
             Alpha = reader.ReadByte();
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return $"UndertaleYYSWFLineStyleData ({Red};{Green};{Blue};{Alpha})";
@@ -1066,18 +1105,21 @@ namespace UndertaleModLib.Models
         public int X { get; set; }
         public int Y { get; set; }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.Write(X);
             writer.Write(Y);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             X = reader.ReadInt32();
             Y = reader.ReadInt32();
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return $"UndertaleYYSWFVector2 ({X};{Y})";
@@ -1090,18 +1132,21 @@ namespace UndertaleModLib.Models
         public float X { get; set; }
         public float Y { get; set; }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.Write(X);
             writer.Write(Y);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             X = reader.ReadSingle();
             Y = reader.ReadSingle();
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return $"UndertaleYYSWFVector2F ({X};{Y})";
@@ -1128,6 +1173,7 @@ namespace UndertaleModLib.Models
         public UndertaleSimpleList<UndertaleYYSWFVector2> LineAALines { get; set; }
         public UndertaleSimpleList<UndertaleYYSWFVector2F> LineAAVectors { get; set; }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.Write(FillStyleOne);
@@ -1189,6 +1235,7 @@ namespace UndertaleModLib.Models
             }
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             FillStyleOne = reader.ReadInt32();
@@ -1271,6 +1318,7 @@ namespace UndertaleModLib.Models
         public UndertaleSimpleList<UndertaleYYSWFStyleGroup> StyleGroups { get; set; }
 
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.Write(MinX);
@@ -1280,6 +1328,7 @@ namespace UndertaleModLib.Models
             writer.WriteUndertaleObject(StyleGroups);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             MinX = reader.ReadSingle();
@@ -1302,6 +1351,7 @@ namespace UndertaleModLib.Models
         public UndertaleSimpleList<UndertaleYYSWFLineStyleData> LineStyles { get; set; }
         public UndertaleSimpleList<UndertaleYYSWFSubshapeData> Subshapes { get; set; }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.Write(FillStyles.Count);
@@ -1324,6 +1374,7 @@ namespace UndertaleModLib.Models
             }
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             int f = reader.ReadInt32();
@@ -1376,6 +1427,7 @@ namespace UndertaleModLib.Models
         public byte[] ColorPaletteData { get; set; }
 
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.Write((int)Type);
@@ -1396,6 +1448,7 @@ namespace UndertaleModLib.Models
             writer.Align(4);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             Type = (UndertaleYYSWFBitmapType)reader.ReadInt32();
@@ -1431,6 +1484,7 @@ namespace UndertaleModLib.Models
             ID = -1;
         }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.Write((int)ItemType);
@@ -1452,6 +1506,7 @@ namespace UndertaleModLib.Models
             }
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             ItemType = (UndertaleYYSWFItemType)reader.ReadInt32();
@@ -1478,12 +1533,13 @@ namespace UndertaleModLib.Models
                 case UndertaleYYSWFItemType.ItemSprite:
                 default:
                 {
-                    reader.SubmitWarning("Tried to read unknown YYSWFItem, " + ItemType.ToString());
+                    reader.SubmitWarning("Tried to read unknown YYSWFItem, " + ItemType);
                     break;
                 }
             }
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return $"UndertaleYYSWFItem ({ItemType}, {ID})";
@@ -1504,6 +1560,7 @@ namespace UndertaleModLib.Models
         public UndertaleSimpleList<UndertaleYYSWFTimelineFrame> Frames { get; set; }
         public UndertaleSimpleList<UndertaleYYSWFCollisionMask> CollisionMasks { get; set; }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.WriteUndertaleObject(UsedItems);
@@ -1528,6 +1585,7 @@ namespace UndertaleModLib.Models
             }
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             //UsedItems = reader.ReadUndertaleObject<UndertaleSimpleList<UndertaleYYSWFItem>>();
@@ -1571,10 +1629,11 @@ namespace UndertaleModLib.Models
         public int Version { get; set; }
         public UndertaleYYSWFTimeline Timeline { get; set; }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.Align(4);
-            int len = (JPEGTable is null ? 0 : JPEGTable.Length) | int.MinValue;
+            int len = (JPEGTable?.Length ?? 0) | Int32.MinValue;
 
             writer.Write(len);
             writer.Write(Version);
@@ -1587,6 +1646,7 @@ namespace UndertaleModLib.Models
             writer.WriteUndertaleObject(Timeline);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             reader.Align(4);
@@ -1603,6 +1663,7 @@ namespace UndertaleModLib.Models
             Timeline = reader.ReadUndertaleObjectNoPool<UndertaleYYSWFTimeline>();
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return $"UndertaleYYSWF ({Version})";

--- a/UndertaleModLib/Models/UndertaleString.cs
+++ b/UndertaleModLib/Models/UndertaleString.cs
@@ -1,14 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-using UndertaleModLib.Decompiler;
-
-namespace UndertaleModLib.Models
+﻿namespace UndertaleModLib.Models
 {
     /// <summary>
     /// A string entry a data file can have.
@@ -37,16 +27,19 @@ namespace UndertaleModLib.Models
             this.Content = content;
         }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.WriteGMString(Content);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             Content = reader.ReadGMString();
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return ToString(true);
@@ -96,6 +89,7 @@ namespace UndertaleModLib.Models
             return res;
         }
 
+        /// <inheritdoc />
         public bool SearchMatches(string filter)
         {
             return Content?.ToLower().Contains(filter.ToLower()) ?? false;

--- a/UndertaleModLib/Models/UndertaleTags.cs
+++ b/UndertaleModLib/Models/UndertaleTags.cs
@@ -1,18 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace UndertaleModLib.Models
 {
+    /// <summary>
+    /// A tag entry in a GameMaker data file.
+    /// </summary>
     [PropertyChanged.AddINotifyPropertyChangedInterface]
     public class UndertaleTags : UndertaleObject
     {
         public UndertaleSimpleListString Tags { get; set; }
         public Dictionary<int, UndertaleSimpleListString> AssetTags { get; set; }
 
+        //TODO: condense these all into one method
         public static int GetAssetTagID(UndertaleData data, UndertaleGameObject res)
         {
             return ((int)ResourceType.Object << 24) | (data.GameObjects.IndexOf(res) & 0xFFFFFF);
@@ -74,6 +73,7 @@ namespace UndertaleModLib.Models
             return ((int)ResourceType.AnimCurve << 24) | (data.AnimationCurves.IndexOf(res) & 0xFFFFFF);
         }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             Tags.Serialize(writer);
@@ -83,6 +83,7 @@ namespace UndertaleModLib.Models
             temp.Serialize(writer);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             Tags = new UndertaleSimpleListString();
@@ -98,12 +99,14 @@ namespace UndertaleModLib.Models
             public int ID { get; set; }
             public UndertaleSimpleListString Tags { get; set; }
 
+            /// <inheritdoc />
             public void Serialize(UndertaleWriter writer)
             {
                 writer.Write(ID);
                 Tags.Serialize(writer);
             }
 
+            /// <inheritdoc />
             public void Unserialize(UndertaleReader reader)
             {
                 ID = reader.ReadInt32();

--- a/UndertaleModLib/Models/UndertaleTextureGroupInfo.cs
+++ b/UndertaleModLib/Models/UndertaleTextureGroupInfo.cs
@@ -69,6 +69,9 @@
         /// </summary>
         public UndertaleSimpleResourcesList<UndertaleBackground, UndertaleChunkBGND> Tilesets { get; set; }
 
+        /// <summary>
+        /// Initializes a new instance of <see cref="UndertaleTextureGroupInfo"/>.
+        /// </summary>
         public UndertaleTextureGroupInfo()
         {
             TexturePages = new UndertaleSimpleResourcesList<UndertaleEmbeddedTexture, UndertaleChunkTXTR>();

--- a/UndertaleModLib/Models/UndertaleTextureGroupInfo.cs
+++ b/UndertaleModLib/Models/UndertaleTextureGroupInfo.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace UndertaleModLib.Models
+﻿namespace UndertaleModLib.Models
 {
     /// <summary>
     /// A texture group info entry in a data file.
@@ -86,6 +78,7 @@ namespace UndertaleModLib.Models
             Tilesets = new UndertaleSimpleResourcesList<UndertaleBackground, UndertaleChunkBGND>();
         }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.WriteUndertaleString(Name);
@@ -103,6 +96,7 @@ namespace UndertaleModLib.Models
             writer.WriteUndertaleObject(Tilesets);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             Name = reader.ReadUndertaleString();
@@ -122,6 +116,7 @@ namespace UndertaleModLib.Models
             reader.ReadUndertaleObject(Tilesets);
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return Name.Content + " (" + GetType().Name + ")";

--- a/UndertaleModLib/Models/UndertaleTexturePageItem.cs
+++ b/UndertaleModLib/Models/UndertaleTexturePageItem.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Drawing;
 using UndertaleModLib.Util;
 
@@ -79,8 +78,10 @@ namespace UndertaleModLib.Models
         /// </summary>
         public UndertaleEmbeddedTexture TexturePage { get => _TexturePage.Resource; set { _TexturePage.Resource = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(TexturePage))); } }
 
+        /// <inheritdoc />
         public event PropertyChangedEventHandler PropertyChanged;
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.Write(SourceX);
@@ -96,6 +97,7 @@ namespace UndertaleModLib.Models
             writer.Write((short)_TexturePage.SerializeById(writer));
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             SourceX = reader.ReadUInt16();
@@ -112,6 +114,7 @@ namespace UndertaleModLib.Models
             _TexturePage.UnserializeById(reader, reader.ReadInt16()); // This one is special as it uses a short instead of int
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             try

--- a/UndertaleModLib/Models/UndertaleTimeline.cs
+++ b/UndertaleModLib/Models/UndertaleTimeline.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.ComponentModel;
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 
 namespace UndertaleModLib.Models
 {
@@ -52,11 +46,13 @@ namespace UndertaleModLib.Models
                 Event = events;
             }
 
+            /// <inheritdoc />
             public void Serialize(UndertaleWriter writer)
             {
                 // Since GM:S stores Steps first, and then Events, we can't serialize a single entry in a single function :(
             }
 
+            /// <inheritdoc />
             public void Unserialize(UndertaleReader reader)
             {
                 // Same goes for unserializing.
@@ -73,11 +69,13 @@ namespace UndertaleModLib.Models
         /// </summary>
         public ObservableCollection<UndertaleTimelineMoment> Moments { get; set; } = new ObservableCollection<UndertaleTimelineMoment>();
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return Name.Content + " (" + GetType().Name + ")";
         }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.WriteUndertaleString(Name);
@@ -99,6 +97,7 @@ namespace UndertaleModLib.Models
             }
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             Name = reader.ReadUndertaleString();

--- a/UndertaleModLib/Models/UndertaleVariable.cs
+++ b/UndertaleModLib/Models/UndertaleVariable.cs
@@ -11,17 +11,28 @@ namespace UndertaleModLib.Models
     // TODO: INotifyPropertyChanged
     public class UndertaleVariable : UndertaleNamedResource, ISearchable, UndertaleInstruction.ReferencedObject
     {
+        /// <inheritdoc />
         public UndertaleString Name { get; set; }
         public UndertaleInstruction.InstanceType InstanceType { get; set; }
         public int VarID { get; set; }
 
+        /// <inheritdoc />
         public uint Occurrences { get; set; }
+
+        /// <inheritdoc />
         public UndertaleInstruction FirstAddress { get; set; }
+
+        /// <inheritdoc />
         public int NameStringID { get; set; }
 
+        /// <summary>
+        /// OBSOLETE. This variable is now located at <see cref="NameStringID"/>.
+        /// </summary>
         [Obsolete("This variable has been renamed to NameStringID.")]
         public int UnknownChainEndingValue { get => NameStringID; set => NameStringID = value; }
 
+
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.WriteUndertaleString(Name);
@@ -34,9 +45,10 @@ namespace UndertaleModLib.Models
             if (Occurrences > 0)
                 writer.Write(writer.GetAddressForUndertaleObject(FirstAddress));
             else
-                writer.Write((int)-1);
+                writer.Write(-1);
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             Name = reader.ReadUndertaleString();
@@ -59,11 +71,13 @@ namespace UndertaleModLib.Models
             }
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return Name != null && Name.Content != null ? Name.Content : "<NULL_VAR_NAME>";
         }
 
+        /// <inheritdoc />
         public bool SearchMatches(string filter)
         {
             return Name?.SearchMatches(filter) ?? false;

--- a/UndertaleModLib/Models/UndertaleVariable.cs
+++ b/UndertaleModLib/Models/UndertaleVariable.cs
@@ -1,10 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace UndertaleModLib.Models
 {

--- a/UndertaleModLib/UndertaleBaseTypes.cs
+++ b/UndertaleModLib/UndertaleBaseTypes.cs
@@ -54,7 +54,17 @@ namespace UndertaleModLib
 
     public interface PrePaddedObject
     {
+
+        /// <summary>
+        /// TODO!
+        /// </summary>
+        /// <param name="writer">Where to serialize to.</param>
         void SerializePrePadding(UndertaleWriter writer);
+
+        /// <summary>
+        /// TODO!
+        /// </summary>
+        /// <param name="reader">Where to deserialize from.</param>
         void UnserializePrePadding(UndertaleReader reader);
     }
 

--- a/UndertaleModLib/UndertaleData.cs
+++ b/UndertaleModLib/UndertaleData.cs
@@ -194,11 +194,19 @@ namespace UndertaleModLib
         public uint VarCount2 { get => FORM.VARI.VarCount2; set => FORM.VARI.VarCount2 = value; }
 
         /// <summary>
-        /// TODO: Unknown value, need more research.
+        /// TODO: Unknown value, need more research. Also obsolete.
         /// </summary>
         public bool DifferentVarCounts { get => FORM.VARI.DifferentVarCounts; set => FORM.VARI.DifferentVarCounts = value; }
+
+        /// <summary>
+        /// TODO: Unknown value, need more research. Also obsolete.
+        /// </summary>
         [Obsolete]
         public uint InstanceVarCount { get => VarCount1; set => VarCount1 = value; }
+
+        /// <summary>
+        /// TODO: Unknown value, need more research. Also obsolete.
+        /// </summary>
         [Obsolete]
         public uint InstanceVarCountAgain { get => VarCount2; set => VarCount2 = value; }
 
@@ -243,6 +251,9 @@ namespace UndertaleModLib
         /// </summary>
         public IList<UndertaleEmbeddedAudio> EmbeddedAudio => FORM.AUDO?.List;
 
+        /// <summary>
+        /// The used tags of the data file.
+        /// </summary>
         public UndertaleTags Tags => FORM.TAGS?.Object;
 
         /// <summary>
@@ -304,17 +315,17 @@ namespace UndertaleModLib
         /// Whether the data file is from version GMS2022.1.
         /// </summary>
         public bool GMS2022_1 = false;
-      
+
         /// <summary>
         /// Whether the data file is from version GMS2022.2.
         /// </summary>
         public bool GMS2022_2 = false;
-      
+
         /// <summary>
         /// Whether the data file is from version GMS2022.3.
         /// </summary>
         public bool GM2022_3 = false;
-      
+
         /// <summary>
         /// Some info for the editor to store data on.
         /// </summary>
@@ -591,198 +602,6 @@ namespace UndertaleModLib
             data.BuiltinList = new BuiltinList(data);
             Decompiler.AssetTypeResolver.InitializeTypes(data);
             return data;
-        }
-    }
-
-    public static class UndertaleDataExtensionMethods
-    {
-        public static T ByName<T>(this IList<T> list, string name, bool ignoreCase = false) where T : UndertaleNamedResource
-        {
-            if (ignoreCase)
-            {
-                foreach (var item in list)
-                    if (item.Name.Content.Equals(name, StringComparison.OrdinalIgnoreCase))
-                        return item;
-            }
-            else
-            {
-                foreach (var item in list)
-                    if (item.Name.Content == name)
-                        return item;
-            }
-            return default(T);
-        }
-
-        public static UndertaleCodeLocals For(this IList<UndertaleCodeLocals> list, UndertaleCode code)
-        {
-            // TODO: I'm not sure if the runner looks these up by name or by index
-            return list.Where((x) => code.Name == x.Name).FirstOrDefault();
-        }
-
-        public static UndertaleString MakeString(this IList<UndertaleString> list, string content)
-        {
-            if (content == null)
-                throw new ArgumentNullException(nameof(content));
-
-            // TODO: without reference counting the strings, this may leave unused strings in the array
-            foreach (UndertaleString str in list)
-            {
-                if (str.Content == content)
-                    return str;
-            }
-
-            UndertaleString newString = new UndertaleString(content);
-            list.Add(newString);
-            return newString;
-        }
-
-        public static UndertaleString MakeString(this IList<UndertaleString> list, string content, out int index)
-        {
-            if (content == null)
-                throw new ArgumentNullException(nameof(content));
-
-            // TODO: without reference counting the strings, this may leave unused strings in the array
-            for (int i = 0; i < list.Count; i++)
-            {
-                UndertaleString str = list[i];
-                if (str.Content == content)
-                {
-                    index = i;
-                    return str;
-                }
-            }
-
-            UndertaleString newString = new UndertaleString(content);
-            index = list.Count;
-            list.Add(newString);
-            return newString;
-        }
-
-        public static UndertaleFunction EnsureDefined(this IList<UndertaleFunction> list, string name, IList<UndertaleString> strg, bool fast = false)
-        {
-            UndertaleFunction func = fast ? null : list.ByName(name);
-            if (func == null)
-            {
-                var str = strg.MakeString(name, out int id);
-                func = new UndertaleFunction()
-                {
-                    Name = str,
-                    NameStringID = id
-                };
-                list.Add(func);
-            }
-            return func;
-        }
-
-        public static UndertaleVariable EnsureDefined(this IList<UndertaleVariable> list, string name, UndertaleInstruction.InstanceType inst, bool isBuiltin, IList<UndertaleString> strg, UndertaleData data, bool fast = false)
-        {
-            if (inst == UndertaleInstruction.InstanceType.Local)
-                throw new InvalidOperationException("Use DefineLocal instead");
-            bool bytecode14 = (data?.GeneralInfo?.BytecodeVersion <= 14);
-            if (bytecode14)
-                inst = UndertaleInstruction.InstanceType.Undefined;
-            UndertaleVariable vari = fast ? null : list.Where((x) => x.Name?.Content == name && x.InstanceType == inst).FirstOrDefault();
-            if (vari == null)
-            {
-                var str = strg.MakeString(name, out int id);
-
-                var oldId = data.VarCount1;
-                if (!bytecode14)
-                {
-                    if (data.GMS2_3)
-                    {
-                        // GMS 2.3+
-                        if (!isBuiltin)
-                        {
-                            data.VarCount1++;
-                            data.VarCount2 = data.VarCount1;
-                        }
-                        oldId = (uint)id;
-                    }
-                    else if (!data.DifferentVarCounts)
-                    {
-                        // Bytecode 16+
-                        data.VarCount1++;
-                        data.VarCount2++;
-                    }
-                    else
-                    {
-                        // Bytecode 15
-                        if (inst == UndertaleInstruction.InstanceType.Self && !isBuiltin)
-                        {
-                            oldId = data.VarCount2;
-                            data.VarCount2++;
-                        }
-                        else if (inst == UndertaleInstruction.InstanceType.Global)
-                        {
-                            data.VarCount1++;
-                        }
-                    }
-                }
-
-                vari = new UndertaleVariable()
-                {
-                    Name = str,
-                    InstanceType = inst,
-                    VarID = bytecode14 ? 0 : (isBuiltin ? (int)UndertaleInstruction.InstanceType.Builtin : (int)oldId),
-                    NameStringID = id
-                };
-                list.Add(vari);
-            }
-            return vari;
-        }
-
-        public static UndertaleVariable DefineLocal(this IList<UndertaleVariable> list, IList<UndertaleVariable> originalReferencedLocalVars, int localId, string name, IList<UndertaleString> strg, UndertaleData data)
-        {
-            bool bytecode14 = (data?.GeneralInfo?.BytecodeVersion <= 14);
-            if (bytecode14)
-            {
-                UndertaleVariable search = list.Where((x) => x.Name.Content == name).FirstOrDefault();
-                if (search != null)
-                    return search;
-            }
-
-            // Use existing registered variables.
-            if (originalReferencedLocalVars != null)
-            {
-                UndertaleVariable refvar;
-                if (data?.GMS2_3 == true)
-                    refvar = originalReferencedLocalVars.Where((x) => x.Name.Content == name).FirstOrDefault();
-                else
-                    refvar = originalReferencedLocalVars.Where((x) => x.Name.Content == name && x.VarID == localId).FirstOrDefault();
-                if (refvar != null)
-                    return refvar;
-            }
-
-            var str = strg.MakeString(name, out int id);
-            if (data?.GMS2_3 == true)
-                localId = id;
-            UndertaleVariable vari = new UndertaleVariable()
-            {
-                Name = str,
-                InstanceType = bytecode14 ? UndertaleInstruction.InstanceType.Undefined : UndertaleInstruction.InstanceType.Local,
-                VarID = bytecode14 ? 0 : localId,
-                NameStringID = id
-            };
-            list.Add(vari);
-            return vari;
-        }
-
-        public static UndertaleExtensionFunction DefineExtensionFunction(this IList<UndertaleExtensionFunction> extfuncs, IList<UndertaleFunction> funcs, IList<UndertaleString> strg, uint id, uint kind, string name, UndertaleExtensionVarType rettype, string extname, params UndertaleExtensionVarType[] args)
-        {
-            var func = new UndertaleExtensionFunction()
-            {
-                ID = id,
-                Name = strg.MakeString(name),
-                ExtName = strg.MakeString(extname),
-                Kind = kind,
-                RetType = rettype
-            };
-            foreach(var a in args)
-                func.Arguments.Add(new UndertaleExtensionFunctionArg() { Type = a });
-            extfuncs.Add(func);
-            funcs.EnsureDefined(name, strg);
-            return func;
         }
     }
 

--- a/UndertaleModLib/UndertaleDataExtensionMethods.cs
+++ b/UndertaleModLib/UndertaleDataExtensionMethods.cs
@@ -35,9 +35,17 @@ public static class UndertaleDataExtensionMethods
 	public static UndertaleCodeLocals For(this IList<UndertaleCodeLocals> list, UndertaleCode code)
 	{
 		// TODO: I'm not sure if the runner looks these up by name or by index
-		return list.Where((x) => code.Name == x.Name).FirstOrDefault();
+		return list.FirstOrDefault(x => code.Name == x.Name);
 	}
 
+	/// <summary>
+	/// Creates <paramref name="content"/> as a new <see cref="UndertaleString"/>,
+	/// adds it to a <see cref="List{T}"/> of <see cref="UndertaleString"/> if it does not exist yet, and returns it.
+	/// </summary>
+	/// <param name="list">The <see cref="List{T}"/> of <see cref="UndertaleString"/>.</param>
+	/// <param name="content">The string to create a <see cref="UndertaleString"/> of.</param>
+	/// <returns><paramref name="content"/> as a <see cref="UndertaleString"/>.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="content"/> is null.</exception>
 	public static UndertaleString MakeString(this IList<UndertaleString> list, string content)
 	{
 		if (content == null)
@@ -55,6 +63,15 @@ public static class UndertaleDataExtensionMethods
 		return newString;
 	}
 
+	/// <summary>
+	/// Creates <paramref name="content"/> as a new <see cref="UndertaleString"/>,
+	/// adds it to a <see cref="List{T}"/> of <see cref="UndertaleString"/> if it does not exist yet, and returns it.
+	/// </summary>
+	/// <param name="list">The <see cref="List{T}"/> of <see cref="UndertaleString"/>.</param>
+	/// <param name="content">The string to create a <see cref="UndertaleString"/> of.</param>
+	/// <param name="index">The index where the newly created <see cref="UndertaleString"/> is located in <paramref name="list"/>.</param>
+	/// <returns><paramref name="content"/> as a <see cref="UndertaleString"/>.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="content"/> is null.</exception>
 	public static UndertaleString MakeString(this IList<UndertaleString> list, string content, out int index)
 	{
 		if (content == null)

--- a/UndertaleModLib/UndertaleDataExtensionMethods.cs
+++ b/UndertaleModLib/UndertaleDataExtensionMethods.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UndertaleModLib.Models;
+
+namespace UndertaleModLib;
+
+/// <summary>
+/// Extension methods for <see cref="UndertaleData"/>.
+/// </summary>
+public static class UndertaleDataExtensionMethods
+{
+	/// <summary>
+	/// An extension method, that returns the element in a <see cref="List{T}"/> of <see cref="UndertaleNamedResource"/>s
+	/// that has a specified <paramref name="name"/>.
+	/// </summary>
+	/// <param name="list">The <see cref="List{T}"/> of <see cref="UndertaleNamedResource"/>s to search in.</param>
+	/// <param name="name">The name of the <see cref="UndertaleNamedResource"/> to find.</param>
+	/// <param name="ignoreCase">Whether casing should be ignored for searching.</param>
+	/// <typeparam name="T">A type of <see cref="UndertaleNamedResource"/>.</typeparam>
+	/// <returns>The element that has the specified name.</returns>
+	public static T ByName<T>(this IList<T> list, string name, bool ignoreCase = false) where T : UndertaleNamedResource
+	{
+		StringComparison comparisonType = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+		foreach (T item in list)
+		{
+			if (item.Name.Content.Equals(name, comparisonType))
+				return item;
+		}
+
+		return default(T);
+	}
+
+	public static UndertaleCodeLocals For(this IList<UndertaleCodeLocals> list, UndertaleCode code)
+	{
+		// TODO: I'm not sure if the runner looks these up by name or by index
+		return list.Where((x) => code.Name == x.Name).FirstOrDefault();
+	}
+
+	public static UndertaleString MakeString(this IList<UndertaleString> list, string content)
+	{
+		if (content == null)
+			throw new ArgumentNullException(nameof(content));
+
+		// TODO: without reference counting the strings, this may leave unused strings in the array
+		foreach (UndertaleString str in list)
+		{
+			if (str.Content == content)
+				return str;
+		}
+
+		UndertaleString newString = new UndertaleString(content);
+		list.Add(newString);
+		return newString;
+	}
+
+	public static UndertaleString MakeString(this IList<UndertaleString> list, string content, out int index)
+	{
+		if (content == null)
+			throw new ArgumentNullException(nameof(content));
+
+		// TODO: without reference counting the strings, this may leave unused strings in the array
+		for (int i = 0; i < list.Count; i++)
+		{
+			UndertaleString str = list[i];
+			if (str.Content == content)
+			{
+				index = i;
+				return str;
+			}
+		}
+
+		UndertaleString newString = new UndertaleString(content);
+		index = list.Count;
+		list.Add(newString);
+		return newString;
+	}
+
+	public static UndertaleFunction EnsureDefined(this IList<UndertaleFunction> list, string name, IList<UndertaleString> strg, bool fast = false)
+	{
+		UndertaleFunction func = fast ? null : list.ByName(name);
+		if (func == null)
+		{
+			var str = strg.MakeString(name, out int id);
+			func = new UndertaleFunction()
+			{
+				Name = str,
+				NameStringID = id
+			};
+			list.Add(func);
+		}
+		return func;
+	}
+
+	public static UndertaleVariable EnsureDefined(this IList<UndertaleVariable> list, string name, UndertaleInstruction.InstanceType inst, bool isBuiltin, IList<UndertaleString> strg, UndertaleData data, bool fast = false)
+	{
+		if (inst == UndertaleInstruction.InstanceType.Local)
+			throw new InvalidOperationException("Use DefineLocal instead");
+		bool bytecode14 = (data?.GeneralInfo?.BytecodeVersion <= 14);
+		if (bytecode14)
+			inst = UndertaleInstruction.InstanceType.Undefined;
+		UndertaleVariable vari = fast ? null : list.Where((x) => x.Name?.Content == name && x.InstanceType == inst).FirstOrDefault();
+		if (vari == null)
+		{
+			var str = strg.MakeString(name, out int id);
+
+			var oldId = data.VarCount1;
+			if (!bytecode14)
+			{
+				if (data.GMS2_3)
+				{
+					// GMS 2.3+
+					if (!isBuiltin)
+					{
+						data.VarCount1++;
+						data.VarCount2 = data.VarCount1;
+					}
+					oldId = (uint)id;
+				}
+				else if (!data.DifferentVarCounts)
+				{
+					// Bytecode 16+
+					data.VarCount1++;
+					data.VarCount2++;
+				}
+				else
+				{
+					// Bytecode 15
+					if (inst == UndertaleInstruction.InstanceType.Self && !isBuiltin)
+					{
+						oldId = data.VarCount2;
+						data.VarCount2++;
+					}
+					else if (inst == UndertaleInstruction.InstanceType.Global)
+					{
+						data.VarCount1++;
+					}
+				}
+			}
+
+			vari = new UndertaleVariable()
+			{
+				Name = str,
+				InstanceType = inst,
+				VarID = bytecode14 ? 0 : (isBuiltin ? (int)UndertaleInstruction.InstanceType.Builtin : (int)oldId),
+				NameStringID = id
+			};
+			list.Add(vari);
+		}
+		return vari;
+	}
+
+	public static UndertaleVariable DefineLocal(this IList<UndertaleVariable> list, IList<UndertaleVariable> originalReferencedLocalVars, int localId, string name, IList<UndertaleString> strg, UndertaleData data)
+	{
+		bool bytecode14 = (data?.GeneralInfo?.BytecodeVersion <= 14);
+		if (bytecode14)
+		{
+			UndertaleVariable search = list.Where((x) => x.Name.Content == name).FirstOrDefault();
+			if (search != null)
+				return search;
+		}
+
+		// Use existing registered variables.
+		if (originalReferencedLocalVars != null)
+		{
+			UndertaleVariable refvar;
+			if (data?.GMS2_3 == true)
+				refvar = originalReferencedLocalVars.Where((x) => x.Name.Content == name).FirstOrDefault();
+			else
+				refvar = originalReferencedLocalVars.Where((x) => x.Name.Content == name && x.VarID == localId).FirstOrDefault();
+			if (refvar != null)
+				return refvar;
+		}
+
+		var str = strg.MakeString(name, out int id);
+		if (data?.GMS2_3 == true)
+			localId = id;
+		UndertaleVariable vari = new UndertaleVariable()
+		{
+			Name = str,
+			InstanceType = bytecode14 ? UndertaleInstruction.InstanceType.Undefined : UndertaleInstruction.InstanceType.Local,
+			VarID = bytecode14 ? 0 : localId,
+			NameStringID = id
+		};
+		list.Add(vari);
+		return vari;
+	}
+
+	public static UndertaleExtensionFunction DefineExtensionFunction(this IList<UndertaleExtensionFunction> extfuncs, IList<UndertaleFunction> funcs, IList<UndertaleString> strg, uint id, uint kind, string name, UndertaleExtensionVarType rettype, string extname, params UndertaleExtensionVarType[] args)
+	{
+		var func = new UndertaleExtensionFunction()
+		{
+			ID = id,
+			Name = strg.MakeString(name),
+			ExtName = strg.MakeString(extname),
+			Kind = kind,
+			RetType = rettype
+		};
+		foreach(var a in args)
+			func.Arguments.Add(new UndertaleExtensionFunctionArg() { Type = a });
+		extfuncs.Add(func);
+		funcs.EnsureDefined(name, strg);
+		return func;
+	}
+}

--- a/UndertaleModLib/UndertaleLists.cs
+++ b/UndertaleModLib/UndertaleLists.cs
@@ -13,6 +13,7 @@ namespace UndertaleModLib
 {
     public class UndertaleSimpleList<T> : ObservableCollection<T>, UndertaleObject where T : UndertaleObject, new()
     {
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.Write((uint)Count);
@@ -29,6 +30,7 @@ namespace UndertaleModLib
             }
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             uint count = reader.ReadUInt32();
@@ -49,6 +51,7 @@ namespace UndertaleModLib
 
     public class UndertaleSimpleListString : ObservableCollection<UndertaleString>, UndertaleObject
     {
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.Write((uint)Count);
@@ -65,6 +68,7 @@ namespace UndertaleModLib
             }
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             uint count = reader.ReadUInt32();
@@ -96,6 +100,7 @@ namespace UndertaleModLib
                 throw new InvalidOperationException("Count of short SimpleList exceeds maximum number allowed.");
         }
 
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.Write((ushort)Count);
@@ -112,6 +117,7 @@ namespace UndertaleModLib
             }
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             ushort count = reader.ReadUInt16();
@@ -132,6 +138,7 @@ namespace UndertaleModLib
 
     public class UndertalePointerList<T> : ObservableCollection<T>, UndertaleObject where T : UndertaleObject, new()
     {
+        /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
             writer.Write((uint)Count);
@@ -167,6 +174,7 @@ namespace UndertaleModLib
             }
         }
 
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader)
         {
             uint count = reader.ReadUInt32();
@@ -212,6 +220,7 @@ namespace UndertaleModLib
 
     public class UndertalePointerListLenCheck<T> : UndertalePointerList<T>, UndertaleObjectEndPos where T : UndertaleObjectLenCheck, new()
     {
+        /// <inheritdoc />
         public void Unserialize(UndertaleReader reader, uint endPosition)
         {
             uint count = reader.ReadUInt32();

--- a/UndertaleModLib/UndertaleLists.cs
+++ b/UndertaleModLib/UndertaleLists.cs
@@ -1,12 +1,8 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UndertaleModLib.Models;
 
 namespace UndertaleModLib


### PR DESCRIPTION
## Description
This goes through most models and uses the `inheritdoc` xml comment in order to auto-generate xml documents based on what the methods/properties are inheriting from.
Gets rid of ~100 warnings.