### PR TITLE
Remove an annoying message box

### DIFF
--- a/UndertaleModTool/Controls/UndertaleObjectReference.xaml.cs
+++ b/UndertaleModTool/Controls/UndertaleObjectReference.xaml.cs
@@ -100,8 +100,6 @@ namespace UndertaleModTool
         {
             if (ObjectReference is null)
             {
-                MessageBox.Show("This feature is very WIP, so expect it to be broken.");
-
                 MainWindow mainWindow = Application.Current.MainWindow as MainWindow;
 
                 if (mainWindow.Selected is null)


### PR DESCRIPTION
There's a messagebox that appears when you attempt to add a new code entry through the reference box. This has been removed, as the feature is quite stable.
