### PR TITLE
File path related fixes and improvements.

### DIFF
--- a/UndertaleModTool/Editors/UndertaleSoundEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleSoundEditor.xaml.cs
@@ -12,7 +12,6 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
-using System.Windows.Shapes;
 using NAudio.Vorbis;
 using NAudio.Wave;
 using UndertaleModLib;
@@ -66,10 +65,10 @@ namespace UndertaleModTool
                         filename = sound.File.Content + ".ogg";
                     else
                         filename = sound.File.Content;
-                    string audioPath = System.IO.Path.Combine(System.IO.Path.GetDirectoryName((Application.Current.MainWindow as MainWindow).FilePath), filename);
+                    string audioPath = Path.Combine(Path.GetDirectoryName((Application.Current.MainWindow as MainWindow).FilePath), filename);
                     if (File.Exists(audioPath))
                     {
-                        switch (System.IO.Path.GetExtension(filename).ToLower())
+                        switch (Path.GetExtension(filename).ToLower())
                         {
                             case ".wav":
                                 wavReader = new WaveFileReader(audioPath);
@@ -109,7 +108,7 @@ namespace UndertaleModTool
             {
                 try
                 {
-                    string path = System.IO.Path.Combine(System.IO.Path.GetDirectoryName((Application.Current.MainWindow as MainWindow).FilePath), "audiogroup" + sound.GroupID + ".dat");
+                    string path = Path.Combine(Path.GetDirectoryName((Application.Current.MainWindow as MainWindow).FilePath), "audiogroup" + sound.GroupID + ".dat");
                     if (File.Exists(path))
                     {
                         if (loadedPath != path)

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -1155,11 +1155,17 @@ namespace UndertaleModTool
         private async Task LoadGMLCache(string filename, LoaderDialog dialog = null)
         {
             await Task.Run(() => {
-                if (SettingsWindow.UseGMLCache && File.Exists(Path.Join("GMLCache", "index")))
+                if (SettingsWindow.UseGMLCache)
                 {
+                    string cacheDirPath = Path.Combine(ExePath, "GMLCache");
+                    string cacheIndexPath = Path.Combine(cacheDirPath, "index");
+
+                    if (!File.Exists(cacheIndexPath))
+                        return;
+
                     dialog?.Dispatcher.Invoke(() => dialog.ReportProgress("Loading decompiled code cache..."));
 
-                    string[] indexLines = File.ReadAllLines(Path.Join("GMLCache", "index"));
+                    string[] indexLines = File.ReadAllLines(cacheIndexPath);
 
                     int num = -1;
                     for (int i = 0; i < indexLines.Length; i++)
@@ -1172,7 +1178,7 @@ namespace UndertaleModTool
                     if (num == -1)
                         return;
 
-                    if (!File.Exists(Path.Join("GMLCache", num.ToString())))
+                    if (!File.Exists(Path.Combine(cacheDirPath, num.ToString())))
                     {
                         ShowWarning("Decompiled code cache file for open data is missing, but its name present in the index.");
 
@@ -1181,7 +1187,7 @@ namespace UndertaleModTool
 
                     string hash = GenerateMD5(filename);
 
-                    using (StreamReader fs = new(Path.Join("GMLCache", num.ToString())))
+                    using (StreamReader fs = new(Path.Combine(cacheDirPath, num.ToString())))
                     {
                         string prevHash = fs.ReadLine();
 
@@ -1242,14 +1248,15 @@ namespace UndertaleModTool
                 {
                     dialog?.Dispatcher.Invoke(() => dialog.ReportProgress("Saving decompiled code cache..."));
 
-                    if (!File.Exists(Path.Join("GMLCache", "index")))
+                    string cacheDirPath = Path.Combine(ExePath, "GMLCache");
+                    string cacheIndexPath = Path.Combine(cacheDirPath, "index");
+                    if (!File.Exists(cacheIndexPath))
                     {
-                        Directory.CreateDirectory("GMLCache");
-
-                        File.WriteAllText(Path.Join("GMLCache", "index"), filename);
+                        Directory.CreateDirectory(cacheDirPath);
+                        File.WriteAllText(cacheIndexPath, filename);
                     }
 
-                    List<string> indexLines = File.ReadAllLines(Path.Join("GMLCache", "index")).ToList();
+                    List<string> indexLines = File.ReadAllLines(cacheIndexPath).ToList();
 
                     int num = -1;
                     for (int i = 0; i < indexLines.Count; i++)
@@ -1284,7 +1291,7 @@ namespace UndertaleModTool
 
                     string hash = GenerateMD5(filename);
 
-                    using (FileStream fs = File.Create(Path.Join("GMLCache", num.ToString())))
+                    using (FileStream fs = File.Create(Path.Combine(cacheDirPath, num.ToString())))
                     {
                         fs.Write(Encoding.UTF8.GetBytes(hash + '\n'));
                         fs.Write(SystemJson.JsonSerializer.SerializeToUtf8Bytes(sortedCache));
@@ -1296,7 +1303,7 @@ namespace UndertaleModTool
                         }
                     }
 
-                    File.WriteAllLines(Path.Join("GMLCache", "index"), indexLines);
+                    File.WriteAllLines(cacheIndexPath, indexLines);
 
                     Data.GMLCacheWasSaved = true;
                 }

--- a/UndertaleModTool/Scripts/Repackers/ImportFontData.csx
+++ b/UndertaleModTool/Scripts/Repackers/ImportFontData.csx
@@ -16,13 +16,15 @@ string importFolder = PromptChooseDirectory();
 if (importFolder == null)
     throw new ScriptException("The import folder was not set.");
 
-System.IO.Directory.CreateDirectory("Packager");
+string packagerDirPath = Path.Combine(ExePath, "Packager");
 string sourcePath = importFolder;
 string searchPattern = "*.png";
-string outName = "Packager/atlas.txt";
+string outName = Path.Combine(packagerDirPath, "atlas.txt");
 int textureSize = 2048;
 int border = 2;
 bool debug = false;
+
+Directory.CreateDirectory(packagerDirPath);
 Packer packer = new Packer();
 packer.Process(sourcePath, searchPattern, textureSize, border, debug);
 packer.SaveAtlasses(outName);
@@ -91,7 +93,7 @@ ScriptMessage("Import Complete!");
 
 public void fontUpdate(UndertaleFont newFont)
 {
-    using(StreamReader reader = new StreamReader(sourcePath + "glyphs_" + newFont.Name.Content + ".csv"))
+    using (StreamReader reader = new StreamReader(Path.Combine(sourcePath, "glyphs_" + newFont.Name.Content + ".csv")))
     {
         newFont.Glyphs.Clear();
         string line;

--- a/UndertaleModTool/Scripts/Repackers/ImportGML_2_3.csx
+++ b/UndertaleModTool/Scripts/Repackers/ImportGML_2_3.csx
@@ -44,11 +44,12 @@ if (importFolder == null)
 
 List<string> CodeList = new List<string>();
 
-if (File.Exists(importFolder + "/LookUpTable.txt"))
+string tablePath = Path.Combine(importFolder, "LookUpTable.txt");
+if (File.Exists(tablePath))
 {
     int counter = 0;
     string line;
-    System.IO.StreamReader file = new System.IO.StreamReader(importFolder + "/" + "LookUpTable.txt");
+    StreamReader file = new StreamReader(tablePath);
     while((line = file.ReadLine()) != null)
     {
         if (counter > 0)

--- a/UndertaleModTool/Scripts/Repackers/ImportGraphics.csx
+++ b/UndertaleModTool/Scripts/Repackers/ImportGraphics.csx
@@ -16,8 +16,7 @@ bool importAsSprite = false;
 
 string importFolder = CheckValidity();
 
-string workDirectory = Path.GetDirectoryName(FilePath) + Path.DirectorySeparatorChar;
-string packDir = Path.Combine(workDirectory, "Packager");
+string packDir = Path.Combine(ExePath, "Packager");
 Directory.CreateDirectory(packDir);
 
 string sourcePath = importFolder;

--- a/UndertaleModTool/Scripts/Repackers/ImportShaderData.csx
+++ b/UndertaleModTool/Scripts/Repackers/ImportShaderData.csx
@@ -1,33 +1,23 @@
 using System.Text;
 using System;
+using System.Linq;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
 EnsureDataLoaded();
 
-// "Select 'Import_Loc.txt' file in 'Shader_Data'"
 string importFolder = PromptChooseDirectory();
 if (importFolder == null)
     throw new ScriptException("The import folder was not set.");
 
-string[] dirFiles = Directory.GetFiles(importFolder, "*.*", SearchOption.AllDirectories);
-List<string> shadersToModify = new List<string>();
+var shadersToModify = Directory.GetDirectories(importFolder).Select(x => Path.GetFileName(x));
 List<string> shadersExisting = new List<string>();
 List<string> shadersNonExist = new List<string>();
-foreach (string file in dirFiles)
-{
-    if (Path.GetFileName(file) == "Import_Loc.txt")
-        continue;
-    else
-    {
-        shadersToModify.Add(Path.GetDirectoryName(file).Replace(importFolder, ""));
-    }
-}
 List<string> currentList = new List<string>();
 string res = "";
 
-for (var i = 0; i < shadersToModify.Count; i++)
+foreach (string shaderName in shadersToModify)
 {
     currentList.Clear();
     for (int j = 0; j < Data.Shaders.Count; j++)
@@ -36,14 +26,14 @@ for (var i = 0; i < shadersToModify.Count; i++)
         res += (x + "\n");
         currentList.Add(x);
     }
-    if (Data.Shaders.ByName(shadersToModify[i]) != null)
+    if (Data.Shaders.ByName(shaderName) != null)
     {
-        Data.Shaders.Remove(Data.Shaders.ByName(shadersToModify[i]));
-        AddShader(shadersToModify[i]);
+        Data.Shaders.Remove(Data.Shaders.ByName(shaderName));
+        AddShader(shaderName);
         Reorganize<UndertaleShader>(Data.Shaders, currentList);
     }
     else
-        AddShader(shadersToModify[i]);
+        AddShader(shaderName);
 }
 
 
@@ -257,7 +247,7 @@ void AddShader(string shader_name)
     {
         string line;
         // Read the file and display it line by line.
-        System.IO.StreamReader file = new System.IO.StreamReader(localImportDir + "VertexShaderAttributes.txt");
+        StreamReader file = new StreamReader(localImportDir + "VertexShaderAttributes.txt");
         while((line = file.ReadLine()) != null)
         {
             if (line != "")

--- a/UndertaleModTool/Scripts/Repackers/NewTextureRepacker.csx
+++ b/UndertaleModTool/Scripts/Repackers/NewTextureRepacker.csx
@@ -239,7 +239,7 @@ async Task<List<TPageItem>> dumpTexturePageItems(string dir, bool reuse)
 
     var tpageitems = await Task.Run(() => Data.TexturePageItems
         .AsParallel()
-        .Select(item => dumpTexturePageItem(item, worker, $"{dir}texture_page_{Data.TexturePageItems.IndexOf(item)}.png", reuse))
+        .Select(item => dumpTexturePageItem(item, worker, Path.Combine(dir, $"texture_page_{Data.TexturePageItems.IndexOf(item)}.png"), reuse))
         .ToList());
 
     worker.Cleanup();
@@ -366,10 +366,9 @@ if (maxArea <= 0)
 
 bool reuseTextures = false;
 
-// Setup work directory and packager directory
-string workDirectory = Path.GetDirectoryName(FilePath) + Path.DirectorySeparatorChar;
-string packagerDirectory = $"{workDirectory}{Path.DirectorySeparatorChar}Packager{Path.DirectorySeparatorChar}";
-if (System.IO.Directory.Exists(packagerDirectory))
+// Setup packager directory
+string packagerDirectory = Path.Combine(ExePath, "Packager");
+if (Directory.Exists(packagerDirectory))
 {
     DialogResult dr = MessageBox.Show("Do you want to reuse previously extracted page items?", 
         "Texture Repacker", MessageBoxButtons.YesNo);
@@ -377,7 +376,7 @@ if (System.IO.Directory.Exists(packagerDirectory))
     reuseTextures = dr == DialogResult.Yes;
 }
 
-System.IO.DirectoryInfo dir = System.IO.Directory.CreateDirectory(packagerDirectory);
+Directory.CreateDirectory(packagerDirectory);
 
 // Dump all the texture page items
 ResetProgress("Existing Textures Exported");
@@ -420,7 +419,7 @@ int lastTextPage = Data.EmbeddedTextures.Count - 1;
 
 // Now recreate texture pages and link the items to the pages
 ResetProgress("Regenerating Texture Pages");
-using (var f = new StreamWriter($"{packagerDirectory}log.txt"))
+using (var f = new StreamWriter(Path.Combine(packagerDirectory, "log.txt")))
 {
     var atlasCount = 0;
 

--- a/UndertaleModTool/Scripts/Repackers/ReduceEmbeddedTexturePages.csx
+++ b/UndertaleModTool/Scripts/Repackers/ReduceEmbeddedTexturePages.csx
@@ -15,9 +15,8 @@ using UndertaleModLib.Util;
 
 EnsureDataLoaded();
 
-// Get directory paths
-string workDirectory = Path.GetDirectoryName(FilePath) + Path.DirectorySeparatorChar;
-System.IO.DirectoryInfo dir = System.IO.Directory.CreateDirectory(workDirectory + Path.DirectorySeparatorChar + "Packager");
+// Get directory path
+DirectoryInfo dir = Directory.CreateDirectory(Path.Combine(ExePath, "Packager"));
 
 // Clear any files if they already exist
 foreach (FileInfo file in dir.GetFiles())

--- a/UndertaleModTool/Scripts/TechnicalScripts/CheckDecompiler.csx
+++ b/UndertaleModTool/Scripts/TechnicalScripts/CheckDecompiler.csx
@@ -265,7 +265,7 @@ List<string> GetCodeList(string importFolder)
     {
         int counter = 0;
         string line;
-        System.IO.StreamReader file = new System.IO.StreamReader(index_path);
+        StreamReader file = new StreamReader(index_path);
         while ((line = file.ReadLine()) != null)
         {
             if ((counter > 0) && (line.Length >= 1))

--- a/UndertaleModTool/Scripts/TechnicalScripts/FindNullsInOffsetMap.csx
+++ b/UndertaleModTool/Scripts/TechnicalScripts/FindNullsInOffsetMap.csx
@@ -44,7 +44,7 @@ if (dlg.ShowDialog() == true)
         {
             try
             {
-                System.IO.StreamReader file = new System.IO.StreamReader(dlgin.FileName);
+                StreamReader file = new StreamReader(dlgin.FileName);
                 string line;
                 line = file.ReadLine();
                 using (var stream = new FileStream(dlg.FileName, FileMode.Open, FileAccess.Read))

--- a/UndertaleModTool/Scripts/TechnicalScripts/FindUnknownFunctions.csx
+++ b/UndertaleModTool/Scripts/TechnicalScripts/FindUnknownFunctions.csx
@@ -28,8 +28,7 @@ Would you like to overwrite it?");
     }
 }
 
-BuiltinList list = new BuiltinList();
-list.Initialize(Data);
+BuiltinList list = new BuiltinList(Data);
 
 List<String> extensionFunctions = new List<String>();
 List<String> unknownFunctions = new List<String>();
@@ -89,7 +88,7 @@ if (unknownFunctions.Count > 0)
             resultsToDisplay += (unknownFunctions[i] + "\r\n");
         }
         resultsToDisplay = SimpleTextInput("Prune Menu", "Delete one or more lines to remove those entries", resultsToDisplay, true);
-        string[] IndividualLineArray = resultsToDisplay.Split('\n'}, StringSplitOptions.RemoveEmptyEntries);
+        string[] IndividualLineArray = resultsToDisplay.Split('\n', StringSplitOptions.RemoveEmptyEntries);
         foreach (var OneLine in IndividualLineArray)
         {
             unknownFunctions2.Add(OneLine.Trim());
@@ -116,4 +115,9 @@ if (unknownFunctions.Count > 0)
             removed = "The function(s)\r\n" + removed;
         ScriptMessage(removed + "were removed.");
     }
+}
+else
+{
+    ScriptMessage("No unknown functions were found.");
+    File.Delete(exportFolder + "unknown_functions.txt");
 }

--- a/UndertaleModTool/Scripts/TechnicalScripts/ImportGraphics_Full_Repack.csx
+++ b/UndertaleModTool/Scripts/TechnicalScripts/ImportGraphics_Full_Repack.csx
@@ -79,9 +79,8 @@ foreach (string file in dirFiles)
         throw new ScriptException(spriteName + " is missing one or more indexes. The detected missing index is: " + prevFrameName);
 }
 
-// Get directory paths
-string workDirectory = System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().CodeBase).Substring(6);
-System.IO.DirectoryInfo dir = System.IO.Directory.CreateDirectory(workDirectory + Path.DirectorySeparatorChar + "Packager");
+// Get directory path
+DirectoryInfo dir = Directory.CreateDirectory(Path.Combine(ExePath, "Packager"));
 
 // Clear any files if they already exist
 foreach (FileInfo file in dir.GetFiles())
@@ -181,17 +180,17 @@ DirectoryInfo textureDirectory = new DirectoryInfo(importFolder);
 FileInfo[] files = textureDirectory.GetFiles(searchPattern, SearchOption.AllDirectories);
 foreach (FileInfo file in files)
 {
-    string destFile = System.IO.Path.Combine(exportedTexturesFolder, file.Name);
-    string sourceFile = System.IO.Path.Combine(importFolder, file.Name);
+    string destFile = Path.Combine(exportedTexturesFolder, file.Name);
+    string sourceFile = Path.Combine(importFolder, file.Name);
     string stripped = Path.GetFileNameWithoutExtension(sourceFile);
     if (assetCoordinateDict.ContainsKey(stripped))
         assetCoordinateDict.Remove(stripped);
-    System.IO.File.Copy(sourceFile, destFile, true);
+    File.Copy(sourceFile, destFile, true);
 }
 
 try
 {
-    string[] marginLines = System.IO.File.ReadAllLines(importFolder + Path.DirectorySeparatorChar + "margins.txt");
+    string[] marginLines = File.ReadAllLines(importFolder + Path.DirectorySeparatorChar + "margins.txt");
     foreach (String str in marginLines)
     {
         string key = str.Substring(0, str.IndexOf(','));

--- a/UndertaleModTool/Scripts/Unpackers/ExportShaderData.csx
+++ b/UndertaleModTool/Scripts/Unpackers/ExportShaderData.csx
@@ -11,7 +11,6 @@ if (exportFolder == null)
     throw new ScriptException("The export folder was not set.");
 
 Directory.CreateDirectory(exportFolder + "/Shader_Data/");
-File.WriteAllText(exportFolder + "/Shader_Data/" + "Import_Loc.txt", "Import location");
 
 foreach(UndertaleShader shader in Data.Shaders)
 {


### PR DESCRIPTION
## Description

1. **Fixed bug when sometimes UTMT tries to access one of system folders instead of the app folder.**
2. Fixed the following scripts: "ImportShaderData.csx", "FindUnknownFunctions.csx".
3. Some of `System.IO` class references are simplified (e.g. `System.IO.Path` -> `Path`).
4. All the scripts that are modifying textures create "Packager" folder in UTMT folder.
5. GML cache load and save methods use `Path.Combine()` instead of `Path.Join()` for consistency with other code.

Closes #690, closes #943.