### PR TITLE
Change default AppdataProfiles behaviour.

### DIFF
--- a/UndertaleModCli/Program.cs
+++ b/UndertaleModCli/Program.cs
@@ -772,8 +772,6 @@ public partial class Program : IScriptInterface
         {
             using FileStream fs = datafile.OpenRead();
             UndertaleData gmData = UndertaleIO.Read(fs, warningHandler, messageHandler);
-            //TODO: this should be handled in UTCode, not here
-            gmData.ToolInfo.AppDataProfiles = "";
             return gmData;
         }
         catch (FileNotFoundException e)

--- a/UndertaleModLib/UndertaleData.cs
+++ b/UndertaleModLib/UndertaleData.cs
@@ -618,7 +618,7 @@ namespace UndertaleModLib
         /// <summary>
         /// The location of the profiles folder.
         /// </summary>
-        public string AppDataProfiles = null;
+        public string AppDataProfiles = "";
 
         /// <summary>
         /// The MD5 hash of the current file.


### PR DESCRIPTION
## Description
This changes the default `AppdataProfile` to an empty string instead of null. The result, is that anything that's trying to integrate UMTLib does not have to manually change the path to something else in order to avoid a crash.

### Caveats
None