### PR TITLE
Dont copy gitversion.txt to output dir

### DIFF
--- a/UndertaleModLib/UndertaleModLib.csproj
+++ b/UndertaleModLib/UndertaleModLib.csproj
@@ -40,9 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Remove="gitversion.txt" />
-    <EmbeddedResource Include="gitversion.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </EmbeddedResource>
+    <EmbeddedResource Include="gitversion.txt" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <!-- puts the git commit name and branch name into gitversion.txt which is an embedded resource -->


### PR DESCRIPTION
## Description
This fixes an oversight where gitversion.txt was accidentally copied to the output dir.

### Caveats
None