### PR TITLE
Fix MessageBoxes appearing below the UMT window

### DIFF
--- a/UndertaleModTool/Controls/UndertaleObjectReference.xaml.cs
+++ b/UndertaleModTool/Controls/UndertaleObjectReference.xaml.cs
@@ -95,7 +95,7 @@ namespace UndertaleModTool
         {
             if (ObjectReference is null)
             {
-                MessageBox.Show("This feature is very WIP, so expect it to be broken.");
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, "This feature is very WIP, so expect it to be broken.");
 
                 MainWindow mainWindow = Application.Current.MainWindow as MainWindow;
 

--- a/UndertaleModTool/Controls/UndertaleObjectReference.xaml.cs
+++ b/UndertaleModTool/Controls/UndertaleObjectReference.xaml.cs
@@ -95,9 +95,9 @@ namespace UndertaleModTool
         {
             if (ObjectReference is null)
             {
-                MessageBox.Show(Application.Current.MainWindow as MainWindow, "This feature is very WIP, so expect it to be broken.");
-
                 MainWindow mainWindow = Application.Current.MainWindow as MainWindow;
+
+                MessageBox.Show(mainWindow, "This feature is very WIP, so expect it to be broken.");
 
                 if (mainWindow.Selected is null)
                 {

--- a/UndertaleModTool/CorrectionsManager.cs
+++ b/UndertaleModTool/CorrectionsManager.cs
@@ -25,7 +25,7 @@ namespace UndertaleModTool
             }
             catch (Exception exc)
             {
-                MessageBox.Show("ReplaceTempWithMain error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, "ReplaceTempWithMain error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
         public void ReplaceMainWithTemp(bool imAnExpertBtw = false)
@@ -44,7 +44,7 @@ namespace UndertaleModTool
             }
             catch (Exception exc)
             {
-                MessageBox.Show("ReplaceMainWithTemp error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, "ReplaceMainWithTemp error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
         public void ReplaceTempWithCorrections(bool imAnExpertBtw = false)
@@ -69,7 +69,7 @@ namespace UndertaleModTool
             }
             catch (Exception exc)
             {
-                MessageBox.Show("ReplaceCorrectionsWithTemp error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, "ReplaceCorrectionsWithTemp error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
         public void ReplaceCorrectionsWithTemp(bool imAnExpertBtw = false)
@@ -85,7 +85,7 @@ namespace UndertaleModTool
             }
             catch (Exception exc)
             {
-                MessageBox.Show("ReplaceCorrectionsWithTemp error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, "ReplaceCorrectionsWithTemp error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
         public void UpdateCorrections(bool imAnExpertBtw = false)

--- a/UndertaleModTool/CorrectionsManager.cs
+++ b/UndertaleModTool/CorrectionsManager.cs
@@ -25,7 +25,7 @@ namespace UndertaleModTool
             }
             catch (Exception exc)
             {
-                MessageBox.Show(Application.Current.MainWindow as MainWindow, "ReplaceTempWithMain error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                MessageBox.Show(this, "ReplaceTempWithMain error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
         public void ReplaceMainWithTemp(bool imAnExpertBtw = false)
@@ -44,7 +44,7 @@ namespace UndertaleModTool
             }
             catch (Exception exc)
             {
-                MessageBox.Show(Application.Current.MainWindow as MainWindow, "ReplaceMainWithTemp error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                MessageBox.Show(this, "ReplaceMainWithTemp error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
         public void ReplaceTempWithCorrections(bool imAnExpertBtw = false)
@@ -69,7 +69,7 @@ namespace UndertaleModTool
             }
             catch (Exception exc)
             {
-                MessageBox.Show(Application.Current.MainWindow as MainWindow, "ReplaceCorrectionsWithTemp error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                MessageBox.Show(this, "ReplaceCorrectionsWithTemp error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
         public void ReplaceCorrectionsWithTemp(bool imAnExpertBtw = false)
@@ -85,7 +85,7 @@ namespace UndertaleModTool
             }
             catch (Exception exc)
             {
-                MessageBox.Show(Application.Current.MainWindow as MainWindow, "ReplaceCorrectionsWithTemp error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                MessageBox.Show(this, "ReplaceCorrectionsWithTemp error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
         public void UpdateCorrections(bool imAnExpertBtw = false)

--- a/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
@@ -359,11 +359,11 @@ namespace UndertaleModTool
                     }
                     catch (ArgumentException)
                     {
-                        MessageBox.Show("There is a duplicate key in textdata_en, being " + m.Groups[1].Value + ". This may cause errors in the comment display of text.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        MessageBox.Show(Application.Current.MainWindow as MainWindow, "There is a duplicate key in textdata_en, being " + m.Groups[1].Value + ". This may cause errors in the comment display of text.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
                     }
                     catch
                     {
-                        MessageBox.Show("Unknown error in textdata_en. This may cause errors in the comment display of text.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        MessageBox.Show(Application.Current.MainWindow as MainWindow, "Unknown error in textdata_en. This may cause errors in the comment display of text.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
                     }
                 }
             }
@@ -466,7 +466,7 @@ namespace UndertaleModTool
                     }
                     catch (Exception exc)
                     {
-                        MessageBox.Show(exc.ToString());
+                        MessageBox.Show(Application.Current.MainWindow as MainWindow, exc.ToString());
                     }
 
                     if (decompiled != null)
@@ -595,14 +595,14 @@ namespace UndertaleModTool
                     catch (Exception e)
                     {
                         Debug.WriteLine(e.ToString());
-                        if (MessageBox.Show("Unable to execute GraphViz: " + e.Message + "\nMake sure you have downloaded it and set the path in settings.\nDo you want to open the download page now?", "Graph generation failed", MessageBoxButton.YesNo, MessageBoxImage.Error) == MessageBoxResult.Yes)
+                        if (MessageBox.Show(Application.Current.MainWindow as MainWindow, "Unable to execute GraphViz: " + e.Message + "\nMake sure you have downloaded it and set the path in settings.\nDo you want to open the download page now?", "Graph generation failed", MessageBoxButton.YesNo, MessageBoxImage.Error) == MessageBoxResult.Yes)
                             MainWindow.OpenBrowser("https://graphviz.gitlab.io/_pages/Download/Download_windows.html");
                     }
                 }
                 catch (Exception e)
                 {
                     Debug.WriteLine(e.ToString());
-                    MessageBox.Show(e.Message, "Graph generation failed", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(Application.Current.MainWindow as MainWindow, e.Message, "Graph generation failed", MessageBoxButton.OK, MessageBoxImage.Error);
                 }
 
                 Dispatcher.Invoke(() =>
@@ -692,21 +692,21 @@ namespace UndertaleModTool
             if (compileContext == null)
             {
                 dialog.TryClose();
-                MessageBox.Show("Compile context was null for some reason...", "This shouldn't happen", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, "Compile context was null for some reason...", "This shouldn't happen", MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
 
             if (compileContext.HasError)
             {
                 dialog.TryClose();
-                MessageBox.Show(Truncate(compileContext.ResultError, 512), "Compiler error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, Truncate(compileContext.ResultError, 512), "Compiler error", MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
 
             if (!compileContext.SuccessfulCompile)
             {
                 dialog.TryClose();
-                MessageBox.Show("(unknown error message)", "Compile failed", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, "(unknown error message)", "Compile failed", MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
 
@@ -733,7 +733,7 @@ namespace UndertaleModTool
                 }
                 catch (Exception exc)
                 {
-                    MessageBox.Show("Error during writing of GML code to profile:\n" + exc.ToString());
+                    MessageBox.Show(Application.Current.MainWindow as MainWindow, "Error during writing of GML code to profile:\n" + exc.ToString());
                 }
             }
 
@@ -815,7 +815,7 @@ namespace UndertaleModTool
             }
             catch (Exception ex)
             {
-                MessageBox.Show(ex.ToString(), "Assembler error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, ex.ToString(), "Assembler error", MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
 

--- a/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
@@ -45,7 +45,7 @@ namespace UndertaleModTool
     [SupportedOSPlatform("windows7.0")]
     public partial class UndertaleCodeEditor : DataUserControl
     {
-        private static MainWindow mainWindow = Application.Current.MainWindow as MainWindow;
+        private static MainWindow mainWindow = mainWindow;
 
         public UndertaleCode CurrentDisassembled = null;
         public UndertaleCode CurrentDecompiled = null;
@@ -359,11 +359,11 @@ namespace UndertaleModTool
                     }
                     catch (ArgumentException)
                     {
-                        MessageBox.Show(Application.Current.MainWindow as MainWindow, "There is a duplicate key in textdata_en, being " + m.Groups[1].Value + ". This may cause errors in the comment display of text.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        MessageBox.Show(mainWindow, "There is a duplicate key in textdata_en, being " + m.Groups[1].Value + ". This may cause errors in the comment display of text.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
                     }
                     catch
                     {
-                        MessageBox.Show(Application.Current.MainWindow as MainWindow, "Unknown error in textdata_en. This may cause errors in the comment display of text.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        MessageBox.Show(mainWindow, "Unknown error in textdata_en. This may cause errors in the comment display of text.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
                     }
                 }
             }
@@ -466,7 +466,7 @@ namespace UndertaleModTool
                     }
                     catch (Exception exc)
                     {
-                        MessageBox.Show(Application.Current.MainWindow as MainWindow, exc.ToString());
+                        MessageBox.Show(mainWindow, exc.ToString());
                     }
 
                     if (decompiled != null)
@@ -595,14 +595,14 @@ namespace UndertaleModTool
                     catch (Exception e)
                     {
                         Debug.WriteLine(e.ToString());
-                        if (MessageBox.Show(Application.Current.MainWindow as MainWindow, "Unable to execute GraphViz: " + e.Message + "\nMake sure you have downloaded it and set the path in settings.\nDo you want to open the download page now?", "Graph generation failed", MessageBoxButton.YesNo, MessageBoxImage.Error) == MessageBoxResult.Yes)
+                        if (MessageBox.Show(mainWindow, "Unable to execute GraphViz: " + e.Message + "\nMake sure you have downloaded it and set the path in settings.\nDo you want to open the download page now?", "Graph generation failed", MessageBoxButton.YesNo, MessageBoxImage.Error) == MessageBoxResult.Yes)
                             MainWindow.OpenBrowser("https://graphviz.gitlab.io/_pages/Download/Download_windows.html");
                     }
                 }
                 catch (Exception e)
                 {
                     Debug.WriteLine(e.ToString());
-                    MessageBox.Show(Application.Current.MainWindow as MainWindow, e.Message, "Graph generation failed", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(mainWindow, e.Message, "Graph generation failed", MessageBoxButton.OK, MessageBoxImage.Error);
                 }
 
                 Dispatcher.Invoke(() =>
@@ -692,21 +692,21 @@ namespace UndertaleModTool
             if (compileContext == null)
             {
                 dialog.TryClose();
-                MessageBox.Show(Application.Current.MainWindow as MainWindow, "Compile context was null for some reason...", "This shouldn't happen", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(mainWindow, "Compile context was null for some reason...", "This shouldn't happen", MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
 
             if (compileContext.HasError)
             {
                 dialog.TryClose();
-                MessageBox.Show(Application.Current.MainWindow as MainWindow, Truncate(compileContext.ResultError, 512), "Compiler error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(mainWindow, Truncate(compileContext.ResultError, 512), "Compiler error", MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
 
             if (!compileContext.SuccessfulCompile)
             {
                 dialog.TryClose();
-                MessageBox.Show(Application.Current.MainWindow as MainWindow, "(unknown error message)", "Compile failed", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(mainWindow, "(unknown error message)", "Compile failed", MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
 
@@ -733,7 +733,7 @@ namespace UndertaleModTool
                 }
                 catch (Exception exc)
                 {
-                    MessageBox.Show(Application.Current.MainWindow as MainWindow, "Error during writing of GML code to profile:\n" + exc.ToString());
+                    MessageBox.Show(mainWindow, "Error during writing of GML code to profile:\n" + exc.ToString());
                 }
             }
 
@@ -815,7 +815,7 @@ namespace UndertaleModTool
             }
             catch (Exception ex)
             {
-                MessageBox.Show(Application.Current.MainWindow as MainWindow, ex.ToString(), "Assembler error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(mainWindow, ex.ToString(), "Assembler error", MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
 

--- a/UndertaleModTool/Editors/UndertaleEmbeddedAudioEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedAudioEditor.xaml.cs
@@ -62,7 +62,7 @@ namespace UndertaleModTool
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show("Failed to import file: " + ex.Message, "Failed to import file", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(Application.Current.MainWindow as MainWindow, "Failed to import file: " + ex.Message, "Failed to import file", MessageBoxButton.OK, MessageBoxImage.Error);
                 }
             }
         }
@@ -84,7 +84,7 @@ namespace UndertaleModTool
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show("Failed to export file: " + ex.Message, "Failed to export file", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(Application.Current.MainWindow as MainWindow, "Failed to export file: " + ex.Message, "Failed to export file", MessageBoxButton.OK, MessageBoxImage.Error);
                 }
             }
         }
@@ -119,11 +119,11 @@ namespace UndertaleModTool
                         waveOut.Init(oggReader);
                         waveOut.Play();
                     } else
-                        MessageBox.Show("Failed to play audio!\r\nNot a WAV or OGG.", "Audio failure", MessageBoxButton.OK, MessageBoxImage.Warning);
+                        MessageBox.Show(Application.Current.MainWindow as MainWindow, "Failed to play audio!\r\nNot a WAV or OGG.", "Audio failure", MessageBoxButton.OK, MessageBoxImage.Warning);
                 } catch (Exception ex)
                 {
                     waveOut = null;
-                    MessageBox.Show("Failed to play audio!\r\n" + ex.Message, "Audio failure", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    MessageBox.Show(Application.Current.MainWindow as MainWindow, "Failed to play audio!\r\n" + ex.Message, "Audio failure", MessageBoxButton.OK, MessageBoxImage.Warning);
                 }
             }
         }

--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
@@ -55,7 +55,7 @@ namespace UndertaleModTool
                     
                     if ((width & (width - 1)) != 0 || (height & (height - 1)) != 0)
                     {
-                        MessageBox.Show("WARNING: texture page dimensions are not powers of 2. Sprite blurring is very likely in game.", "Unexpected texture dimensions", MessageBoxButton.OK, MessageBoxImage.Warning);
+                        MessageBox.Show(Application.Current.MainWindow as MainWindow, "WARNING: texture page dimensions are not powers of 2. Sprite blurring is very likely in game.", "Unexpected texture dimensions", MessageBoxButton.OK, MessageBoxImage.Warning);
                     }
 
                     using (var stream = new MemoryStream())
@@ -66,7 +66,7 @@ namespace UndertaleModTool
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show("Failed to import file: " + ex.Message, "Failed to import file", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(Application.Current.MainWindow as MainWindow, "Failed to import file: " + ex.Message, "Failed to import file", MessageBoxButton.OK, MessageBoxImage.Error);
                 }
             }
         }
@@ -88,7 +88,7 @@ namespace UndertaleModTool
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show("Failed to export file: " + ex.Message, "Failed to export file", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(Application.Current.MainWindow as MainWindow, "Failed to export file: " + ex.Message, "Failed to export file", MessageBoxButton.OK, MessageBoxImage.Error);
                 }
             }
         }

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -122,7 +122,7 @@ namespace UndertaleModTool
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show(Application.Current.MainWindow as MainWindow, "Failed to export file: " + ex.Message, "Failed to export file", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(mainWindow, "Failed to export file: " + ex.Message, "Failed to export file", MessageBoxButton.OK, MessageBoxImage.Error);
                 }
             }
         }

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -122,7 +122,7 @@ namespace UndertaleModTool
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show("Failed to export file: " + ex.Message, "Failed to export file", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(Application.Current.MainWindow as MainWindow, "Failed to export file: " + ex.Message, "Failed to export file", MessageBoxButton.OK, MessageBoxImage.Error);
                 }
             }
         }

--- a/UndertaleModTool/Editors/UndertaleSoundEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleSoundEditor.xaml.cs
@@ -98,7 +98,7 @@ namespace UndertaleModTool
                 } catch (Exception ex)
                 {
                     waveOut = null;
-                    MessageBox.Show("Failed to play audio!\r\n" + ex.Message, "Audio failure", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    MessageBox.Show(Application.Current.MainWindow as MainWindow, "Failed to play audio!\r\n" + ex.Message, "Audio failure", MessageBoxButton.OK, MessageBoxImage.Warning);
                 }
                 return;
             }
@@ -131,7 +131,7 @@ namespace UndertaleModTool
                 } catch (Exception ex)
                 {
                     waveOut = null;
-                    MessageBox.Show("Failed to play audio!\r\n" + ex.Message, "Audio failure", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    MessageBox.Show(Application.Current.MainWindow as MainWindow, "Failed to play audio!\r\n" + ex.Message, "Audio failure", MessageBoxButton.OK, MessageBoxImage.Warning);
                     return;
                 }
             } else
@@ -158,17 +158,17 @@ namespace UndertaleModTool
                             waveOut.Play();
                         }
                         else
-                            MessageBox.Show("Failed to play audio!\r\nNot a WAV or OGG.", "Audio failure", MessageBoxButton.OK, MessageBoxImage.Warning);
+                            MessageBox.Show(Application.Current.MainWindow as MainWindow, "Failed to play audio!\r\nNot a WAV or OGG.", "Audio failure", MessageBoxButton.OK, MessageBoxImage.Warning);
                     }
                     catch (Exception ex)
                     {
                         waveOut = null;
-                        MessageBox.Show("Failed to play audio!\r\n" + ex.Message, "Audio failure", MessageBoxButton.OK, MessageBoxImage.Warning);
+                        MessageBox.Show(Application.Current.MainWindow as MainWindow, "Failed to play audio!\r\n" + ex.Message, "Audio failure", MessageBoxButton.OK, MessageBoxImage.Warning);
                     }
                 }
             }
             else
-                MessageBox.Show("Failed to play audio!\r\nNo options for playback worked.", "Audio failure", MessageBoxButton.OK, MessageBoxImage.Warning);
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, "Failed to play audio!\r\nNo options for playback worked.", "Audio failure", MessageBoxButton.OK, MessageBoxImage.Warning);
         }
 
 

--- a/UndertaleModTool/Editors/UndertaleSpriteEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleSpriteEditor.xaml.cs
@@ -33,7 +33,7 @@ namespace UndertaleModTool
 
         private void ExportAllSpine(SaveFileDialog dlg, UndertaleSprite sprite)
         {
-            MessageBox.Show("This seems to be a Spine sprite, .json and .atlas files will be exported together with the frames. " +
+            MessageBox.Show(Application.Current.MainWindow as MainWindow, "This seems to be a Spine sprite, .json and .atlas files will be exported together with the frames. " +
                 "PLEASE EDIT THEM CAREFULLY! SOME MANUAL EDITING OF THE JSON MAY BE REQUIRED! THE DATA IS EXPORTED AS-IS.", "Spine warning", MessageBoxButton.OK, MessageBoxImage.Warning, MessageBoxResult.OK);
 
             if (dlg.ShowDialog() == true)
@@ -58,7 +58,7 @@ namespace UndertaleModTool
                             }
                             catch (Exception ex)
                             {
-                                MessageBox.Show("Failed to export file: " + ex.Message, "Failed to export file", MessageBoxButton.OK, MessageBoxImage.Error);
+                                MessageBox.Show(Application.Current.MainWindow as MainWindow, "Failed to export file: " + ex.Message, "Failed to export file", MessageBoxButton.OK, MessageBoxImage.Error);
                             }
                         }
 
@@ -69,7 +69,7 @@ namespace UndertaleModTool
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show("Failed to export: " + ex.Message, "Failed to export sprite", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(Application.Current.MainWindow as MainWindow, "Failed to export: " + ex.Message, "Failed to export sprite", MessageBoxButton.OK, MessageBoxImage.Error);
                 }
             }
         }
@@ -112,7 +112,7 @@ namespace UndertaleModTool
                             }
                             catch (Exception ex)
                             {
-                                MessageBox.Show("Failed to export file: " + ex.Message, "Failed to export file", MessageBoxButton.OK, MessageBoxImage.Error);
+                                MessageBox.Show(Application.Current.MainWindow as MainWindow, "Failed to export file: " + ex.Message, "Failed to export file", MessageBoxButton.OK, MessageBoxImage.Error);
                             }
                         }
                     }
@@ -124,17 +124,17 @@ namespace UndertaleModTool
                         }
                         catch (Exception ex)
                         {
-                            MessageBox.Show("Failed to export file: " + ex.Message, "Failed to export file", MessageBoxButton.OK, MessageBoxImage.Error);
+                            MessageBox.Show(Application.Current.MainWindow as MainWindow, "Failed to export file: " + ex.Message, "Failed to export file", MessageBoxButton.OK, MessageBoxImage.Error);
                         }
                     }
                     else
                     {
-                        MessageBox.Show("No frames to export", "Failed to export sprite", MessageBoxButton.OK, MessageBoxImage.Error);
+                        MessageBox.Show(Application.Current.MainWindow as MainWindow, "No frames to export", "Failed to export sprite", MessageBoxButton.OK, MessageBoxImage.Error);
                     }
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show("Failed to export: " + ex.Message, "Failed to export sprite", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(Application.Current.MainWindow as MainWindow, "Failed to export: " + ex.Message, "Failed to export sprite", MessageBoxButton.OK, MessageBoxImage.Error);
                 }
             }
 
@@ -166,7 +166,7 @@ namespace UndertaleModTool
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show("Failed to import file: " + ex.Message, "Failed to import file", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(Application.Current.MainWindow as MainWindow, "Failed to import file: " + ex.Message, "Failed to import file", MessageBoxButton.OK, MessageBoxImage.Error);
                 }
             }
         }
@@ -189,7 +189,7 @@ namespace UndertaleModTool
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show("Failed to export file: " + ex.Message, "Failed to export file", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(Application.Current.MainWindow as MainWindow, "Failed to export file: " + ex.Message, "Failed to export file", MessageBoxButton.OK, MessageBoxImage.Error);
                 }
             }
         }

--- a/UndertaleModTool/Editors/UndertaleTexturePageItemEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleTexturePageItemEditor.xaml.cs
@@ -36,7 +36,7 @@ namespace UndertaleModTool
             }
             catch (Exception ex)
             {
-                MessageBox.Show(ex.Message, "Failed to import image", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, ex.Message, "Failed to import image", MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }
 
@@ -56,7 +56,7 @@ namespace UndertaleModTool
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show("Failed to export file: " + ex.Message, "Failed to export file", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(Application.Current.MainWindow as MainWindow, "Failed to export file: " + ex.Message, "Failed to export file", MessageBoxButton.OK, MessageBoxImage.Error);
                 }
                 worker.Cleanup();
             }

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -583,7 +583,7 @@ namespace UndertaleModTool
         {
             if (Data != null)
             {
-                if (MessageBox.Show("Warning: you currently have a project open.\nAre you sure you want to make a new project?", "UndertaleModTool", MessageBoxButton.YesNo, MessageBoxImage.Warning) == MessageBoxResult.No)
+                if (MessageBox.Show(Application.Current.MainWindow as MainWindow, "Warning: you currently have a project open.\nAre you sure you want to make a new project?", "UndertaleModTool", MessageBoxButton.YesNo, MessageBoxImage.Warning) == MessageBoxResult.No)
                     return false;
             }
             this.Dispatcher.Invoke(() =>
@@ -633,12 +633,12 @@ namespace UndertaleModTool
 
                     if (fileext == ".csx")
                     {
-                        if (MessageBox.Show($"Run {filepath} as a script?", "Question", MessageBoxButton.YesNo, MessageBoxImage.Question, MessageBoxResult.No) == MessageBoxResult.Yes)
+                        if (MessageBox.Show(Application.Current.MainWindow as MainWindow, $"Run {filepath} as a script?", "Question", MessageBoxButton.YesNo, MessageBoxImage.Question, MessageBoxResult.No) == MessageBoxResult.Yes)
                             await RunScript(filepath);
                     }
                     else if (IFF_EXTENSIONS.Contains(fileext) || fileext == ".dat" /* audiogroup */)
                     {
-                        if (MessageBox.Show($"Open {filepath} as a data file?", "Question", MessageBoxButton.YesNo, MessageBoxImage.Question, MessageBoxResult.No) == MessageBoxResult.Yes)
+                        if (MessageBox.Show(Application.Current.MainWindow as MainWindow, $"Open {filepath} as a data file?", "Question", MessageBoxButton.YesNo, MessageBoxImage.Question, MessageBoxResult.No) == MessageBoxResult.Yes)
                             await LoadFile(filepath, true);
                     }
                     // else, do something?
@@ -868,7 +868,7 @@ namespace UndertaleModTool
                     {
                         data = UndertaleIO.Read(stream, warning =>
                         {
-                            MessageBox.Show(warning, "Loading warning", MessageBoxButton.OK, MessageBoxImage.Warning);
+                            MessageBox.Show(Application.Current.MainWindow as MainWindow, warning, "Loading warning", MessageBoxButton.OK, MessageBoxImage.Warning);
                             hadWarnings = true;
                         }, message =>
                         {
@@ -878,7 +878,7 @@ namespace UndertaleModTool
                 }
                 catch (Exception e)
                 {
-                    MessageBox.Show("An error occured while trying to load:\n" + e.Message, "Load error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(Application.Current.MainWindow as MainWindow, "An error occured while trying to load:\n" + e.Message, "Load error", MessageBoxButton.OK, MessageBoxImage.Error);
                 }
 
                 Dispatcher.Invoke(async () =>
@@ -887,13 +887,13 @@ namespace UndertaleModTool
                     {
                         if (data.UnsupportedBytecodeVersion)
                         {
-                            MessageBox.Show("Only bytecode versions 13 to 17 are supported for now, you are trying to load " + data.GeneralInfo.BytecodeVersion + ". A lot of code is disabled and will likely break something. Saving/exporting is disabled.", "Unsupported bytecode version", MessageBoxButton.OK, MessageBoxImage.Warning);
+                            MessageBox.Show(Application.Current.MainWindow as MainWindow, "Only bytecode versions 13 to 17 are supported for now, you are trying to load " + data.GeneralInfo.BytecodeVersion + ". A lot of code is disabled and will likely break something. Saving/exporting is disabled.", "Unsupported bytecode version", MessageBoxButton.OK, MessageBoxImage.Warning);
                             CanSave = false;
                             CanSafelySave = false;
                         }
                         else if (hadWarnings)
                         {
-                            MessageBox.Show("Warnings occurred during loading. Data loss will likely occur when trying to save!", "Loading problems", MessageBoxButton.OK, MessageBoxImage.Warning);
+                            MessageBox.Show(Application.Current.MainWindow as MainWindow, "Warnings occurred during loading. Data loss will likely occur when trying to save!", "Loading problems", MessageBoxButton.OK, MessageBoxImage.Warning);
                             CanSave = true;
                             CanSafelySave = false;
                         }
@@ -910,17 +910,17 @@ namespace UndertaleModTool
                         }
                         if (data.GMS2_3 && SettingsWindow.Warn_About_GMS23)
                         {
-                            MessageBox.Show("This game was built using GameMaker Studio 2.3 (or above). Support for this version is a work in progress, and you will likely run into issues decompiling code or in other places.", "GMS 2.3", MessageBoxButton.OK, MessageBoxImage.Warning);
+                            MessageBox.Show(Application.Current.MainWindow as MainWindow, "This game was built using GameMaker Studio 2.3 (or above). Support for this version is a work in progress, and you will likely run into issues decompiling code or in other places.", "GMS 2.3", MessageBoxButton.OK, MessageBoxImage.Warning);
                         }
                         if (data.IsYYC())
                         {
-                            MessageBox.Show("This game uses YYC (YoYo Compiler), which means the code is embedded into the game executable. This configuration is currently not fully supported; continue at your own risk.", "YYC", MessageBoxButton.OK, MessageBoxImage.Warning);
+                            MessageBox.Show(Application.Current.MainWindow as MainWindow, "This game uses YYC (YoYo Compiler), which means the code is embedded into the game executable. This configuration is currently not fully supported; continue at your own risk.", "YYC", MessageBoxButton.OK, MessageBoxImage.Warning);
                         }
                         if (data.GeneralInfo != null)
                         {
                             if (!data.GeneralInfo.IsDebuggerDisabled)
                             {
-                                MessageBox.Show("This game is set to run with the GameMaker Studio debugger and the normal runtime will simply hang after loading if the debugger is not running. You can turn this off in General Info by checking the \"Disable Debugger\" box and saving.", "GMS Debugger", MessageBoxButton.OK, MessageBoxImage.Warning);
+                                MessageBox.Show(Application.Current.MainWindow as MainWindow, "This game is set to run with the GameMaker Studio debugger and the normal runtime will simply hang after loading if the debugger is not running. You can turn this off in General Info by checking the \"Disable Debugger\" box and saving.", "GMS Debugger", MessageBoxButton.OK, MessageBoxImage.Warning);
                             }
                         }
                         if (Path.GetDirectoryName(FilePath) != Path.GetDirectoryName(filename))
@@ -992,7 +992,7 @@ namespace UndertaleModTool
 
             DebugDataDialog.DebugDataMode debugMode = DebugDataDialog.DebugDataMode.NoDebug;
             if (!suppressDebug && Data.GeneralInfo != null && !Data.GeneralInfo.IsDebuggerDisabled)
-                MessageBox.Show("You are saving the game in GameMaker Studio debug mode. Unless the debugger is running, the normal runtime will simply hang after loading. You can turn this off in General Info by checking the \"Disable Debugger\" box and saving.", "GMS Debugger", MessageBoxButton.OK, MessageBoxImage.Warning);
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, "You are saving the game in GameMaker Studio debug mode. Unless the debugger is running, the normal runtime will simply hang after loading. You can turn this off in General Info by checking the \"Disable Debugger\" box and saving.", "GMS Debugger", MessageBoxButton.OK, MessageBoxImage.Warning);
             Task t = Task.Run(async () =>
             {
                 bool SaveSucceeded = true;
@@ -1087,7 +1087,7 @@ namespace UndertaleModTool
                 }
                 catch (Exception e)
                 {
-                    MessageBox.Show("An error occured while trying to save:\n" + e.Message, "Save error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(Application.Current.MainWindow as MainWindow, "An error occured while trying to save:\n" + e.Message, "Save error", MessageBoxButton.OK, MessageBoxImage.Error);
                     SaveSucceeded = false;
                 }
                 // Don't make any changes unless the save succeeds.
@@ -1119,7 +1119,7 @@ namespace UndertaleModTool
                 }
                 catch (Exception exc)
                 {
-                    MessageBox.Show("An error occured while trying to save:\n" + exc.Message, "Save error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(Application.Current.MainWindow as MainWindow, "An error occured while trying to save:\n" + exc.Message, "Save error", MessageBoxButton.OK, MessageBoxImage.Error);
                     SaveSucceeded = false;
                 }
                 if (Data != null)
@@ -1617,7 +1617,7 @@ namespace UndertaleModTool
             object source = container.ItemsSource;
             IList list = ((source as ICollectionView)?.SourceCollection as IList) ?? (source as IList);
             bool isLast = list.IndexOf(obj) == list.Count - 1;
-            if (MessageBox.Show("Delete " + obj.ToString() + "?" + (!isLast ? "\n\nNote that the code often references objects by ID, so this operation is likely to break stuff because other items will shift up!" : ""), "Confirmation", MessageBoxButton.YesNo, isLast ? MessageBoxImage.Question : MessageBoxImage.Warning) == MessageBoxResult.Yes)
+            if (MessageBox.Show(Application.Current.MainWindow as MainWindow, "Delete " + obj.ToString() + "?" + (!isLast ? "\n\nNote that the code often references objects by ID, so this operation is likely to break stuff because other items will shift up!" : ""), "Confirmation", MessageBoxButton.YesNo, isLast ? MessageBoxImage.Question : MessageBoxImage.Warning) == MessageBoxResult.Yes)
             {
                 list.Remove(obj);
                 if (obj is UndertaleCode codeObj)
@@ -2236,7 +2236,7 @@ namespace UndertaleModTool
             {
                 Console.WriteLine(exc.ToString());
                 Dispatcher.Invoke(() => CommandBox.Text = exc.Message);
-                MessageBox.Show(exc.Message, "Script compile error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, exc.Message, "Script compile error", MessageBoxButton.OK, MessageBoxImage.Error);
                 ScriptExecutionSuccess = false;
                 ScriptErrorMessage = exc.Message;
                 ScriptErrorType = "CompilationErrorException";
@@ -2253,7 +2253,7 @@ namespace UndertaleModTool
 
                 Console.WriteLine(exc.ToString());
                 Dispatcher.Invoke(() => CommandBox.Text = exc.Message);
-                MessageBox.Show(isScriptException ? exc.Message : excString, "Script error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, isScriptException ? exc.Message : excString, "Script error", MessageBoxButton.OK, MessageBoxImage.Error);
                 ScriptExecutionSuccess = false;
                 ScriptErrorMessage = exc.Message;
                 ScriptErrorType = "Exception";
@@ -2287,20 +2287,20 @@ namespace UndertaleModTool
 
         public void ScriptMessage(string message)
         {
-            MessageBox.Show(message, "Script message", MessageBoxButton.OK, MessageBoxImage.Information);
+            MessageBox.Show(Application.Current.MainWindow as MainWindow, message, "Script message", MessageBoxButton.OK, MessageBoxImage.Information);
         }
         public bool ScriptQuestion(string message)
         {
             PlayInformationSound();
-            return MessageBox.Show(message, "Script message", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes;
+            return MessageBox.Show(Application.Current.MainWindow as MainWindow, message, "Script message", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes;
         }
         public void ScriptWarning(string message)
         {
-            MessageBox.Show(message, "Script warning", MessageBoxButton.OK, MessageBoxImage.Warning);
+            MessageBox.Show(Application.Current.MainWindow as MainWindow, message, "Script warning", MessageBoxButton.OK, MessageBoxImage.Warning);
         }
         public void ScriptError(string error, string title = "Error", bool SetConsoleText = true)
         {
-            MessageBox.Show(error, title, MessageBoxButton.OK, MessageBoxImage.Error);
+            MessageBox.Show(Application.Current.MainWindow as MainWindow, error, title, MessageBoxButton.OK, MessageBoxImage.Error);
             if (SetConsoleText)
             {
                 SetUMTConsoleText(error);
@@ -2311,27 +2311,27 @@ namespace UndertaleModTool
         public static void ShowMessage(string message, bool wait = true)
         {
             if (wait)
-                MessageBox.Show(message, "UndertaleModTool", MessageBoxButton.OK, MessageBoxImage.Information);
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, message, "UndertaleModTool", MessageBoxButton.OK, MessageBoxImage.Information);
             else
-                _ = Task.Run(() => MessageBox.Show(message, "UndertaleModTool", MessageBoxButton.OK, MessageBoxImage.Information));
+                _ = Task.Run(() => MessageBox.Show(Application.Current.MainWindow as MainWindow, message, "UndertaleModTool", MessageBoxButton.OK, MessageBoxImage.Information));
         }
         public static MessageBoxResult ShowQuestion(string message, MessageBoxImage icon = MessageBoxImage.Question)
         {
-            return MessageBox.Show(message, "UndertaleModTool", MessageBoxButton.YesNo, icon);
+            return MessageBox.Show(Application.Current.MainWindow as MainWindow, message, "UndertaleModTool", MessageBoxButton.YesNo, icon);
         }
         public static void ShowWarning(string message, bool wait = true)
         {
             if (wait)
-                MessageBox.Show(message, "UndertaleModTool", MessageBoxButton.OK, MessageBoxImage.Warning);
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, message, "UndertaleModTool", MessageBoxButton.OK, MessageBoxImage.Warning);
             else
-                _ = Task.Run(() => MessageBox.Show(message, "UndertaleModTool", MessageBoxButton.OK, MessageBoxImage.Warning));
+                _ = Task.Run(() => MessageBox.Show(Application.Current.MainWindow as MainWindow, message, "UndertaleModTool", MessageBoxButton.OK, MessageBoxImage.Warning));
         }
         public static void ShowError(string message, bool wait = true)
         {
             if (wait)
-                MessageBox.Show(message, "UndertaleModTool", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, message, "UndertaleModTool", MessageBoxButton.OK, MessageBoxImage.Error);
             else
-                _ = Task.Run(() => MessageBox.Show(message, "UndertaleModTool", MessageBoxButton.OK, MessageBoxImage.Error));
+                _ = Task.Run(() => MessageBox.Show(Application.Current.MainWindow as MainWindow, message, "UndertaleModTool", MessageBoxButton.OK, MessageBoxImage.Error));
         }
 
         public void SetUMTConsoleText(string message)
@@ -2450,7 +2450,7 @@ namespace UndertaleModTool
 
         private void MenuItem_About_Click(object sender, RoutedEventArgs e)
         {
-            MessageBox.Show("UndertaleModTool by krzys_h\nVersion " + Version, "About", MessageBoxButton.OK);
+            MessageBox.Show(Application.Current.MainWindow as MainWindow, "UndertaleModTool by krzys_h\nVersion " + Version, "About", MessageBoxButton.OK);
         }
 
         /// From https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Dialogs/AboutAvaloniaDialog.xaml.cs
@@ -2485,7 +2485,7 @@ namespace UndertaleModTool
             }
             catch (Exception e)
             {
-                MessageBox.Show("Failed to open browser!\n" + e.ToString());
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, "Failed to open browser!\n" + e.ToString());
             }
         }
 
@@ -2505,7 +2505,7 @@ namespace UndertaleModTool
             }
             catch (Exception e)
             {
-                MessageBox.Show("Failed to open folder!\n" + e.ToString());
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, "Failed to open folder!\n" + e.ToString());
             }
         }
 
@@ -2931,7 +2931,7 @@ result in loss of work.");
                     return;
                 if (runtime.DebuggerPath == null)
                 {
-                    MessageBox.Show("The selected runtime does not support debugging.", "Run error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(Application.Current.MainWindow as MainWindow, "The selected runtime does not support debugging.", "Run error", MessageBoxButton.OK, MessageBoxImage.Error);
                     return;
                 }
 
@@ -3128,7 +3128,7 @@ result in loss of work.");
                         }
                         catch (Exception ex)
                         {
-                            MessageBox.Show("An error occured while trying to load:\n" + ex.Message, "Load error", MessageBoxButton.OK, MessageBoxImage.Error);
+                            MessageBox.Show(Application.Current.MainWindow as MainWindow, "An error occured while trying to load:\n" + ex.Message, "Load error", MessageBoxButton.OK, MessageBoxImage.Error);
                         }
 
                         Dispatcher.Invoke(() =>

--- a/UndertaleModTool/ProfileSystem.cs
+++ b/UndertaleModTool/ProfileSystem.cs
@@ -75,12 +75,12 @@ namespace UndertaleModTool
                         if (Directory.Exists(Path.Combine(ProfilesFolder, reportedHashOfCrashedFile)) &&
                             profileHashOfCrashedFile == reportedHashOfCrashedFile)
                         {
-                            if (MessageBox.Show(Application.Current.MainWindow as MainWindow, "UndertaleModTool crashed during usage last time while editing " + pathOfCrashedFile + ", would you like to recover your code now?", "UndertaleModTool", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes)
+                            if (MessageBox.Show(this, "UndertaleModTool crashed during usage last time while editing " + pathOfCrashedFile + ", would you like to recover your code now?", "UndertaleModTool", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes)
                             {
                                 LoadFile(pathOfCrashedFile, true).ContinueWith((t) => { });
                                 if (Data == null)
                                 {
-                                    MessageBox.Show(Application.Current.MainWindow as MainWindow, "Failed to load data when recovering.");
+                                    MessageBox.Show(this, "Failed to load data when recovering.");
                                     return;
                                 }
                                 string[] dirFiles = Directory.GetFiles(dataRecoverLocation);
@@ -96,11 +96,11 @@ namespace UndertaleModTool
                                     codeLoadDialog.Dispatcher.Invoke(DispatcherPriority.Background, new ThreadStart(delegate { })); // Updates the UI, so you can see the progress.
                                 }
                                 codeLoadDialog.TryClose();
-                                MessageBox.Show(Application.Current.MainWindow as MainWindow, "Completed.");
+                                MessageBox.Show(this, "Completed.");
                             }
-                            else if (MessageBox.Show(Application.Current.MainWindow as MainWindow, "Would you like to move this code to the \"Recovered\" folder now? Any previous code there will be cleared!", "UndertaleModTool", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes)
+                            else if (MessageBox.Show(this, "Would you like to move this code to the \"Recovered\" folder now? Any previous code there will be cleared!", "UndertaleModTool", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes)
                             {
-                                MessageBox.Show(Application.Current.MainWindow as MainWindow, "Your code can be recovered from the \"Recovered\" folder at any time.");
+                                MessageBox.Show(this, "Your code can be recovered from the \"Recovered\" folder at any time.");
                                 string recoveredDir = Path.Combine(AppDataFolder, "Recovered", reportedHashOfCrashedFile);
                                 if (!Directory.Exists(Path.Combine(AppDataFolder, "Recovered")))
                                     Directory.CreateDirectory(Path.Combine(AppDataFolder, "Recovered"));
@@ -111,19 +111,19 @@ namespace UndertaleModTool
                             }
                             else
                             {
-                                MessageBox.Show(Application.Current.MainWindow as MainWindow, "A crash has been detected from last session. Please check the Profiles folder for recoverable data now.");
+                                MessageBox.Show(this, "A crash has been detected from last session. Please check the Profiles folder for recoverable data now.");
                             }
                         }
                     }
                     else
                     {
-                        MessageBox.Show(Application.Current.MainWindow as MainWindow, "A crash has been detected from last session. Please check the Profiles folder for recoverable data now.");
+                        MessageBox.Show(this, "A crash has been detected from last session. Please check the Profiles folder for recoverable data now.");
                     }
                 }
             }
             catch (Exception exc)
             {
-                MessageBox.Show(Application.Current.MainWindow as MainWindow, "CrashCheck error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                MessageBox.Show(this, "CrashCheck error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
 
@@ -135,7 +135,7 @@ namespace UndertaleModTool
             }
             catch (Exception exc)
             {
-                MessageBox.Show(Application.Current.MainWindow as MainWindow, "ApplyCorrections error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                MessageBox.Show(this, "ApplyCorrections error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
 
@@ -147,7 +147,7 @@ namespace UndertaleModTool
             }
             catch (Exception exc)
             {
-                MessageBox.Show(Application.Current.MainWindow as MainWindow, "CreateUMTLastEdited error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                MessageBox.Show(this, "CreateUMTLastEdited error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
 
@@ -161,7 +161,7 @@ namespace UndertaleModTool
             }
             catch (Exception exc)
             {
-                MessageBox.Show(Application.Current.MainWindow as MainWindow, "DestroyUMTLastEdited error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                MessageBox.Show(this, "DestroyUMTLastEdited error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
 
@@ -180,7 +180,7 @@ namespace UndertaleModTool
             }
             catch (Exception exc)
             {
-                MessageBox.Show(Application.Current.MainWindow as MainWindow, "RevertProfile error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                MessageBox.Show(this, "RevertProfile error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
         public void SaveTempToMainProfile()
@@ -201,7 +201,7 @@ namespace UndertaleModTool
             }
             catch (Exception exc)
             {
-                MessageBox.Show(Application.Current.MainWindow as MainWindow, "SaveTempToMainProfile error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                MessageBox.Show(this, "SaveTempToMainProfile error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
         public void UpdateProfile(UndertaleData data, string filename)
@@ -226,7 +226,7 @@ namespace UndertaleModTool
                 {
                     if (data.GMS2_3)
                     {
-                        MessageBox.Show(Application.Current.MainWindow as MainWindow, "Profile mode is not currently supported for GameMaker Studio 2.3 games.");
+                        MessageBox.Show(this, "Profile mode is not currently supported for GameMaker Studio 2.3 games.");
                         return;
                     }
 
@@ -267,14 +267,14 @@ namespace UndertaleModTool
                     Directory.CreateDirectory(profDirTemp);
                     if (!Directory.Exists(profDir) || !Directory.Exists(profDirMain) || !Directory.Exists(profDirTemp))
                     {
-                        MessageBox.Show(Application.Current.MainWindow as MainWindow, "Profile should exist, but does not. Insufficient permissions? Profile mode is disabled.");
+                        MessageBox.Show(this, "Profile should exist, but does not. Insufficient permissions? Profile mode is disabled.");
                         SettingsWindow.ProfileModeEnabled = false;
                         return;
                     }
 
                     if (!SettingsWindow.ProfileMessageShown)
                     {
-                        MessageBox.Show(Application.Current.MainWindow as MainWindow, @"The profile for your game loaded successfully!
+                        MessageBox.Show(this, @"The profile for your game loaded successfully!
 
 UndertaleModTool now uses the ""Profile"" system by default for code.
 Using the profile system, many new features are available to you!
@@ -301,7 +301,7 @@ an issue on GitHub.");
             }
             catch (Exception exc)
             {
-                MessageBox.Show(Application.Current.MainWindow as MainWindow, "UpdateProfile error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                MessageBox.Show(this, "UpdateProfile error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
         public void ProfileSaveEvent(UndertaleData data, string filename)
@@ -371,7 +371,7 @@ an issue on GitHub.");
                     Directory.CreateDirectory(profDir);
                     Directory.CreateDirectory(Path.Combine(profDir, "Main"));
                     Directory.CreateDirectory(Path.Combine(profDir, "Temp"));
-                    MessageBox.Show(Application.Current.MainWindow as MainWindow, "Profile saved successfully to " + ProfileHash);
+                    MessageBox.Show(this, "Profile saved successfully to " + ProfileHash);
                 }
                 if (SettingsWindow.DeleteOldProfileOnSave && copyProfile)
                 {
@@ -380,7 +380,7 @@ an issue on GitHub.");
             }
             catch (Exception exc)
             {
-                MessageBox.Show(Application.Current.MainWindow as MainWindow, "ProfileSaveEvent error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                MessageBox.Show(this, "ProfileSaveEvent error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
         public void DirectoryCopy(string sourceDirName, string destDirName, bool copySubDirs)
@@ -413,7 +413,7 @@ an issue on GitHub.");
                         }
                         catch (Exception ex)
                         {
-                            MessageBox.Show(Application.Current.MainWindow as MainWindow, "An exception occurred while processing copying " + tempPath + "\nException: \n" + ex.ToString(), "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                            MessageBox.Show(this, "An exception occurred while processing copying " + tempPath + "\nException: \n" + ex.ToString(), "Error", MessageBoxButton.OK, MessageBoxImage.Error);
                             return;
                         }
                     }
@@ -431,7 +431,7 @@ an issue on GitHub.");
             }
             catch (Exception exc)
             {
-                MessageBox.Show(Application.Current.MainWindow as MainWindow, "DirectoryCopy error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                MessageBox.Show(this, "DirectoryCopy error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
     }

--- a/UndertaleModTool/ProfileSystem.cs
+++ b/UndertaleModTool/ProfileSystem.cs
@@ -75,12 +75,12 @@ namespace UndertaleModTool
                         if (Directory.Exists(Path.Combine(ProfilesFolder, reportedHashOfCrashedFile)) &&
                             profileHashOfCrashedFile == reportedHashOfCrashedFile)
                         {
-                            if (MessageBox.Show("UndertaleModTool crashed during usage last time while editing " + pathOfCrashedFile + ", would you like to recover your code now?", "UndertaleModTool", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes)
+                            if (MessageBox.Show(Application.Current.MainWindow as MainWindow, "UndertaleModTool crashed during usage last time while editing " + pathOfCrashedFile + ", would you like to recover your code now?", "UndertaleModTool", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes)
                             {
                                 LoadFile(pathOfCrashedFile, true).ContinueWith((t) => { });
                                 if (Data == null)
                                 {
-                                    MessageBox.Show("Failed to load data when recovering.");
+                                    MessageBox.Show(Application.Current.MainWindow as MainWindow, "Failed to load data when recovering.");
                                     return;
                                 }
                                 string[] dirFiles = Directory.GetFiles(dataRecoverLocation);
@@ -96,11 +96,11 @@ namespace UndertaleModTool
                                     codeLoadDialog.Dispatcher.Invoke(DispatcherPriority.Background, new ThreadStart(delegate { })); // Updates the UI, so you can see the progress.
                                 }
                                 codeLoadDialog.TryClose();
-                                MessageBox.Show("Completed.");
+                                MessageBox.Show(Application.Current.MainWindow as MainWindow, "Completed.");
                             }
-                            else if (MessageBox.Show("Would you like to move this code to the \"Recovered\" folder now? Any previous code there will be cleared!", "UndertaleModTool", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes)
+                            else if (MessageBox.Show(Application.Current.MainWindow as MainWindow, "Would you like to move this code to the \"Recovered\" folder now? Any previous code there will be cleared!", "UndertaleModTool", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes)
                             {
-                                MessageBox.Show("Your code can be recovered from the \"Recovered\" folder at any time.");
+                                MessageBox.Show(Application.Current.MainWindow as MainWindow, "Your code can be recovered from the \"Recovered\" folder at any time.");
                                 string recoveredDir = Path.Combine(AppDataFolder, "Recovered", reportedHashOfCrashedFile);
                                 if (!Directory.Exists(Path.Combine(AppDataFolder, "Recovered")))
                                     Directory.CreateDirectory(Path.Combine(AppDataFolder, "Recovered"));
@@ -111,19 +111,19 @@ namespace UndertaleModTool
                             }
                             else
                             {
-                                MessageBox.Show("A crash has been detected from last session. Please check the Profiles folder for recoverable data now.");
+                                MessageBox.Show(Application.Current.MainWindow as MainWindow, "A crash has been detected from last session. Please check the Profiles folder for recoverable data now.");
                             }
                         }
                     }
                     else
                     {
-                        MessageBox.Show("A crash has been detected from last session. Please check the Profiles folder for recoverable data now.");
+                        MessageBox.Show(Application.Current.MainWindow as MainWindow, "A crash has been detected from last session. Please check the Profiles folder for recoverable data now.");
                     }
                 }
             }
             catch (Exception exc)
             {
-                MessageBox.Show("CrashCheck error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, "CrashCheck error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
 
@@ -135,7 +135,7 @@ namespace UndertaleModTool
             }
             catch (Exception exc)
             {
-                MessageBox.Show("ApplyCorrections error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, "ApplyCorrections error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
 
@@ -147,7 +147,7 @@ namespace UndertaleModTool
             }
             catch (Exception exc)
             {
-                MessageBox.Show("CreateUMTLastEdited error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, "CreateUMTLastEdited error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
 
@@ -161,7 +161,7 @@ namespace UndertaleModTool
             }
             catch (Exception exc)
             {
-                MessageBox.Show("DestroyUMTLastEdited error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, "DestroyUMTLastEdited error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
 
@@ -180,7 +180,7 @@ namespace UndertaleModTool
             }
             catch (Exception exc)
             {
-                MessageBox.Show("RevertProfile error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, "RevertProfile error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
         public void SaveTempToMainProfile()
@@ -201,7 +201,7 @@ namespace UndertaleModTool
             }
             catch (Exception exc)
             {
-                MessageBox.Show("SaveTempToMainProfile error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, "SaveTempToMainProfile error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
         public void UpdateProfile(UndertaleData data, string filename)
@@ -226,7 +226,7 @@ namespace UndertaleModTool
                 {
                     if (data.GMS2_3)
                     {
-                        MessageBox.Show("Profile mode is not currently supported for GameMaker Studio 2.3 games.");
+                        MessageBox.Show(Application.Current.MainWindow as MainWindow, "Profile mode is not currently supported for GameMaker Studio 2.3 games.");
                         return;
                     }
 
@@ -267,14 +267,14 @@ namespace UndertaleModTool
                     Directory.CreateDirectory(profDirTemp);
                     if (!Directory.Exists(profDir) || !Directory.Exists(profDirMain) || !Directory.Exists(profDirTemp))
                     {
-                        MessageBox.Show("Profile should exist, but does not. Insufficient permissions? Profile mode is disabled.");
+                        MessageBox.Show(Application.Current.MainWindow as MainWindow, "Profile should exist, but does not. Insufficient permissions? Profile mode is disabled.");
                         SettingsWindow.ProfileModeEnabled = false;
                         return;
                     }
 
                     if (!SettingsWindow.ProfileMessageShown)
                     {
-                        MessageBox.Show(@"The profile for your game loaded successfully!
+                        MessageBox.Show(Application.Current.MainWindow as MainWindow, @"The profile for your game loaded successfully!
 
 UndertaleModTool now uses the ""Profile"" system by default for code.
 Using the profile system, many new features are available to you!
@@ -301,7 +301,7 @@ an issue on GitHub.");
             }
             catch (Exception exc)
             {
-                MessageBox.Show("UpdateProfile error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, "UpdateProfile error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
         public void ProfileSaveEvent(UndertaleData data, string filename)
@@ -371,7 +371,7 @@ an issue on GitHub.");
                     Directory.CreateDirectory(profDir);
                     Directory.CreateDirectory(Path.Combine(profDir, "Main"));
                     Directory.CreateDirectory(Path.Combine(profDir, "Temp"));
-                    MessageBox.Show("Profile saved successfully to " + ProfileHash);
+                    MessageBox.Show(Application.Current.MainWindow as MainWindow, "Profile saved successfully to " + ProfileHash);
                 }
                 if (SettingsWindow.DeleteOldProfileOnSave && copyProfile)
                 {
@@ -380,7 +380,7 @@ an issue on GitHub.");
             }
             catch (Exception exc)
             {
-                MessageBox.Show("ProfileSaveEvent error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, "ProfileSaveEvent error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
         public void DirectoryCopy(string sourceDirName, string destDirName, bool copySubDirs)
@@ -413,7 +413,7 @@ an issue on GitHub.");
                         }
                         catch (Exception ex)
                         {
-                            MessageBox.Show("An exception occurred while processing copying " + tempPath + "\nException: \n" + ex.ToString(), "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                            MessageBox.Show(Application.Current.MainWindow as MainWindow, "An exception occurred while processing copying " + tempPath + "\nException: \n" + ex.ToString(), "Error", MessageBoxButton.OK, MessageBoxImage.Error);
                             return;
                         }
                     }
@@ -431,7 +431,7 @@ an issue on GitHub.");
             }
             catch (Exception exc)
             {
-                MessageBox.Show("DirectoryCopy error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, "DirectoryCopy error! Send this to Grossley#2869 and make an issue on Github\n" + exc.ToString());
             }
         }
     }

--- a/UndertaleModTool/Program.cs
+++ b/UndertaleModTool/Program.cs
@@ -37,7 +37,7 @@ namespace UndertaleModTool
             catch (Exception e)
             {
                 File.WriteAllText(Path.Combine(GetExecutableDirectory(), "crash.txt"), e.ToString());
-                MessageBox.Show(e.ToString());
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, e.ToString());
             }
         }
         private static void GlobalUnhandledExceptionHandler(object sender, UnhandledExceptionEventArgs e)

--- a/UndertaleModTool/Program.cs
+++ b/UndertaleModTool/Program.cs
@@ -37,7 +37,7 @@ namespace UndertaleModTool
             catch (Exception e)
             {
                 File.WriteAllText(Path.Combine(GetExecutableDirectory(), "crash.txt"), e.ToString());
-                MessageBox.Show(Application.Current.MainWindow as MainWindow, e.ToString());
+                MessageBox.Show(e.ToString());
             }
         }
         private static void GlobalUnhandledExceptionHandler(object sender, UnhandledExceptionEventArgs e)

--- a/UndertaleModTool/Settings.cs
+++ b/UndertaleModTool/Settings.cs
@@ -86,7 +86,7 @@ namespace UndertaleModTool
                     Save();
             } catch (Exception e)
             {
-                MessageBox.Show($"Failed to load settings.json! Using default values.\n{e.Message}");
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, $"Failed to load settings.json! Using default values.\n{e.Message}");
                 new Settings();
             }
         }
@@ -102,7 +102,7 @@ namespace UndertaleModTool
             }
             catch (Exception e)
             {
-                MessageBox.Show($"Failed to save settings.json!\n{e.Message}");
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, $"Failed to save settings.json!\n{e.Message}");
             }
         }
     }

--- a/UndertaleModTool/Windows/RuntimePicker.xaml.cs
+++ b/UndertaleModTool/Windows/RuntimePicker.xaml.cs
@@ -106,7 +106,7 @@ namespace UndertaleModTool
             DiscoverRuntimes(dataFilePath, data);
             if (Runtimes.Count == 0)
             {
-                MessageBox.Show("Unable to find game EXE or any installed Studio runtime", "Run error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(Application.Current.MainWindow as MainWindow, "Unable to find game EXE or any installed Studio runtime", "Run error", MessageBoxButton.OK, MessageBoxImage.Error);
                 return null;
             }
             else if (Runtimes.Count == 1)


### PR DESCRIPTION

## Description
Fixes MessageBoxes appearing below the UMT window by passing the MainWindow instance to the MessageBox.Show call.

This does NOT make the MessageBox appear in the foreground, only above the UMT window.

Fixes #878.
### Caveats
None known.

### Notes
Yes, I used Find&Replace, but it seems to work so ¯\\_(ツ)_/¯