### PR TITLE
Room layers rearrangement related fixes.

### DIFF
--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -1240,7 +1240,7 @@ namespace UndertaleModTool
                 }
             }
 
-            int layerDepth = 0;
+            long layerDepth = 0;
             if (room.Layers.Count > 0)
             {
                 layerDepth = room.Layers.Select(l => l.LayerDepth).Max();
@@ -1293,7 +1293,7 @@ namespace UndertaleModTool
             layer.LayerName = data.Strings.MakeString(name);
             layer.LayerId = largest_layerid + 1;
             layer.LayerType = type;
-            layer.LayerDepth = layerDepth;
+            layer.LayerDepth = (int)layerDepth;
             layer.Data = new T();
             room.Layers.Add(layer);
             room.UpdateBGColorLayer();

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -103,6 +103,12 @@ namespace UndertaleModTool
             visualOffProp.SetValue(roomCanvas, prevOffset);
         }
 
+        /// <summary>
+        /// Checks if the room layers are ordered by depth. If they are not, the user will be prompted,
+        /// whether they want to rearrange them.
+        /// </summary>
+        /// <param name="room">The <see cref="UndertaleRoom"/>, whose layers should be checked and,
+        /// if necessary, rearranged.</param>
         public static void CheckAndRearrangeLayers(UndertaleRoom room)
         {
             bool ordered = true;
@@ -116,8 +122,10 @@ namespace UndertaleModTool
             }
 
             if (!ordered)
+            {
                 if (MainWindow.ShowQuestion("Room layers are not ordered by depth.\nRearrange them?", MessageBoxImage.Warning) == MessageBoxResult.Yes)
                     room.RearrangeLayers();
+            }
         }
 
         private void ExportAsPNG_Click(object sender, RoutedEventArgs e)
@@ -1246,13 +1254,15 @@ namespace UndertaleModTool
                 }
             }
 
+            // "layerDepth" is "long", because otherwise one can't check if the incremented value is larger than "Int32.MaxValue",
+            // because then it would overflow.
             long layerDepth = 0;
             if (room.Layers.Count > 0)
             {
                 layerDepth = room.Layers.Select(l => l.LayerDepth).Max();
-                if (layerDepth + 100 > int.MaxValue)
+                if (layerDepth + 100 > Int32.MaxValue)
                 {
-                    if (layerDepth + 1 > int.MaxValue)
+                    if (layerDepth + 1 > Int32.MaxValue)
                     {
                         layerDepth -= 1;
                         MainWindow.ShowWarning("Warning - the maximum layer depth is reached.\nYou probably should change the depth of the new layer.");

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -103,6 +103,23 @@ namespace UndertaleModTool
             visualOffProp.SetValue(roomCanvas, prevOffset);
         }
 
+        public static void CheckAndRearrangeLayers(UndertaleRoom room)
+        {
+            bool ordered = true;
+            for (int i = 0; i < room.Layers.Count - 1; i++)
+            {
+                if (room.Layers[i].LayerDepth > room.Layers[i + 1].LayerDepth)
+                {
+                    ordered = false;
+                    break;
+                }
+            }
+
+            if (!ordered)
+                if (MainWindow.ShowQuestion("Room layers are not ordered by depth.\nRearrange them?", MessageBoxImage.Warning) == MessageBoxResult.Yes)
+                    room.RearrangeLayers();
+        }
+
         private void ExportAsPNG_Click(object sender, RoutedEventArgs e)
         {
             SaveFileDialog dlg = new();
@@ -167,19 +184,8 @@ namespace UndertaleModTool
                 {
                     LayerZIndexConverter.ProcessOnce = true;
 
-                    bool ordered = true;
-                    for (int i = 0; i < room.Layers.Count - 1; i++)
-                    {
-                        if (room.Layers[i].LayerDepth > room.Layers[i + 1].LayerDepth)
-                        {
-                            ordered = false;
-                            break;
-                        }
-                    }
-
-                    if (!ordered)
-                        if (MainWindow.ShowQuestion("Room layers are not ordered by depth.\nRearrange them?", MessageBoxImage.Warning) == MessageBoxResult.Yes)
-                            room.RearrangeLayers();
+                    if (IsLoaded)
+                        CheckAndRearrangeLayers(room);
 
                     Parallel.ForEach(room.Layers, (layer) =>
                     {

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -1295,14 +1295,21 @@ namespace UndertaleModTool
                 }
             }
 
-            Layer layer = new();
-            layer.LayerName = data.Strings.MakeString(name);
-            layer.LayerId = largest_layerid + 1;
-            layer.LayerType = type;
-            layer.LayerDepth = (int)layerDepth;
-            layer.Data = new T();
+            Layer layer = new()
+            {
+                LayerName = data.Strings.MakeString(name),
+                LayerId = largest_layerid + 1,
+                LayerType = type,
+                LayerDepth = (int)layerDepth,
+                Data = new T()
+            };
             room.Layers.Add(layer);
             room.UpdateBGColorLayer();
+
+            LayerZIndexConverter.ProcessOnce = true;
+            foreach (Layer l in room.Layers)
+                l.UpdateZIndex();
+            layer.ParentRoom = room;
 
             if (layer.LayerType == LayerType.Assets)
             {
@@ -1322,7 +1329,6 @@ namespace UndertaleModTool
             }
 
             SelectObject(layer);
-            room.SetupRoom(false);
         }
 
         private void AddObjectInstance(UndertaleRoom room)

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -1485,6 +1485,9 @@ namespace UndertaleModTool
 
         private void MainTree_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
+            if (Highlighted is UndertaleRoom room && Selected is not UndertaleRoom)
+                UndertaleRoomEditor.CheckAndRearrangeLayers(room);
+
             OpenInTab(Highlighted);
         }
 


### PR DESCRIPTION
## Description

1. **Fixed the crashes on following events: opening a room with layers that are not ordered by depth, new layer addition (not consistent).**
2. **Fixed new layer depth overflow check that caused negative depth of the new layer.**