### PR TITLE
Slight improvements to continously updating release

### DIFF
--- a/.github/workflows/publish_gui_nightly.yml
+++ b/.github/workflows/publish_gui_nightly.yml
@@ -92,7 +92,7 @@ jobs:
   upload:
 
     needs: [build_gui, build_cli]
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
     - name: Download artifacts
       uses: actions/download-artifact@v2
@@ -100,14 +100,15 @@ jobs:
       uses: dev-drprasad/delete-tag-and-release@v0.2.0
       with:
         delete_release: true # default: false
-        tag_name: latest # tag name to delete
+        tag_name: bleeding-edge # tag name to delete
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
-        tag_name: latest
-        name: Latest Build
+        tag_name: bleeding-edge
+        name: Bleeding Edge
+        prerelease: true
         files: |
           artifact/*
         body: | 


### PR DESCRIPTION
## Description
Following changed:
- it's now a prerelease, further indicating that it's not for stable usage
- runs on ubuntu now, because GH's linux runners are way faster
- tag has been renamed to "bleeding-edge" because "latest" is very ambiguous.

### Caveats
One needs to delete the "latest" and release based of it manually afterwards.
