### PR TITLE
Add hotfix for unix breakage

### DIFF
--- a/UndertaleModCli/UndertaleModCli.csproj
+++ b/UndertaleModCli/UndertaleModCli.csproj
@@ -21,4 +21,10 @@
     <ProjectReference Include="..\UndertaleModLib\UndertaleModLib.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="runtimeconfig.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/UndertaleModCli/runtimeconfig.json
+++ b/UndertaleModCli/runtimeconfig.json
@@ -1,0 +1,5 @@
+{
+  "configProperties": {
+    "System.Drawing.EnableUnixSupport": true
+  }
+}


### PR DESCRIPTION
## Description
This uses the MS provided hotfix for the System.Drawing.Commong breakage on Unix systems. (see here: https://docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only)

### Caveats
None

### Notes
#875 is **not** fixed by this, this is merely a hotfix to make UNIX system usable until the issue is properly fixed.