### PR TITLE
Meta: update discord link and remove unnecessary issue title

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Something not behaving the way it should? Let us know!
-title: "Bug: <Title>"
+title: ""
 labels: ["bug"]
 body:
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: UnderMiners Discord
-    url: https://discord.gg/UMwccfs2Hb
-    about: For UndertaleModTool questions, discussion, analysis and feedback
+    url: https://discord.gg/hnyMDypMbN
+    about: For UndertaleModTool questions, discussion, analysis and feedback.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Suggest a Feature
 description: Have an idea for something completely new that UndertaleModTool could benefit from having? Or for improving something that already exists? Let us know!
-title: "Feature: <Title>"
+title: ""
 labels: ["enhancement"]
 body:
 - type: dropdown

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # UndertaleModTool
 
-[![Underminers Discord](https://img.shields.io/discord/566861759210586112?label=Discord&logo=discord&logoColor=white)](https://discord.gg/UMwccfs2Hb) [![GitHub](https://img.shields.io/github/license/krzys-h/UndertaleModTool?logo=github)](https://github.com/krzys-h/UndertaleModTool/blob/master/LICENSE.txt)
+[![Underminers Discord](https://img.shields.io/discord/566861759210586112?label=Discord&logo=discord&logoColor=white)](https://discord.gg/hnyMDypMbN) [![GitHub](https://img.shields.io/github/license/krzys-h/UndertaleModTool?logo=github)](https://github.com/krzys-h/UndertaleModTool/blob/master/LICENSE.txt)
 
 (seeing such an amazing tool fills you with DETERMINATION.)
 


### PR DESCRIPTION
## Description
Updates the discord link in readme and removes unnecessary titles for issue templates, as their type is already apparent via labels.

### Caveats
None