### PR TITLE
Fix CLI warnings

### DIFF
--- a/UndertaleModCli/CommandOptions/DumpOptions.cs
+++ b/UndertaleModCli/CommandOptions/DumpOptions.cs
@@ -2,6 +2,7 @@ using System.IO;
 
 namespace UndertaleModCli;
 
+// ReSharper disable NotNullMemberIsNotInitialized - Properties are applied via reflection.
 /// <summary>
 /// Cli options for the Dump command
 /// </summary>

--- a/UndertaleModCli/CommandOptions/InfoOptions.cs
+++ b/UndertaleModCli/CommandOptions/InfoOptions.cs
@@ -2,6 +2,7 @@ using System.IO;
 
 namespace UndertaleModCli;
 
+// ReSharper disable NotNullMemberIsNotInitialized - Properties are applied via reflection.
 /// <summary>
 /// Cli options for the Info command
 /// </summary>

--- a/UndertaleModCli/CommandOptions/LoadOptions.cs
+++ b/UndertaleModCli/CommandOptions/LoadOptions.cs
@@ -2,6 +2,7 @@ using System.IO;
 
 namespace UndertaleModCli;
 
+// ReSharper disable NotNullMemberIsNotInitialized - Properties are applied via reflection.
 /// <summary>
 /// Cli options for the Load command
 /// </summary>

--- a/UndertaleModCli/CommandOptions/NewOptions.cs
+++ b/UndertaleModCli/CommandOptions/NewOptions.cs
@@ -2,6 +2,7 @@ using System.IO;
 
 namespace UndertaleModCli;
 
+// ReSharper disable NotNullMemberIsNotInitialized - Properties are applied via reflection.
 /// <summary>
 /// Cli options for the New command
 /// </summary>

--- a/UndertaleModCli/CommandOptions/ReplaceOptions.cs
+++ b/UndertaleModCli/CommandOptions/ReplaceOptions.cs
@@ -2,6 +2,7 @@ using System.IO;
 
 namespace UndertaleModCli;
 
+// ReSharper disable NotNullMemberIsNotInitialized - Properties are applied via reflection.
 /// <summary>
 /// Cli options for the Replace command
 /// </summary>

--- a/UndertaleModCli/Program.cs
+++ b/UndertaleModCli/Program.cs
@@ -51,7 +51,7 @@ public partial class Program : IScriptInterface
     /// <summary>
     /// File path or directory path that determines an output for the current Program.
     /// </summary>
-    private FileSystemInfo? Output { get; }
+    private FileSystemInfo Output { get; }
 
     /// <summary>
     /// Constant, used to indicate that the user wants to replace everything in a replace command.
@@ -114,6 +114,7 @@ public partial class Program : IScriptInterface
             //TODO: why no force overwrite here, but needed for new?
             new Option<FileInfo>(new []{"-o", "--output"}, "Where to save the modified data file"),
             new Option<string>(new []{"-l","--line"}, "Run C# string. Runs AFTER everything else"),
+            //TODO: make interactive another Command
             new Option<bool>(new []{"-i", "--interactive"}, "Interactive menu launch")
         };
         loadCommand.Handler = CommandHandler.Create<LoadOptions>(Program.Load);
@@ -169,11 +170,11 @@ public partial class Program : IScriptInterface
         return commandLine.Invoke(args);
     }
 
-    public Program(FileInfo datafile, FileInfo[]? scripts, FileInfo? output, bool verbose = false, bool interactive = false)
+    public Program(FileInfo datafile, FileInfo[] scripts, FileInfo output, bool verbose = false, bool interactive = false)
     {
         this.Verbose = verbose;
         IsInteractive = interactive;
-        Console.InputEncoding = System.Text.Encoding.UTF8;
+        Console.InputEncoding = Encoding.UTF8;
         Console.OutputEncoding = Console.InputEncoding;
 
 
@@ -203,6 +204,8 @@ public partial class Program : IScriptInterface
 
     public Program(FileInfo datafile, bool verbose, DirectoryInfo output = null)
     {
+        if (datafile == null) throw new ArgumentNullException(nameof(datafile));
+
         Console.WriteLine($"Trying to load file: '{datafile.FullName}'");
         this.Verbose = verbose;
         this.Data = ReadDataFile(datafile, verbose ? WarningHandler : null, verbose ? MessageHandler : null);
@@ -489,7 +492,7 @@ public partial class Program : IScriptInterface
                     {
                         RunCSharpFile(path);
                     }
-                    catch (Exception e)
+                    catch (Exception)
                     {
                         // ignored
                     }
@@ -712,7 +715,7 @@ public partial class Program : IScriptInterface
     /// <param name="code">The C# string to execute</param>
     /// <param name="scriptFile">The path to the script file where <see cref="code"/> was executed from.
     /// Leave as null, if it wasn't executed from a script file</param>
-    private void RunCSharpCode(string code, string? scriptFile = null)
+    private void RunCSharpCode(string code, string scriptFile = null)
     {
         if (Verbose)
             Console.WriteLine($"Attempting to execute '1{scriptFile ?? code}'...");
@@ -766,7 +769,7 @@ public partial class Program : IScriptInterface
     /// <param name="messageHandler">Handler for Messages</param>
     /// <returns></returns>
     /// <exception cref="FileNotFoundException">If the data file cannot be found</exception>
-    private static UndertaleData ReadDataFile(FileInfo datafile, WarningHandlerDelegate? warningHandler = null, MessageHandlerDelegate? messageHandler = null)
+    private static UndertaleData ReadDataFile(FileInfo datafile, WarningHandlerDelegate warningHandler = null, MessageHandlerDelegate messageHandler = null)
     {
         try
         {

--- a/UndertaleModCli/UndertaleModCli.csproj
+++ b/UndertaleModCli/UndertaleModCli.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
-	<Nullable>annotations</Nullable>
+	<Nullable>disable</Nullable>
 	<RollForward>LatestMajor</RollForward>
 	<PackageVersion>1.0.0</PackageVersion>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/UndertaleModLib/Scripting/IScriptInterface.cs
+++ b/UndertaleModLib/Scripting/IScriptInterface.cs
@@ -126,11 +126,11 @@ namespace UndertaleModLib.Scripting
         }
 
         //TODO: i have absolutely no idea what any of these do.
-        void ReplaceTempWithMain(bool ImAnExpertBTW = false);
-        void ReplaceMainWithTemp(bool ImAnExpertBTW = false);
-        void ReplaceTempWithCorrections(bool ImAnExpertBTW = false);
-        void ReplaceCorrectionsWithTemp(bool ImAnExpertBTW = false);
-        void UpdateCorrections(bool ImAnExpertBTW = false);
+        void ReplaceTempWithMain(bool imAnExpertBtw = false);
+        void ReplaceMainWithTemp(bool imAnExpertBtw = false);
+        void ReplaceTempWithCorrections(bool imAnExpertBtw = false);
+        void ReplaceCorrectionsWithTemp(bool imAnExpertBtw = false);
+        void UpdateCorrections(bool imAnExpertBtw = false);
 
         /// <summary>
         /// Used in Scripts in order to show a message to the user.
@@ -549,10 +549,10 @@ namespace UndertaleModLib.Scripting
         /// <param name="gmlCode">The new GML code that shall replace the current GML code of <paramref name="codeName"/>.</param>
         /// <param name="doParse">Whether the code entry should get linked.
         /// In other words, have special handling for scripts, globals and object code.</param>
-        /// <param name="replaceWithEmptyStringOnFail">If this is <see langword="false"/> an empty string
+        /// <param name="checkDecompiler">If this is <see langword="false"/> an empty string
         /// will be used for replacing the code entry in the case that anything fails.
         /// If this is <see langword="true"/> then an error will be shown instead and the code entry will not get replaced.</param>
-        void ImportGMLString(string codeName, string gmlCode, bool doParse = true, bool replaceWithEmptyStringOnFail = false);
+        void ImportGMLString(string codeName, string gmlCode, bool doParse = true, bool checkDecompiler = false);
 
         /// <summary>
         /// Replaces/Imports all GM-Bytecode ASM in a specific code entry with a specified string.
@@ -563,10 +563,10 @@ namespace UndertaleModLib.Scripting
         /// <param name="doParse">Whether the code entry should get linked.
         /// In other words, have special handling for scripts, globals and object code.</param>
         /// <param name="nukeProfile">Whether or not to nuke the profile entry for profile mode.</param>
-        /// <param name="replaceWithEmptyStringOnFail">If this is <see langword="false"/> an empty string
+        /// <param name="checkDecompiler">If this is <see langword="false"/> an empty string
         /// will be used for replacing the code entry in the case that anything fails.
         /// If this is <see langword="true"/> then an error will be shown instead and the code entry will not get replaced.</param>
-        void ImportASMString(string codeName, string gmlCode, bool doParse = true, bool nukeProfile = true, bool replaceWithEmptyStringOnFail = false);
+        void ImportASMString(string codeName, string gmlCode, bool doParse = true, bool nukeProfile = true, bool checkDecompiler = false);
 
         /// <summary>
         /// Replaces/Imports all GML in a specific code entry with a specified file.
@@ -577,10 +577,10 @@ namespace UndertaleModLib.Scripting
         /// </param>
         /// <param name="doParse">Whether the code entry should get linked.
         /// In other words, have special handling for scripts, globals and object code.</param>
-        /// <param name="replaceWithEmptyStringOnFail">If this is <see langword="false"/> an empty string
+        /// <param name="checkDecompiler">If this is <see langword="false"/> an empty string
         /// will be used for replacing the code entry in the case that anything fails.</param>
         /// <param name="throwOnError">Whether a <see cref="ScriptException"/> will be thrown on any errors.</param>
-        void ImportGMLFile(string fileName, bool doParse = true, bool replaceWithEmptyStringOnFail = false, bool throwOnError = false);
+        void ImportGMLFile(string fileName, bool doParse = true, bool checkDecompiler = false, bool throwOnError = false);
 
         /// <summary>
         /// Replaces/Imports all GM-Bytecode ASM in a specific code entry with a specified file.
@@ -591,10 +591,10 @@ namespace UndertaleModLib.Scripting
         /// <param name="doParse">Whether the code entry should get linked.
         /// In other words, have special handling for scripts, globals and object code.</param>
         /// <param name="nukeProfile">Whether or not to nuke the profile entry for profile mode.</param>
-        /// <param name="replaceWithEmptyStringOnFail">If this is <see langword="false"/> an empty string
+        /// <param name="checkDecompiler">If this is <see langword="false"/> an empty string
         /// will be used for replacing the code entry in the case that anything fails.</param>
         /// <param name="throwOnError">Whether a <see cref="ScriptException"/> will be thrown on any errors.</param>
-        void ImportASMFile(string fileName, bool doParse = true, bool nukeProfile = true, bool replaceWithEmptyStringOnFail = false, bool throwOnError = false);
+        void ImportASMFile(string fileName, bool doParse = true, bool nukeProfile = true, bool checkDecompiler = false, bool throwOnError = false);
 
         /// <summary>
         /// Find a keyword in a GML code entry and replaces it with a replacement string.

--- a/UndertaleModTests/GameScriptTests.cs
+++ b/UndertaleModTests/GameScriptTests.cs
@@ -48,19 +48,19 @@ namespace UndertaleModTests
             await Task.Delay(1); //dummy await
             return true;
         }
-        public void ReplaceTempWithMain(bool ImAnExpertBTW = false)
+        public void ReplaceTempWithMain(bool imAnExpertBtw = false)
         {
         }
-        public void ReplaceMainWithTemp(bool ImAnExpertBTW = false)
+        public void ReplaceMainWithTemp(bool imAnExpertBtw = false)
         {
         }
-        public void ReplaceTempWithCorrections(bool ImAnExpertBTW = false)
+        public void ReplaceTempWithCorrections(bool imAnExpertBtw = false)
         {
         }
-        public void ReplaceCorrectionsWithTemp(bool ImAnExpertBTW = false)
+        public void ReplaceCorrectionsWithTemp(bool imAnExpertBtw = false)
         {
         }
-        public void UpdateCorrections(bool ImAnExpertBTW = false)
+        public void UpdateCorrections(bool imAnExpertBtw = false)
         {
         }
         public void ReapplyProfileCode()
@@ -177,29 +177,29 @@ namespace UndertaleModTests
         {
             Console.Write("SetUMTConsoleText(): " + message);
         }
-        public void ReplaceTextInGML(string codeName, string keyword, string replacement, bool case_sensitive = false, bool isRegex = false, GlobalDecompileContext context = null)
+        public void ReplaceTextInGML(string codeName, string keyword, string replacement, bool caseSensitive = false, bool isRegex = false, GlobalDecompileContext context = null)
         {
-            Console.Write("ReplaceTextInGML(): " + codeName + ", " + keyword + ", " + replacement + ", " + case_sensitive.ToString() + ", " + isRegex.ToString() + ", " + context?.ToString());
+            Console.Write("ReplaceTextInGML(): " + codeName + ", " + keyword + ", " + replacement + ", " + caseSensitive.ToString() + ", " + isRegex.ToString() + ", " + context?.ToString());
         }
-        public void ReplaceTextInGML(UndertaleCode code, string keyword, string replacement, bool case_sensitive = false, bool isRegex = false, GlobalDecompileContext context = null)
+        public void ReplaceTextInGML(UndertaleCode code, string keyword, string replacement, bool caseSensitive = false, bool isRegex = false, GlobalDecompileContext context = null)
         {
-            Console.Write("ReplaceTextInGML(): " + code.ToString() + ", " + keyword + ", " + replacement + ", " + case_sensitive.ToString() + ", " + isRegex.ToString() + ", " + context?.ToString());
+            Console.Write("ReplaceTextInGML(): " + code.ToString() + ", " + keyword + ", " + replacement + ", " + caseSensitive.ToString() + ", " + isRegex.ToString() + ", " + context?.ToString());
         }
-        public void ImportGMLString(string codeName, string gmlCode, bool doParse = true, bool replaceWithEmptyStringOnFail = false)
+        public void ImportGMLString(string codeName, string gmlCode, bool doParse = true, bool checkDecompiler = false)
         {
             Console.Write("ImportGMLString(): " + codeName + ", " + gmlCode + ", " + doParse.ToString());
         }
-        public void ImportASMString(string codeName, string gmlCode, bool doParse = true, bool nukeProfile = true, bool replaceWithEmptyStringOnFail = false)
+        public void ImportASMString(string codeName, string gmlCode, bool doParse = true, bool nukeProfile = true, bool checkDecompiler = false)
         {
             Console.Write("ImportASMString(): " + codeName + ", " + gmlCode + ", " + doParse.ToString());
         }
-        public void ImportGMLFile(string fileName, bool doParse = true, bool replaceWithEmptyStringOnFail = false, bool throwOnError = false)
+        public void ImportGMLFile(string fileName, bool doParse = true, bool checkDecompiler = false, bool throwOnError = false)
         {
-            Console.Write($"ImportGMLFile(): \"{fileName}\", {doParse}, {replaceWithEmptyStringOnFail}, {throwOnError}");
+            Console.Write($"ImportGMLFile(): \"{fileName}\", {doParse}, {checkDecompiler}, {throwOnError}");
         }
-        public void ImportASMFile(string fileName, bool doParse = true, bool nukeProfile = true, bool replaceWithEmptyStringOnFail = false, bool throwOnError = false)
+        public void ImportASMFile(string fileName, bool doParse = true, bool nukeProfile = true, bool checkDecompiler = false, bool throwOnError = false)
         {
-            Console.Write($"ImportASMFile(): \"{fileName}\", {doParse}, {nukeProfile}, {replaceWithEmptyStringOnFail}, {throwOnError}");
+            Console.Write($"ImportASMFile(): \"{fileName}\", {doParse}, {nukeProfile}, {checkDecompiler}, {throwOnError}");
         }
 
         public void SetFinishedMessage(bool isFinishedMessageEnabled)

--- a/UndertaleModTool/CorrectionsManager.cs
+++ b/UndertaleModTool/CorrectionsManager.cs
@@ -9,11 +9,11 @@ namespace UndertaleModTool
     //Make new GUID helper functions
     public partial class MainWindow : Window, INotifyPropertyChanged, IScriptInterface
     {
-        public void ReplaceTempWithMain(bool ImAnExpertBTW = false)
+        public void ReplaceTempWithMain(bool imAnExpertBtw = false)
         {
             try
             {
-                if (!ImAnExpertBTW && (!(ScriptQuestion("Warning: This may cause desyncs! The intended purpose is for reverting incorrect code corrections.\nOnly use this if you know what you're doing! Continue?"))))
+                if (!imAnExpertBtw && (!(ScriptQuestion("Warning: This may cause desyncs! The intended purpose is for reverting incorrect code corrections.\nOnly use this if you know what you're doing! Continue?"))))
                     return;
                 string MainPath = Path.Combine(ProfilesFolder, ProfileHash, "Main");
                 string TempPath = Path.Combine(ProfilesFolder, ProfileHash, "Temp");
@@ -28,11 +28,11 @@ namespace UndertaleModTool
                 MessageBox.Show("ReplaceTempWithMain error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
-        public void ReplaceMainWithTemp(bool ImAnExpertBTW = false)
+        public void ReplaceMainWithTemp(bool imAnExpertBtw = false)
         {
             try
             {
-                if (!ImAnExpertBTW && (!(ScriptQuestion("Warning: This may cause desyncs! The intended purpose is for pushing code corrections (such as asset resolutions)\nOnly use this if you know what you're doing! Continue?"))))
+                if (!imAnExpertBtw && (!(ScriptQuestion("Warning: This may cause desyncs! The intended purpose is for pushing code corrections (such as asset resolutions)\nOnly use this if you know what you're doing! Continue?"))))
                     return;
                 string MainPath = Path.Combine(ProfilesFolder, ProfileHash, "Main");
                 string TempPath = Path.Combine(ProfilesFolder, ProfileHash, "Temp");
@@ -47,11 +47,11 @@ namespace UndertaleModTool
                 MessageBox.Show("ReplaceMainWithTemp error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
-        public void ReplaceTempWithCorrections(bool ImAnExpertBTW = false)
+        public void ReplaceTempWithCorrections(bool imAnExpertBtw = false)
         {
             try
             {
-                if (!ImAnExpertBTW && (!(ScriptQuestion("If you messed up royally while developing your corrections, you can use this to revert all of the changes to them in your Temp folder to what is in the Corrections folder. Only use this if you know what you're doing! Continue?"))))
+                if (!imAnExpertBtw && (!(ScriptQuestion("If you messed up royally while developing your corrections, you can use this to revert all of the changes to them in your Temp folder to what is in the Corrections folder. Only use this if you know what you're doing! Continue?"))))
                     return;
                 string MainPath = Path.Combine(ProfilesFolder, ProfileHash, "Main");
                 string TempPath = Path.Combine(ProfilesFolder, ProfileHash, "Temp");
@@ -72,11 +72,11 @@ namespace UndertaleModTool
                 MessageBox.Show("ReplaceCorrectionsWithTemp error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
-        public void ReplaceCorrectionsWithTemp(bool ImAnExpertBTW = false)
+        public void ReplaceCorrectionsWithTemp(bool imAnExpertBtw = false)
         {
             try
             {
-                if (!ImAnExpertBTW && (!(ScriptQuestion("The intended purpose is for pushing your custom made code corrections (your entire temporary profile) to the code corrections folder bundled with UndertaleModTool, making them permanent. Only use this if you know what you're doing! Continue?"))))
+                if (!imAnExpertBtw && (!(ScriptQuestion("The intended purpose is for pushing your custom made code corrections (your entire temporary profile) to the code corrections folder bundled with UndertaleModTool, making them permanent. Only use this if you know what you're doing! Continue?"))))
                     return;
                 Directory.Delete(CorrectionsFolder, true);
                 string MainPath = Path.Combine(ProfilesFolder, ProfileHash, "Main");
@@ -88,13 +88,13 @@ namespace UndertaleModTool
                 MessageBox.Show("ReplaceCorrectionsWithTemp error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
-        public void UpdateCorrections(bool ImAnExpertBTW = false)
+        public void UpdateCorrections(bool imAnExpertBtw = false)
         {
-            if (!ImAnExpertBTW && (!(ScriptQuestion("Update Main with Temp, Temp with Main, Corrections with Temp. Only use this if you know what you're doing! Continue?"))))
+            if (!imAnExpertBtw && (!(ScriptQuestion("Update Main with Temp, Temp with Main, Corrections with Temp. Only use this if you know what you're doing! Continue?"))))
                 return;
-            ReplaceMainWithTemp(ImAnExpertBTW);
-            ReplaceTempWithMain(ImAnExpertBTW);
-            ReplaceCorrectionsWithTemp(ImAnExpertBTW);
+            ReplaceMainWithTemp(imAnExpertBtw);
+            ReplaceTempWithMain(imAnExpertBtw);
+            ReplaceCorrectionsWithTemp(imAnExpertBtw);
         }
     }
 }

--- a/UndertaleModTool/ImportCodeSystem.cs
+++ b/UndertaleModTool/ImportCodeSystem.cs
@@ -34,24 +34,24 @@ namespace UndertaleModTool
             PreCreate
         }
 
-        public void ImportGMLString(string codeName, string gmlCode, bool doParse = true, bool replaceWithEmptyStringOnFail = false)
+        public void ImportGMLString(string codeName, string gmlCode, bool doParse = true, bool checkDecompiler = false)
         {
-            ImportCode(codeName, gmlCode, true, doParse, true, replaceWithEmptyStringOnFail);
+            ImportCode(codeName, gmlCode, true, doParse, true, checkDecompiler);
         }
 
-        public void ImportASMString(string codeName, string gmlCode, bool doParse = true, bool nukeProfile = true, bool replaceWithEmptyStringOnFail = false)
+        public void ImportASMString(string codeName, string gmlCode, bool doParse = true, bool nukeProfile = true, bool checkDecompiler = false)
         {
-            ImportCode(codeName, gmlCode, false, doParse, nukeProfile, replaceWithEmptyStringOnFail);
+            ImportCode(codeName, gmlCode, false, doParse, nukeProfile, checkDecompiler);
         }
 
-        public void ImportGMLFile(string fileName, bool doParse = true, bool replaceWithEmptyStringOnFail = false, bool throwOnError = false)
+        public void ImportGMLFile(string fileName, bool doParse = true, bool checkDecompiler = false, bool throwOnError = false)
         {
-            ImportCodeFromFile(fileName, true, doParse, true, replaceWithEmptyStringOnFail, throwOnError);
+            ImportCodeFromFile(fileName, true, doParse, true, checkDecompiler, throwOnError);
         }
 
-        public void ImportASMFile(string fileName, bool doParse = true, bool nukeProfile = true, bool replaceWithEmptyStringOnFail = false, bool throwOnError = false)
+        public void ImportASMFile(string fileName, bool doParse = true, bool nukeProfile = true, bool checkDecompiler = false, bool throwOnError = false)
         {
-            ImportCodeFromFile(fileName, false, doParse, nukeProfile, replaceWithEmptyStringOnFail, throwOnError);
+            ImportCodeFromFile(fileName, false, doParse, nukeProfile, checkDecompiler, throwOnError);
         }
 
         public void NukeProfileGML(string codeName)
@@ -97,15 +97,15 @@ namespace UndertaleModTool
             return passBack;
         }
 
-        public void ReplaceTextInGML(string codeName, string keyword, string replacement, bool case_sensitive = false, bool isRegex = false, GlobalDecompileContext context = null)
+        public void ReplaceTextInGML(string codeName, string keyword, string replacement, bool caseSensitive = false, bool isRegex = false, GlobalDecompileContext context = null)
         {
             UndertaleCode code = Data.Code.ByName(codeName);
             if (code is null)
                 throw new ScriptException($"No code named \"{codeName}\" was found!");
 
-            ReplaceTextInGML(code, keyword, replacement, case_sensitive, isRegex, context);
+            ReplaceTextInGML(code, keyword, replacement, caseSensitive, isRegex, context);
         }
-        public void ReplaceTextInGML(UndertaleCode code, string keyword, string replacement, bool case_sensitive = false, bool isRegex = false, GlobalDecompileContext context = null)
+        public void ReplaceTextInGML(UndertaleCode code, string keyword, string replacement, bool caseSensitive = false, bool isRegex = false, GlobalDecompileContext context = null)
         {
             EnsureDataLoaded();
 
@@ -117,7 +117,7 @@ namespace UndertaleModTool
             {
                 try
                 {
-                    passBack = GetPassBack((code != null ? Decompiler.Decompile(code, DECOMPILE_CONTEXT ) : ""), keyword, replacement, case_sensitive, isRegex);
+                    passBack = GetPassBack((code != null ? Decompiler.Decompile(code, DECOMPILE_CONTEXT ) : ""), keyword, replacement, caseSensitive, isRegex);
                     code.ReplaceGML(passBack, Data);
                 }
                 catch (Exception exc)
@@ -132,7 +132,7 @@ namespace UndertaleModTool
                     string path = Path.Combine(ProfilesFolder, Data.ToolInfo.CurrentMD5, "Temp", codeName + ".gml");
                     if (File.Exists(path))
                     {
-                        passBack = GetPassBack(File.ReadAllText(path), keyword, replacement, case_sensitive, isRegex);
+                        passBack = GetPassBack(File.ReadAllText(path), keyword, replacement, caseSensitive, isRegex);
                         File.WriteAllText(path, passBack);
                         code.ReplaceGML(passBack, Data);
                     }
@@ -141,9 +141,9 @@ namespace UndertaleModTool
                         try
                         {
                             if (context is null)
-                                passBack = GetPassBack((code != null ? Decompiler.Decompile(code, new GlobalDecompileContext(Data, false)) : ""), keyword, replacement, case_sensitive, isRegex);
+                                passBack = GetPassBack((code != null ? Decompiler.Decompile(code, new GlobalDecompileContext(Data, false)) : ""), keyword, replacement, caseSensitive, isRegex);
                             else
-                                passBack = GetPassBack((code != null ? Decompiler.Decompile(code, context) : ""), keyword, replacement, case_sensitive, isRegex);
+                                passBack = GetPassBack((code != null ? Decompiler.Decompile(code, context) : ""), keyword, replacement, caseSensitive, isRegex);
                             code.ReplaceGML(passBack, Data);
                         }
                         catch (Exception exc)


### PR DESCRIPTION
## Description
This fixes almost all warnings related to UMTCli.
It does so by fixing typos, fixing the naming scheme, disabling Nullable types (as no other projects use them, and CLI never used those in the first place) and disabling warnings for CommandOptions (as those get assigned via reflection)

### Caveats
None