### PR TITLE
Improved sprite texture entries removing.

### DIFF
--- a/UndertaleModTool/Controls/UndertaleObjectReference.xaml
+++ b/UndertaleModTool/Controls/UndertaleObjectReference.xaml
@@ -12,8 +12,11 @@
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="Auto"/>
         </Grid.ColumnDefinitions>
-        <TextBox Grid.Column="0" IsReadOnly="True" Cursor="Arrow" ToolTip="This is an object reference. Drag and drop an object of matching type from the tree on the left to change it!" AllowDrop="True" PreviewDragOver="TextBox_DragOver" PreviewDrop="TextBox_Drop" PreviewMouseDoubleClick="TextBox_MouseDoubleClick" Text="{Binding ObjectReference, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
-        <Button Grid.Column="1" Click="Details_Click">
+        <TextBox Grid.Column="0" Name="ObjectText" IsReadOnly="True" Cursor="Arrow" AllowDrop="True"
+                 ToolTip="This is an object reference. Drag and drop an object of matching type from the tree on the left to change it!"
+                 PreviewDragOver="TextBox_DragOver" PreviewDrop="TextBox_Drop" PreviewMouseDoubleClick="TextBox_MouseDoubleClick"
+                 Text="{Binding ObjectReference, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
+        <Button Grid.Column="1" Name="DetailsButton" Click="Details_Click">
             <Button.Style>
                 <Style TargetType="{x:Type Button}">
                     <Setter Property="Content" Value=" ... " />
@@ -36,7 +39,7 @@
                 </Style>
             </Button.Style>
         </Button>
-        <Button Grid.Column="2" Click="Remove_Click" Content=" X " ToolTip="Remove reference">
+        <Button Grid.Column="2" Name="RemoveButton" Click="Remove_Click" Content=" X " ToolTip="Remove reference">
             <Button.Style>
                 <Style TargetType="{x:Type Button}">
                     <Style.Triggers>

--- a/UndertaleModTool/Controls/UndertaleObjectReference.xaml.cs
+++ b/UndertaleModTool/Controls/UndertaleObjectReference.xaml.cs
@@ -93,11 +93,7 @@ namespace UndertaleModTool
 
         public void ClearRemoveClickHandler()
         {
-            try
-            {
-                RemoveButton.Click -= Remove_Click;
-            }
-            catch { }
+            RemoveButton.Click -= Remove_Click;
         }
 
         private void Details_Click(object sender, RoutedEventArgs e)

--- a/UndertaleModTool/Controls/UndertaleObjectReference.xaml.cs
+++ b/UndertaleModTool/Controls/UndertaleObjectReference.xaml.cs
@@ -91,6 +91,15 @@ namespace UndertaleModTool
             InitializeComponent();
         }
 
+        public void ClearRemoveClickHandler()
+        {
+            try
+            {
+                RemoveButton.Click -= Remove_Click;
+            }
+            catch { }
+        }
+
         private void Details_Click(object sender, RoutedEventArgs e)
         {
             if (ObjectReference is null)

--- a/UndertaleModTool/Controls/UndertaleTexturePageItemDisplay.xaml
+++ b/UndertaleModTool/Controls/UndertaleTexturePageItemDisplay.xaml
@@ -1,4 +1,4 @@
-﻿<local:DataUserControl x:Class="UndertaleModTool.UndertaleTexturePageItemDisplay"
+﻿<UserControl x:Class="UndertaleModTool.UndertaleTexturePageItemDisplay"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -21,4 +21,4 @@
             </Border.Background>
         </Border>
     </Canvas>
-</local:DataUserControl>
+</UserControl>

--- a/UndertaleModTool/Controls/UndertaleTexturePageItemDisplay.xaml.cs
+++ b/UndertaleModTool/Controls/UndertaleTexturePageItemDisplay.xaml.cs
@@ -20,7 +20,7 @@ namespace UndertaleModTool
     /// <summary>
     /// Logika interakcji dla klasy UndertaleTexturePageItemDisplay.xaml
     /// </summary>
-    public partial class UndertaleTexturePageItemDisplay : DataUserControl
+    public partial class UndertaleTexturePageItemDisplay : UserControl
     {
         public UndertaleTexturePageItemDisplay()
         {

--- a/UndertaleModTool/Editors/UndertaleSpriteEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleSpriteEditor.xaml
@@ -105,7 +105,10 @@
         </Grid>
 
         <TextBlock Grid.Row="10" Grid.Column="0" Margin="3">Textures</TextBlock>
-        <DataGrid Grid.Row="10" Grid.Column="1" Margin="3" ItemsSource="{Binding Textures, Mode=OneWay}" Name="TextureList" AutoGenerateColumns="False" CanUserAddRows="True" CanUserDeleteRows="True" HorizontalGridLinesBrush="LightGray" VerticalGridLinesBrush="LightGray" HeadersVisibility="None" SelectionMode="Single" SelectionUnit="FullRow" IsSynchronizedWithCurrentItem="True">
+        <DataGrid Grid.Row="10" Grid.Column="1" Margin="3" ItemsSource="{Binding Textures, Mode=OneWay}" Name="TextureList"
+                  AutoGenerateColumns="False" CanUserAddRows="True" CanUserDeleteRows="True"
+                  HorizontalGridLinesBrush="LightGray" VerticalGridLinesBrush="LightGray"
+                  HeadersVisibility="None" SelectionMode="Single" SelectionUnit="FullRow" IsSynchronizedWithCurrentItem="True">
             <DataGrid.Resources>
                 <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="#FF26A0DA"/>
                 <Style TargetType="{x:Type DataGridCell}">
@@ -135,7 +138,10 @@
                 <DataGridTemplateColumn Width="*">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <local:UndertaleObjectReference Margin="20,0,0,0" ObjectReference="{Binding Texture, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ObjectType="{x:Type undertale:UndertaleTexturePageItem}" CanRemove="False"/>
+                            <local:UndertaleObjectReference Margin="20,0,0,0" CanRemove="True"
+                                                            Loaded="UndertaleObjectReference_Loaded"
+                                                            ObjectReference="{Binding Texture, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                            ObjectType="{x:Type undertale:UndertaleTexturePageItem}"/>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>

--- a/UndertaleModTool/Editors/UndertaleSpriteEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleSpriteEditor.xaml.cs
@@ -193,5 +193,27 @@ namespace UndertaleModTool
                 }
             }
         }
+
+        private void UndertaleObjectReference_Loaded(object sender, RoutedEventArgs e)
+        {
+            var objRef = sender as UndertaleObjectReference;
+
+            objRef.ClearRemoveClickHandler();
+            objRef.RemoveButton.Click += Remove_Click_Override;
+            objRef.RemoveButton.ToolTip = "Remove texture entry";
+            objRef.RemoveButton.IsEnabled = true;
+            objRef.DetailsButton.ToolTip = "Open texture entry";
+            objRef.ObjectText.PreviewKeyDown += ObjectText_PreviewKeyDown;
+        }
+        private void ObjectText_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Delete)
+                Remove_Click_Override(sender, null);
+        }
+        private void Remove_Click_Override(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is UndertaleSprite spr && (sender as FrameworkElement).DataContext is UndertaleSprite.TextureEntry entry)
+                spr.Textures.Remove(entry);
+        }
     }
 }

--- a/UndertaleModTool/Editors/UndertaleSpriteEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleSpriteEditor.xaml.cs
@@ -212,8 +212,8 @@ namespace UndertaleModTool
         }
         private void Remove_Click_Override(object sender, RoutedEventArgs e)
         {
-            if (DataContext is UndertaleSprite spr && (sender as FrameworkElement).DataContext is UndertaleSprite.TextureEntry entry)
-                spr.Textures.Remove(entry);
+            if (DataContext is UndertaleSprite sprite && (sender as FrameworkElement).DataContext is UndertaleSprite.TextureEntry entry)
+                sprite.Textures.Remove(entry);
         }
     }
 }


### PR DESCRIPTION
## Description
Now, to remove a sprite texture entry, you can just press `Delete` key or "X" button (which is always active).
Also, fixed a bug, when `UndertaleTexturePageItemDisplay` was displaying last non-null texture instead of displaying nothing.

### Caveats
None.