### PR TITLE
Correct function definitions and 2.3 FancyRoomSelect

### DIFF
--- a/UndertaleModLib/Compiler/Parser.cs
+++ b/UndertaleModLib/Compiler/Parser.cs
@@ -693,14 +693,13 @@ namespace UndertaleModLib.Compiler
                 result.Children.Add(ParseStatement(context));
                 if (expression)
                     return result;
-                else // Whatever you call non-anonymous
+                else // Whatever you call non-anonymous definitions
                 {
-                    Statement trueresult = new Statement(Statement.StatementKind.Assign, new Lexer.Token(TokenKind.Assign));
-                    trueresult.Children.Add(destination);
-                    trueresult.Children.Add(new Statement(Statement.StatementKind.Token, trueresult.Token));
-                    trueresult.Children.Add(result);
-                    return trueresult;
-
+                    Statement trueResult = new Statement(Statement.StatementKind.Assign, new Lexer.Token(TokenKind.Assign));
+                    trueResult.Children.Add(destination);
+                    trueResult.Children.Add(new Statement(Statement.StatementKind.Token, trueResult.Token));
+                    trueResult.Children.Add(result);
+                    return trueResult;
                 }
             }
 

--- a/UndertaleModLib/Compiler/Parser.cs
+++ b/UndertaleModLib/Compiler/Parser.cs
@@ -660,10 +660,19 @@ namespace UndertaleModLib.Compiler
             {
                 Statement result = new Statement(Statement.StatementKind.FunctionDef, EnsureTokenKind(TokenKind.KeywordFunction).Token);
                 Statement args = new Statement();
+                bool expression = true;
+                Statement destination = null;
+
+                if (GetNextTokenKind() == TokenKind.ProcFunction)
+                {
+                    expression = false;
+                    Statement s = remainingStageOne.Dequeue();
+                    destination = new Statement(Statement.StatementKind.ExprFuncName, s.Token) { ID = s.ID };
+                }
 
                 EnsureTokenKind(TokenKind.OpenParen);
 
-                while (remainingStageOne.Count > 0 && !hasError && !IsNextToken(TokenKind.EOF) && !IsNextToken(TokenKind.CloseParen))
+                while (remainingStageOne.Count > 0 && !hasError && !IsNextToken(TokenKind.EOF, TokenKind.CloseParen))
                 {
                     Statement expr = ParseExpression(context);
                     if (expr != null)
@@ -682,7 +691,17 @@ namespace UndertaleModLib.Compiler
                 if (EnsureTokenKind(TokenKind.CloseParen) == null) return null;
 
                 result.Children.Add(ParseStatement(context));
-                return result;
+                if (expression)
+                    return result;
+                else // Whatever you call non-anonymous
+                {
+                    Statement trueresult = new Statement(Statement.StatementKind.Assign, new Lexer.Token(TokenKind.Assign));
+                    trueresult.Children.Add(destination);
+                    trueresult.Children.Add(new Statement(Statement.StatementKind.Token, trueresult.Token));
+                    trueresult.Children.Add(result);
+                    return trueresult;
+
+                }
             }
 
             private static Statement ParseFor(CompileContext context)

--- a/UndertaleModLib/Decompiler/Decompiler.cs
+++ b/UndertaleModLib/Decompiler/Decompiler.cs
@@ -1173,6 +1173,14 @@ namespace UndertaleModLib.Decompiler
                     }
                 }
 
+                // Someone enlighten me on structs, I'm steering clear for now.
+                // And find the "right" way to do this.
+                if (Value is FunctionDefinition functionVal && functionVal.Subtype != FunctionDefinition.FunctionType.Struct)
+                {
+                    functionVal.IsStatement = true;
+                    return functionVal.ToString(context);
+                }
+
                 string varPrefix = (HasVarKeyword ? "var " : "");
 
                 // Check for possible ++, --, or operation equal (for single vars)
@@ -1306,6 +1314,7 @@ namespace UndertaleModLib.Decompiler
             public UndertaleCode FunctionBodyCodeEntry { get; private set; }
             public Block FunctionBodyEntryBlock { get; private set; }
             public FunctionType Subtype { get; private set; }
+            public bool IsStatement = false; // I know it's an expression, yes. But I'm not duplicating the rest.
 
             internal List<Expression> Arguments;
 
@@ -1354,12 +1363,19 @@ namespace UndertaleModLib.Decompiler
                     FunctionDefinition def;
                     var oldDecompilingStruct = context.DecompilingStruct;
                     var oldReplacements = context.ArgumentReplacements;
+
                     if (Subtype == FunctionType.Struct)
                         context.DecompilingStruct = true;
                     else
                     {
                         context.DecompilingStruct = false;
-                        sb.Append("function(");
+                        sb.Append("function");
+                        if (IsStatement)
+                        {
+                            sb.Append(" ");
+                            sb.Append((context.Statements[0].Last() as AssignmentStatement).Destination.Var.Name.Content);
+                        }
+                        sb.Append("(");
                         for (int i = 0; i < FunctionBodyCodeEntry.ArgumentsCount; ++i)
                         {
                             if (i != 0)

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -1178,7 +1178,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
         // GMS 2022.1+
         public bool EffectEnabled { get; set; }
         public UndertaleString EffectType { get; set; }
-        public UndertaleSimpleList<EffectProperty> EffectProperties { get; set; }
+        public UndertaleSimpleList<EffectProperty> EffectProperties { get; set; } = new();
 
         public void UpdateParentRoom()
         {

--- a/UndertaleModTool/Scripts/CommunityScripts/FancyRoomSelect.csx
+++ b/UndertaleModTool/Scripts/CommunityScripts/FancyRoomSelect.csx
@@ -6,69 +6,54 @@ EnsureDataLoaded();
 
 var obj = Data.GameObjects.ByName("obj_roomselector");
 
-if (obj == null)
-{
+if(obj == null) {
     obj = new UndertaleGameObject() { Name = Data.Strings.MakeString("obj_roomselector"), Persistent = true };
     Data.GameObjects.Add(obj);
 }
 
-if (Data.GeneralInfo.Name.Content.StartsWith("UNDERTALE"))
-{
+if(Data.GeneralInfo.Name.Content.StartsWith("UNDERTALE")) {
     // Remove existing F3 handler to avoid accidentally 
     // creating system_information_962
     Data.GameObjects.ByName("obj_time").EventHandlerFor(EventType.KeyPress, (uint)114, Data.Strings, Data.Code, Data.CodeLocals).ReplaceGML("", Data);
 }
 
-bool gms2 = Data.IsVersionAtLeast(2, 0, 0, 0);
+bool gms2 = Data.IsVersionAtLeast(2,0,0,0);
 
 var entry_room = Data.GeneralInfo.RoomOrder[0].Resource;
 var object_list = entry_room.GameObjects;
 bool add_to_room = true;
 
-if (gms2)
-{
+if(gms2) {
     UndertaleRoom.Layer target_layer = null;
-    foreach (var layer in entry_room.Layers)
-    {
-        if (layer.LayerType == UndertaleRoom.LayerType.Instances)
-        {
-            foreach (var layer_obj in layer.InstancesData.Instances)
-            {
-                if (layer_obj.ObjectDefinition == obj)
-                {
+    foreach(var layer in entry_room.Layers) {
+        if(layer.LayerType == UndertaleRoom.LayerType.Instances) {
+            foreach(var layer_obj in layer.InstancesData.Instances) {
+                if(layer_obj.ObjectDefinition == obj) {
                     add_to_room = false;
                     break;
                 }
             }
-            if (!add_to_room)
-            {
+            if(!add_to_room) {
                 break;
             }
-            if (target_layer == null || target_layer.LayerDepth > layer.LayerDepth)
-            {
+            if(target_layer == null || target_layer.LayerDepth > layer.LayerDepth) {
                 target_layer = layer;
             }
         }
     }
-
-    if (add_to_room)
-    {
-        if (target_layer == null)
-        {
+    
+    if(add_to_room) {
+        if(target_layer == null) {
             uint layer_id = 0;
-            foreach (var room in Data.Rooms)
-            {
-                foreach (var layer in room.Layers)
-                {
-                    if (layer.LayerId > layer_id)
-                    {
+            foreach(var room in Data.Rooms) {
+                foreach(var layer in room.Layers) {
+                    if(layer.LayerId > layer_id) {
                         layer_id = (uint)layer.LayerId;
                     }
                 }
             }
-
-            target_layer = new UndertaleRoom.Layer()
-            {
+            
+            target_layer = new UndertaleRoom.Layer() {
                 LayerName = Data.Strings.MakeString("Room_Selector_Layer"),
                 Data = new UndertaleRoom.Layer.LayerInstancesData(),
                 LayerType = UndertaleRoom.LayerType.Instances,
@@ -76,40 +61,32 @@ if (gms2)
                 LayerId = layer_id,
                 IsVisible = true
             };
-
+            
             entry_room.Layers.Add(target_layer);
         }
-        var obj_to_add = new UndertaleRoom.GameObject()
-        {
+        var obj_to_add = new UndertaleRoom.GameObject() {
             InstanceID = Data.GeneralInfo.LastObj++,
             ObjectDefinition = obj,
-            X = 0,
-            Y = 0
+            X = 0, Y = 0
         };
         target_layer.InstancesData.Instances.Add(obj_to_add);
         object_list.Add(obj_to_add);
     }
 }
-else
-{
+else {
 
-    foreach (var room_obj in object_list)
-    {
-        if (room_obj.ObjectDefinition == obj)
-        {
+    foreach(var room_obj in object_list) {
+        if(room_obj.ObjectDefinition == obj) {
             add_to_room = false;
             break;
         }
     }
 
-    if (add_to_room)
-    {
-        object_list.Add(new UndertaleRoom.GameObject()
-        {
+    if(add_to_room) {
+        object_list.Add(new UndertaleRoom.GameObject() {
             InstanceID = Data.GeneralInfo.LastObj++,
             ObjectDefinition = obj,
-            X = 0,
-            Y = 0
+            X = 0, Y = 0
         });
     }
 }
@@ -139,8 +116,8 @@ update = 1
 scale = 1
 fnt = -4
 len = 0
-ss = -4"
-+ (!Data.GMS2_3
+ss = -4" 
++ (!Data.GMS2_3 
   ? "for (i = room_first; i <= room_last; i++)"
   : "for (i = 0; room_exists(i); i++)")
 + @"

--- a/UndertaleModTool/Scripts/CommunityScripts/FancyRoomSelect.csx
+++ b/UndertaleModTool/Scripts/CommunityScripts/FancyRoomSelect.csx
@@ -407,8 +407,15 @@ selector_active = 0
 exiting = 0
 ", Data);
 
+string version;
+if (Data.GMS2_3)
+    version = "2.3";
+else if (gms2)
+    version = "2";
+else
+    version = "1";
 
-ScriptMessage("Successfully applied for Gamemaker " + (Data.GMS2_3 ? "2.3" : (gms2 ? "2" : "1")) + @"
+ScriptMessage(@$"Successfully applied for Gamemaker {version}
 Controls:
 - F3: open/close menu
 - Escape: close menu

--- a/UndertaleModTool/Scripts/CommunityScripts/FancyRoomSelect.csx
+++ b/UndertaleModTool/Scripts/CommunityScripts/FancyRoomSelect.csx
@@ -1,70 +1,74 @@
 //Originally created by _creepersbane#2074
 //Adapted to work with all games by Grossley
+//Adapted to GMS 2.3+ by Space Core/Jacky720
 
 EnsureDataLoaded();
 
-if (Data?.GeneralInfo?.DisplayName?.Content.ToLower() == "deltarune chapter 1 & 2")
-{
-    ScriptError("Error 0: Incompatible with the new Deltarune Chapter 1 & 2 demo");
-    return;
-}
-else if (Data?.GeneralInfo?.DisplayName?.Content.ToLower() == "deltarune chapter 1&2")
-{
-    ScriptError("Error 1: Incompatible with the new Deltarune Chapter 1 & 2 demo");
-    return;
-}
-
-
 var obj = Data.GameObjects.ByName("obj_roomselector");
 
-if(obj == null) {
+if (obj == null)
+{
     obj = new UndertaleGameObject() { Name = Data.Strings.MakeString("obj_roomselector"), Persistent = true };
     Data.GameObjects.Add(obj);
 }
 
-if(Data.GeneralInfo.Name.Content.StartsWith("UNDERTALE")) {
+if (Data.GeneralInfo.Name.Content.StartsWith("UNDERTALE"))
+{
     // Remove existing F3 handler to avoid accidentally 
     // creating system_information_962
     Data.GameObjects.ByName("obj_time").EventHandlerFor(EventType.KeyPress, (uint)114, Data.Strings, Data.Code, Data.CodeLocals).ReplaceGML("", Data);
 }
 
-bool gms2 = Data.IsVersionAtLeast(2,0,0,0);
+bool gms2 = Data.IsVersionAtLeast(2, 0, 0, 0);
 
 var entry_room = Data.GeneralInfo.RoomOrder[0].Resource;
 var object_list = entry_room.GameObjects;
 bool add_to_room = true;
 
-if(gms2) {
+if (gms2)
+{
     UndertaleRoom.Layer target_layer = null;
-    foreach(var layer in entry_room.Layers) {
-        if(layer.LayerType == UndertaleRoom.LayerType.Instances) {
-            foreach(var layer_obj in layer.InstancesData.Instances) {
-                if(layer_obj.ObjectDefinition == obj) {
+    foreach (var layer in entry_room.Layers)
+    {
+        if (layer.LayerType == UndertaleRoom.LayerType.Instances)
+        {
+            foreach (var layer_obj in layer.InstancesData.Instances)
+            {
+                if (layer_obj.ObjectDefinition == obj)
+                {
                     add_to_room = false;
                     break;
                 }
             }
-            if(!add_to_room) {
+            if (!add_to_room)
+            {
                 break;
             }
-            if(target_layer == null || target_layer.LayerDepth > layer.LayerDepth) {
+            if (target_layer == null || target_layer.LayerDepth > layer.LayerDepth)
+            {
                 target_layer = layer;
             }
         }
     }
-    
-    if(add_to_room) {
-        if(target_layer == null) {
+
+    if (add_to_room)
+    {
+        if (target_layer == null)
+        {
             uint layer_id = 0;
-            foreach(var room in Data.Rooms) {
-                foreach(var layer in room.Layers) {
-                    if(layer.LayerId > layer_id) {
+            foreach (var room in Data.Rooms)
+            {
+                foreach (var layer in room.Layers)
+                {
+                    if (layer.LayerId > layer_id)
+                    {
                         layer_id = (uint)layer.LayerId;
                     }
                 }
             }
-            
-            target_layer = new UndertaleRoom.Layer() {
+
+            target_layer = new UndertaleRoom.Layer()
+            {
                 LayerName = Data.Strings.MakeString("Room_Selector_Layer"),
                 Data = new UndertaleRoom.Layer.LayerInstancesData(),
                 LayerType = UndertaleRoom.LayerType.Instances,
@@ -72,32 +76,40 @@ if(gms2) {
                 LayerId = layer_id,
                 IsVisible = true
             };
-            
+
             entry_room.Layers.Add(target_layer);
         }
-        var obj_to_add = new UndertaleRoom.GameObject() {
+        var obj_to_add = new UndertaleRoom.GameObject()
+        {
             InstanceID = Data.GeneralInfo.LastObj++,
             ObjectDefinition = obj,
-            X = 0, Y = 0
+            X = 0,
+            Y = 0
         };
         target_layer.InstancesData.Instances.Add(obj_to_add);
         object_list.Add(obj_to_add);
     }
 }
-else {
+else
+{
 
-    foreach(var room_obj in object_list) {
-        if(room_obj.ObjectDefinition == obj) {
+    foreach (var room_obj in object_list)
+    {
+        if (room_obj.ObjectDefinition == obj)
+        {
             add_to_room = false;
             break;
         }
     }
 
-    if(add_to_room) {
-        object_list.Add(new UndertaleRoom.GameObject() {
+    if (add_to_room)
+    {
+        object_list.Add(new UndertaleRoom.GameObject()
+        {
             InstanceID = Data.GeneralInfo.LastObj++,
             ObjectDefinition = obj,
-            X = 0, Y = 0
+            X = 0,
+            Y = 0
         });
     }
 }
@@ -127,14 +139,19 @@ update = 1
 scale = 1
 fnt = -4
 len = 0
-ss = -4
-for (i = room_first; i <= room_last; i++)
+ss = -4"
++ (!Data.GMS2_3
+  ? "for (i = room_first; i <= room_last; i++)"
+  : "for (i = 0; room_exists(i); i++)")
++ @"
 {
     if room_exists(i)
         room_names[i] = (((room_get_name(i) + "" ("") + string(i)) + "")"")
     else
         room_names[i] = -4
 }
+// for 2.3
+myroom_last = i
 ww = -1
 hh = -1
 xx = 0
@@ -164,8 +181,11 @@ if selector_active
             positions[0] = -1
             roomid = -1
             if (dest_room != """" && dest_room == string_digits(dest_room))
-                roomid = real(dest_room)
-            for (i = room_first; i <= room_last; i++)
+                roomid = real(dest_room)"
+            + (!Data.GMS2_3
+              ? "for (i = room_first; i <= room_last; i++)"
+              : "for (i = 0; i < myroom_last; i++)")
+            + @"
             {
                 if is_string(room_names[i])
                 {
@@ -411,7 +431,7 @@ exiting = 0
 ", Data);
 
 
-ScriptMessage("Successfully applied for Gamemaker " + (gms2 ? 2 : 1).ToString() + @"
+ScriptMessage("Successfully applied for Gamemaker " + (Data.GMS2_3 ? "2.3" : (gms2 ? "2" : "1")) + @"
 Controls:
 - F3: open/close menu
 - Escape: close menu


### PR DESCRIPTION
## Description
Adds support for `function scr_myscript()` formatting in GMS 2.3+ in both compilation and decompilation. Minor tweaks to FancyRoomSelect.csx to function on 2.3+ with strange room orders.

### Caveats
Struct definition isn't 100% due to me not knowing how struct definition works. The new decompiler code hackily uses `FunctionDefinition` as both an Expression and a Statement depending on context. The code does not differentiate in decompilation; `scr_myscript = function()` no longer appears even if it is the format used, although it is still accepted in compilation.

I didn't bother to restrict the `myroom_last` variable to 2.3, so technically it defines one additional unused variable when the script is used on older games. This will not cause performance issues.

### Notes
Closes #926. Closes #951.