### PR TITLE
Fixes and improvements of some names displaying.

### DIFF
--- a/UndertaleModTool/Converters/StringTitleConverter.cs
+++ b/UndertaleModTool/Converters/StringTitleConverter.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Globalization;
+using System.Text.RegularExpressions;
 using System.Windows.Data;
 
 namespace UndertaleModTool
 {
     public class StringTitleConverter : IValueConverter
     {
+        public static readonly Regex NewLineRegex = new(@"\r\n?|\n", RegexOptions.Compiled);
+
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             if (value is not string str)
@@ -13,7 +16,7 @@ namespace UndertaleModTool
 
             if (str.Length > 256)
                 str = str[..256] + "...";
-            str = str.Replace('\n', ' ');
+            str = NewLineRegex.Replace(str, " ");
 
             return str;
         }

--- a/UndertaleModTool/Converters/StringTitleConverter.cs
+++ b/UndertaleModTool/Converters/StringTitleConverter.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace UndertaleModTool
+{
+    public class StringTitleConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is not string str)
+                return null;
+
+            if (str.Length > 256)
+                str = str[..256] + "...";
+            str = str.Replace('\n', ' ');
+
+            return str;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/UndertaleModTool/MainWindow.xaml
+++ b/UndertaleModTool/MainWindow.xaml
@@ -428,7 +428,8 @@
                                         <TextBlock>
                                             <TextBlock.Text>
                                                 <MultiBinding Converter="{StaticResource TabTitleConverter}" Mode="OneWay">
-                                                    <Binding Path="OpenedObject" Mode="OneTime"/>
+                                                    <Binding Mode="OneTime"/>
+                                                    <Binding Path="OpenedObject" Mode="OneWay"/>
                                                     <!-- for notification only -->
                                                     <Binding Path="OpenedObject.Name.Content" Mode="OneWay"/>
                                                 </MultiBinding>

--- a/UndertaleModTool/MainWindow.xaml
+++ b/UndertaleModTool/MainWindow.xaml
@@ -26,6 +26,7 @@
         <local:CompareNumbersConverter x:Key="CompareNumbersConverter"/>
         <BooleanToVisibilityConverter x:Key="BoolToVisConverter"/> <!-- (built-in converter) -->
         <local:TabTitleConverter x:Key="TabTitleConverter"/>
+        <local:StringTitleConverter x:Key="StringTitleConverter"/>
     </Window.Resources>
     <Window.CommandBindings>
         <CommandBinding Command="New" Executed="Command_New" />
@@ -345,7 +346,7 @@
                         <TreeViewItem Header="Strings" ItemsSource="{Binding Strings, Converter={StaticResource FilteredViewConverter}}" Visibility="{Binding Strings, Converter={StaticResource VisibleIfNotNull}}">
                             <TreeViewItem.ItemTemplate>
                                 <HierarchicalDataTemplate DataType="{x:Type undertale:UndertaleString}">
-                                    <TextBlock Text="{Binding Content}" />
+                                    <TextBlock Text="{Binding Content, Mode=OneWay, Converter={StaticResource StringTitleConverter}}" />
                                 </HierarchicalDataTemplate>
                             </TreeViewItem.ItemTemplate>
                         </TreeViewItem>

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -62,6 +62,7 @@ namespace UndertaleModTool
 
         public object OpenedObject { get; set; }
         public string TabTitle { get; set; } = "Untitled";
+        public bool IsCustomTitle { get; set; }
         public int TabIndex { get; set; }
         public bool AutoClose { get; set; } = false;
 
@@ -69,8 +70,16 @@ namespace UndertaleModTool
         {
             OpenedObject = obj;
             TabIndex = tabIndex;
-            TabTitle = tabTitle ?? GetTitleForObject(obj);
             AutoClose = obj is DescriptionView;
+
+            IsCustomTitle = tabTitle is not null;
+            if (IsCustomTitle)
+            {
+                if (tabTitle.Length > 64)
+                    TabTitle = tabTitle[..64] + "...";
+                else
+                    TabTitle = tabTitle;
+            }
         }
 
         public static string GetTitleForObject(object obj)
@@ -128,9 +137,14 @@ namespace UndertaleModTool
                 else
                     Debug.WriteLine($"Could not handle type {obj.GetType()}");
             }
-            else if (obj is UndertaleString)
+            else if (obj is UndertaleString str)
             {
-                title = "String - " + ((UndertaleString)obj).Content;
+                string stringLine = str.Content;
+                int stringLength = stringLine.IndexOf('\n');
+                if (stringLength != -1)
+                    stringLine = stringLine[..stringLength] + " ...";
+
+                title = "String - " + stringLine;
             }
             else if (obj is UndertaleChunkVARI)
             {
@@ -153,6 +167,9 @@ namespace UndertaleModTool
                 Debug.WriteLine($"Could not handle type {obj.GetType()}");
             }
 
+            if (title.Length > 64)
+                title = title[..64] + "...";
+
             return title;
         }
 
@@ -166,7 +183,13 @@ namespace UndertaleModTool
     {
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
-            return Tab.GetTitleForObject(values[0]);
+            if (values[0] is not Tab tab)
+                return null;
+
+            if (!tab.IsCustomTitle)
+                tab.TabTitle = Tab.GetTitleForObject(values[1]);
+
+            return tab.TabTitle;
         }
 
         public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -139,12 +139,12 @@ namespace UndertaleModTool
             }
             else if (obj is UndertaleString str)
             {
-                string stringLine = str.Content;
-                int stringLength = stringLine.IndexOf('\n');
+                string stringFirstLine = str.Content;
+                int stringLength = stringFirstLine.IndexOf('\n');
                 if (stringLength != -1)
-                    stringLine = stringLine[..stringLength] + " ...";
+                    stringFirstLine = stringFirstLine[..stringLength] + " ...";
 
-                title = "String - " + stringLine;
+                title = "String - " + stringFirstLine;
             }
             else if (obj is UndertaleChunkVARI)
             {
@@ -3614,26 +3614,6 @@ result in loss of work.");
         {
             Heading = heading;
             Description = description;
-        }
-    }
-
-    public class StringTitleConverter : IValueConverter
-    {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            if (value is not string str)
-                return null;
-
-            if (str.Length > 256)
-                str = str[..256] + "...";
-            str = str.Replace('\n', ' ');
-
-            return str;
-        }
-
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -3616,4 +3616,24 @@ result in loss of work.");
             Description = description;
         }
     }
+
+    public class StringTitleConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is not string str)
+                return null;
+
+            if (str.Length > 256)
+                str = str[..256] + "...";
+            str = str.Replace('\n', ' ');
+
+            return str;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
 }

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -140,7 +140,7 @@ namespace UndertaleModTool
             else if (obj is UndertaleString str)
             {
                 string stringFirstLine = str.Content;
-                int stringLength = stringFirstLine.IndexOf('\n');
+                int stringLength = StringTitleConverter.NewLineRegex.Match(stringFirstLine).Index;
                 if (stringLength != -1)
                     stringFirstLine = stringFirstLine[..stringLength] + " ...";
 


### PR DESCRIPTION
## Description

1. Fixed displaying of a title of the tab with multiline `UndertaleString` - only first line will be displayed.
2. Added 64 character limit for tab titles.
3. Optimized displaying of `UndertaleString` names in the "Strings" list - added 256 character limit; newline characters are replaced with spaces.
4. Fixed "glitchy" scrolling of the list, with non-empty search box.

Closes #953 

### Caveats
A object name of a tab may not be fully displayed - not everyone may like it.