### PR TITLE
Fix of QOI textures display on different system scale setting.

### DIFF
--- a/UndertaleModLib/Util/QoiConverter.cs
+++ b/UndertaleModLib/Util/QoiConverter.cs
@@ -69,6 +69,7 @@ namespace UndertaleModLib.Util
             ReadOnlySpan<byte> pixelData = bytes.Slice(12, length);
 
             Bitmap bmp = new Bitmap(width, height, PixelFormat.Format32bppArgb);
+            bmp.SetResolution(96.0f, 96.0f);
 
             BitmapData data = bmp.LockBits(new Rectangle(0, 0, bmp.Width, bmp.Height), ImageLockMode.ReadWrite, PixelFormat.Format32bppArgb);
             if (data.Stride != width * 4)

--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml
@@ -36,7 +36,8 @@
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
-            <Viewbox Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" Stretch="Uniform" StretchDirection="DownOnly">
+            <Viewbox Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" Stretch="Uniform" StretchDirection="DownOnly"
+                     SnapsToDevicePixels="True" RenderOptions.BitmapScalingMode="NearestNeighbor">
                 <Border>
                     <Border.Background>
                         <DrawingBrush Stretch="None" TileMode="Tile" Viewport="0,0,20,20" ViewportUnits="Absolute">

--- a/UndertaleModTool/Editors/UndertaleTexturePageItemEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleTexturePageItemEditor.xaml
@@ -91,7 +91,8 @@
             <Button Grid.Column="3" Content="Export" Click="Export_Click"/>
         </Grid>
 
-        <Viewbox Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2" Stretch="Uniform" StretchDirection="DownOnly">
+        <Viewbox Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2" Stretch="Uniform" StretchDirection="DownOnly"
+                 SnapsToDevicePixels="True" RenderOptions.BitmapScalingMode="NearestNeighbor">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"/>


### PR DESCRIPTION
## Description

Textures of GMS 2022 games are displayed correctly independently of system display scale options.
Also, a embedded texture preview looks sharp now ("nearest neighbor" is used).

### Caveats
The preview can be considered "choppy" by some users, especially for large embedded textures.