### PR TITLE
Direct loading and saving game data.

### DIFF
--- a/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
+++ b/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
@@ -137,6 +137,7 @@ public class UndertaleEmbeddedTexture : UndertaleNamedResource
                     using MemoryStream input = new MemoryStream(data);
                     using MemoryStream output = new MemoryStream(1024);
                     BZip2.Compress(input, output, false, 9);
+                    output.Seek(0, SeekOrigin.Begin);
                     writer.Write(output);
                 }
                 else

--- a/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
+++ b/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
@@ -169,11 +169,8 @@ public class UndertaleEmbeddedTexture : UndertaleNamedResource
                     reader.Position += 8;
 
                     // Need to fully decompress and convert the QOI data to PNG for compatibility purposes (at least for now)
-                    using MemoryStream bufferWrapper = new MemoryStream(reader.Buffer);
-                    bufferWrapper.Seek(reader.Offset, SeekOrigin.Begin);
                     using MemoryStream result = new MemoryStream(1024);
-                    BZip2.Decompress(bufferWrapper, result, false);
-                    reader.Position = (uint)bufferWrapper.Position;
+                    BZip2.Decompress(reader.Stream, result, false);
                     result.Seek(0, SeekOrigin.Begin);
                     using Bitmap bmp = QoiConverter.GetImageFromSpan(result.GetBuffer());
                     using MemoryStream final = new MemoryStream();
@@ -187,8 +184,7 @@ public class UndertaleEmbeddedTexture : UndertaleNamedResource
                     reader.undertaleData.UseBZipFormat = false;
 
                     // Need to convert the QOI data to PNG for compatibility purposes (at least for now)
-                    using Bitmap bmp = QoiConverter.GetImageFromSpan(reader.Buffer.AsSpan()[reader.Offset..], out int dataLength);
-                    reader.Offset += dataLength;
+                    using Bitmap bmp = QoiConverter.GetImageFromStream(reader.Stream);
                     using MemoryStream final = new MemoryStream();
                     bmp.Save(final, ImageFormat.Png);
                     TextureBlob = final.ToArray();

--- a/UndertaleModLib/UndertaleChunks.cs
+++ b/UndertaleModLib/UndertaleChunks.cs
@@ -343,27 +343,27 @@ namespace UndertaleModLib
             // Do a length check on room layers to see if this is 2022.1 or higher
             if (!reader.undertaleData.GMS2022_1 && reader.undertaleData.GMS2_3)
             {
-                int returnTo = reader.Offset;
+                uint returnTo = reader.Position;
 
                 // Iterate over all rooms until a length check is performed
                 int roomCount = reader.ReadInt32();
                 bool finished = false;
-                for (int roomIndex = 0; roomIndex < roomCount && !finished; roomIndex++)
+                for (uint roomIndex = 0; roomIndex < roomCount && !finished; roomIndex++)
                 {
                     // Advance to room data we're interested in (and grab pointer for next room)
-                    reader.Offset = returnTo + 4 + (4 * roomIndex);
-                    int roomPtr = reader.ReadInt32();
-                    reader.Offset = roomPtr + (22 * 4);
+                    reader.Position = returnTo + 4 + (4 * roomIndex);
+                    uint roomPtr = (uint)reader.ReadInt32();
+                    reader.Position = roomPtr + (22 * 4);
 
                     // Get the pointer for this room's layer list, as well as pointer to sequence list
-                    int layerListPtr = reader.ReadInt32();
+                    uint layerListPtr = (uint)reader.ReadInt32();
                     int seqnPtr = reader.ReadInt32();
-                    reader.Offset = layerListPtr;
+                    reader.Position = layerListPtr;
                     int layerCount = reader.ReadInt32();
                     if (layerCount >= 1)
                     {
                         // Get pointer into the individual layer data (plus 8 bytes) for the first layer in the room
-                        int jumpOffset = reader.ReadInt32() + 8;
+                        uint jumpOffset = (uint)(reader.ReadInt32() + 8);
 
                         // Find the offset for the end of this layer
                         int nextOffset;
@@ -373,40 +373,40 @@ namespace UndertaleModLib
                             nextOffset = reader.ReadInt32(); // (pointer to next element in the layer list)
 
                         // Actually perform the length checks, depending on layer data
-                        reader.Offset = jumpOffset;
+                        reader.Position = jumpOffset;
                         switch ((LayerType)reader.ReadInt32())
                         {
                             case LayerType.Background:
-                                if (nextOffset - reader.Offset > 16 * 4)
+                                if (nextOffset - reader.Position > 16 * 4)
                                     reader.undertaleData.GMS2022_1 = true;
                                 finished = true;
                                 break;
                             case LayerType.Instances:
-                                reader.Offset += 6 * 4;
+                                reader.Position += 6 * 4;
                                 int instanceCount = reader.ReadInt32();
-                                if (nextOffset - reader.Offset != (instanceCount * 4))
+                                if (nextOffset - reader.Position != (instanceCount * 4))
                                     reader.undertaleData.GMS2022_1 = true;
                                 finished = true;
                                 break;
                             case LayerType.Assets:
-                                reader.Offset += 6 * 4;
+                                reader.Position += 6 * 4;
                                 int tileOffset = reader.ReadInt32();
                                 if (tileOffset != reader.Position + 8)
                                     reader.undertaleData.GMS2022_1 = true;
                                 finished = true;
                                 break;
                             case LayerType.Tiles:
-                                reader.Offset += 7 * 4;
+                                reader.Position += 7 * 4;
                                 int tileMapWidth = reader.ReadInt32();
                                 int tileMapHeight = reader.ReadInt32();
-                                if (nextOffset - reader.Offset != (tileMapWidth * tileMapHeight * 4))
+                                if (nextOffset - reader.Position != (tileMapWidth * tileMapHeight * 4))
                                     reader.undertaleData.GMS2022_1 = true;
                                 finished = true;
                                 break;
                             case LayerType.Effect:
-                                reader.Offset += 7 * 4;
+                                reader.Position += 7 * 4;
                                 int propertyCount = reader.ReadInt32();
-                                if (nextOffset - reader.Offset != (propertyCount * 3 * 4))
+                                if (nextOffset - reader.Position != (propertyCount * 3 * 4))
                                     reader.undertaleData.GMS2022_1 = true;
                                 finished = true;
                                 break;
@@ -414,7 +414,7 @@ namespace UndertaleModLib
                     }
                 }
 
-                reader.Offset = returnTo;
+                reader.Position = returnTo;
             }
         }
     }

--- a/UndertaleModLib/UndertaleChunks.cs
+++ b/UndertaleModLib/UndertaleChunks.cs
@@ -16,7 +16,8 @@ namespace UndertaleModLib
     {
         public override string Name => "FORM";
 
-        public Dictionary<string, UndertaleChunk> Chunks = new Dictionary<string, UndertaleChunk>();
+        public Dictionary<string, UndertaleChunk> Chunks = new();
+        public Dictionary<Type, UndertaleChunk> ChunksTypeDict = new();
 
         public UndertaleChunkGEN8 GEN8 => Chunks.GetValueOrDefault("GEN8") as UndertaleChunkGEN8;
         public UndertaleChunkOPTN OPTN => Chunks.GetValueOrDefault("OPTN") as UndertaleChunkOPTN;
@@ -61,6 +62,7 @@ namespace UndertaleModLib
         internal override void UnserializeChunk(UndertaleReader reader)
         {
             Chunks.Clear();
+            ChunksTypeDict.Clear();
             uint startPos = reader.Position;
 
             // First, find the last chunk in the file because of padding changes
@@ -89,6 +91,7 @@ namespace UndertaleModLib
                     if (Chunks.ContainsKey(chunk.Name))
                         throw new IOException("Duplicate chunk " + chunk.Name);
                     Chunks.Add(chunk.Name, chunk);
+                    ChunksTypeDict.Add(chunk.GetType(), chunk);
                 }
             }
         }

--- a/UndertaleModLib/UndertaleData.cs
+++ b/UndertaleModLib/UndertaleData.cs
@@ -587,6 +587,8 @@ namespace UndertaleModLib
             data.FORM.Chunks["STRG"] = new UndertaleChunkSTRG();
             data.FORM.Chunks["TXTR"] = new UndertaleChunkTXTR();
             data.FORM.Chunks["AUDO"] = new UndertaleChunkAUDO();
+            foreach (UndertaleChunk chunk in data.FORM.Chunks.Values)
+                data.FORM.ChunksTypeDict[chunk.GetType()] = chunk;
             data.FORM.GEN8.Object = new UndertaleGeneralInfo();
             data.FORM.OPTN.Object = new UndertaleOptions();
             data.FORM.LANG.Object = new UndertaleLanguage();

--- a/UndertaleModLib/UndertaleIO.cs
+++ b/UndertaleModLib/UndertaleIO.cs
@@ -132,7 +132,7 @@ namespace UndertaleModLib
         }
     }
 
-    public class UndertaleReader : Util.BufferBinaryReader
+    public class UndertaleReader : Util.FileBinaryReader
     {
         /// <summary>
         /// function to delegate warning messages to

--- a/UndertaleModLib/UndertaleIO.cs
+++ b/UndertaleModLib/UndertaleIO.cs
@@ -52,23 +52,22 @@ namespace UndertaleModLib
             this.CachedId = id;
         }
 
-        private ChunkT FindListChunk(UndertaleData data)
+        private static ChunkT FindListChunk(UndertaleData data)
         {
-            var chunk = data.FORM.Chunks.Where((x) => x.Value is ChunkT);
-            if (chunk.Any())
-                return (ChunkT)chunk.FirstOrDefault().Value;
+            if (data.FORM.ChunksTypeDict.TryGetValue(typeof(ChunkT), out UndertaleChunk chunk))
+                return chunk as ChunkT;
             else
                 return null;
         }
 
         public int SerializeById(UndertaleWriter writer)
         {
-            var chunk = FindListChunk(writer.undertaleData);
+            ChunkT chunk = FindListChunk(writer.undertaleData);
             if (chunk != null)
             {
                 if (Resource != null)
                 {
-                    CachedId = chunk.List.IndexOf(Resource);
+                    CachedId = chunk.IndexDict[Resource];
                     if (CachedId < 0)
                         throw new IOException("Unregistered object");
                 }
@@ -98,7 +97,7 @@ namespace UndertaleModLib
             {
                 if (typeof(ChunkT) == typeof(UndertaleChunkAGRP) && CachedId == reader.undertaleData.GetBuiltinSoundGroupID() && list.Count == 0) // I won't even ask why this works like that
                 {
-                    Resource = default(T);
+                    Resource = default;
                     return;
                 }
                 if (CachedId >= list.Count)
@@ -106,7 +105,7 @@ namespace UndertaleModLib
                     reader.SubmitWarning("Invalid value for resource ID of type " + typeof(ChunkT).Name + ": " + CachedId + " (there are only " + list.Count + ")");
                     return;
                 }
-                Resource = CachedId >= 0 ? list[CachedId] : default(T);
+                Resource = CachedId >= 0 ? list[CachedId] : default;
             }
         }
 
@@ -395,7 +394,7 @@ namespace UndertaleModLib
         }
     }
 
-    public class UndertaleWriter : Util.BufferBinaryWriter
+    public class UndertaleWriter : Util.FileBinaryWriter
     {
         internal UndertaleData undertaleData;
 
@@ -440,6 +439,14 @@ namespace UndertaleModLib
                 LastChunkName = chunk.Key;
             }
 
+            // Generate the object index dictionaries for acceleration of "UndertaleResourceById.SerializeById()"
+            var listChunks = data.FORM.Chunks.Values.Select(x => x as IUndertaleListChunk);
+            Parallel.ForEach(listChunks.Where(x => x is not null), (chunk) =>
+            {
+                chunk.GenerateIndexDict();
+            });
+            UndertaleIO.IsDictionaryCleared = false;
+
             Write(data.FORM);
         }
 
@@ -449,27 +456,38 @@ namespace UndertaleModLib
         private List<ValueTuple<uint, uint>> intsToWriteParallel = new List<ValueTuple<uint, uint>>();
         public List<ValueTuple<uint, UndertaleResourceRef>> resourceIDRefsToWrite = new List<ValueTuple<uint, UndertaleResourceRef>>();
 
-        public override void Flush()
+        public void Flush(UndertaleData data)
         {
-            SubmitMessage("Writing references in parallel...");
+            SubmitMessage("Writing object references...");
 
-            Parallel.ForEach(intsToWriteParallel, (pair) =>
+            var intsToWriteParallelSorted = intsToWriteParallel.AsParallel()
+                                                               .WithExecutionMode(ParallelExecutionMode.ForceParallelism)
+                                                               .OrderBy(x => x.Item1);
+            foreach (var pair in intsToWriteParallelSorted)
             {
-                RawBuffer[pair.Item1] = (byte)(pair.Item2 & 0xFF);
-                RawBuffer[pair.Item1 + 1] = (byte)((pair.Item2 >> 8) & 0xFF);
-                RawBuffer[pair.Item1 + 2] = (byte)((pair.Item2 >> 16) & 0xFF);
-                RawBuffer[pair.Item1 + 3] = (byte)((pair.Item2 >> 24) & 0xFF);
-            });
+                Position = pair.Item1;
+                Write(pair.Item2);
+            }
 
-            Parallel.ForEach(resourceIDRefsToWrite, (pair) =>
+            var resourceIDRefsToWriteSorted = resourceIDRefsToWrite.AsParallel()
+                                                                   .WithExecutionMode(ParallelExecutionMode.ForceParallelism)
+                                                                   .OrderBy(x => x.Item1);
+            foreach (var pair in resourceIDRefsToWriteSorted)
             {
                 int id = pair.Item2.SerializeById(this);
-                RawBuffer[pair.Item1] = (byte)(id & 0xFF);
-                RawBuffer[pair.Item1 + 1] = (byte)((id >> 8) & 0xFF);
-                RawBuffer[pair.Item1 + 2] = (byte)((id >> 16) & 0xFF);
-                RawBuffer[pair.Item1 + 3] = (byte)((id >> 24) & 0xFF);
-            });
+                Position = pair.Item1;
+                Write(id);
+            }
 
+            SubmitMessage("Clearing temporary dictionaries...");
+            var listChunks = data.FORM.Chunks.Values.Select(x => x as IUndertaleListChunk);
+            Parallel.ForEach(listChunks.Where(x => x is not null), (chunk) =>
+            {
+                chunk.ClearIndexDict();
+            });
+            UndertaleIO.IsDictionaryCleared = true;
+
+            SubmitMessage("Flushing remaining file buffer data to disk...");
             base.Flush();
         }
 
@@ -482,8 +500,7 @@ namespace UndertaleModLib
         {
             if (obj == null)
                 return 0;
-            uint res;
-            if (!objectPool.TryGetValue(obj, out res))
+            if (!objectPool.TryGetValue(obj, out uint res))
                 throw new KeyNotFoundException();
             return res;
         }
@@ -502,15 +519,20 @@ namespace UndertaleModLib
                     {
                         foreach (uint pointerAddr in pendingStringWrites[obj])
                             intsToWriteParallel.Add(new ValueTuple<uint, uint>(pointerAddr, objectAddr + 4));
+
                         pendingStringWrites.Remove(obj);
                     }
-                } else
+                }
+                else
                     objectPool.Add(obj, objectAddr); // strings come later in the file, so no need to add them to the pool
+                
                 obj.Serialize(this);
+
                 if (pendingWrites.ContainsKey(obj))
                 {
                     foreach (uint pointerAddr in pendingWrites[obj])
                         intsToWriteParallel.Add(new ValueTuple<uint, uint>(pointerAddr, objectAddr));
+
                     pendingWrites.Remove(obj);
                 }
             }
@@ -524,7 +546,7 @@ namespace UndertaleModLib
         {
             if (obj == null)
             {
-                Write((uint)0x00000000u);
+                Write(0x00000000u);
                 return;
             }
 
@@ -545,21 +567,14 @@ namespace UndertaleModLib
         {
             if (obj == null)
             {
-                Write((uint)0x0000000u);
+                Write(0x0000000u);
                 return;
             }
 
-            if (objectPool.ContainsKey(obj))
-            {
-                Write(objectPool[obj] + 4);
-            }
-            else
-            {
-                if (!pendingStringWrites.ContainsKey(obj))
-                    pendingStringWrites.Add(obj, new List<uint>());
-                pendingStringWrites[obj].Add(Position);
-                Write(0xDEADC0DEu);
-            }
+            if (!pendingStringWrites.ContainsKey(obj))
+                pendingStringWrites.Add(obj, new List<uint>());
+            pendingStringWrites[obj].Add(Position);
+            Write(0xDEADC0DEu);
         }
 
         public void ThrowIfUnwrittenObjects()
@@ -567,7 +582,11 @@ namespace UndertaleModLib
             if ((pendingWrites.Count + pendingStringWrites.Count) != 0)
             {
                 var unwrittenObjects = pendingWrites.Concat(pendingStringWrites);
-                throw new IOException("Found pointer targets that were never written:\n" + String.Join("\n", unwrittenObjects.Take(10).Select((x) => x.Key + " at " + String.Join(", ", x.Value.Select((y) => "0x" + y.ToString("X8"))))) + (unwrittenObjects.Count() > 10 ? "\n(and more, " + unwrittenObjects.Count() + " total)" : ""));
+                throw new IOException("Found pointer targets that were never written:\n"
+                                      + String.Join("\n", unwrittenObjects.Take(10).Select((x) => x.Key + " at " + String.Join(", ", x.Value.Select((y) => "0x" + y.ToString("X8")))))
+                                      + (unwrittenObjects.Count() > 10
+                                         ? "\n(and more, " + unwrittenObjects.Count() + " total)"
+                                         : ""));
             }
         }
 
@@ -616,6 +635,8 @@ namespace UndertaleModLib
 
     public static class UndertaleIO
     {
+        public static bool IsDictionaryCleared { get; set; } = true;
+
         public static UndertaleData Read(Stream stream, UndertaleReader.WarningHandlerDelegate warningHandler = null,
                                                         UndertaleReader.MessageHandlerDelegate messageHandler = null)
         {
@@ -630,7 +651,7 @@ namespace UndertaleModLib
             UndertaleWriter writer = new UndertaleWriter(stream, messageHandler);
             writer.WriteUndertaleData(data);
             writer.ThrowIfUnwrittenObjects();
-            writer.Flush();
+            writer.Flush(data);
         }
 
         public static Dictionary<uint, UndertaleObject> GenerateOffsetMap(Stream stream)

--- a/UndertaleModLib/Util/FileBinaryReader.cs
+++ b/UndertaleModLib/Util/FileBinaryReader.cs
@@ -1,0 +1,233 @@
+﻿using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace UndertaleModLib.Util
+{
+    // Reimplemented based on DogScepter's implementation
+    public class FileBinaryReader : IDisposable
+    {
+        private readonly byte[] buffer = new byte[16];
+
+        private Encoding encoding = new UTF8Encoding(false);
+        public Encoding Encoding { get => encoding; }
+        public Stream Stream { get; set; }
+
+        public long Length { get; private set; }
+
+        public uint Position
+        {
+            get => (uint)Stream.Position;
+            set
+            {
+                if (value > Length)
+                    throw new IOException("Reading out of bounds.");
+
+                Stream.Position = value;
+            }
+        }
+
+        public FileBinaryReader(Stream stream, Encoding encoding = null)
+        {
+            Length = stream.Length;
+            Stream = stream;
+            Position = 0;
+
+            if (stream.Position != 0)
+                stream.Seek(0, SeekOrigin.Begin);
+
+            if (encoding is not null)
+                this.encoding = encoding;
+        }
+
+        private ReadOnlySpan<byte> ReadToBuffer(int count)
+        {
+            Stream.Read(buffer, 0, count);
+            return buffer;
+        }
+
+        public byte ReadByte()
+        {
+#if DEBUG
+            if (Position + 1 > Length)
+                throw new IOException("Reading out of bounds");
+#endif
+            return (byte)Stream.ReadByte();
+        }
+
+        public virtual bool ReadBoolean()
+        {
+            return ReadByte() != 0;
+        }
+
+        public string ReadChars(int count)
+        {
+#if DEBUG
+            if (Position + count > Length)
+                throw new IOException("Reading out of bounds");
+#endif
+            if (count > 1024)
+            {
+                byte[] buf = new byte[count];
+                Stream.Read(buf, 0, count);
+
+                return encoding.GetString(buf);
+            }
+            else
+            {
+                Span<byte> buf = stackalloc byte[count];
+                Stream.Read(buf);
+
+                return encoding.GetString(buf);
+            }
+        }
+
+        public byte[] ReadBytes(int count)
+        {
+#if DEBUG
+            if (Position + count > Length)
+                throw new IOException("Reading out of bounds");
+#endif
+            byte[] val = new byte[count];
+            Stream.Read(val, 0, count);
+            return val;
+        }
+
+        public short ReadInt16()
+        {
+#if DEBUG
+            if (Position + 2 > Length)
+                throw new IOException("Reading out of bounds");
+#endif
+            return BinaryPrimitives.ReadInt16LittleEndian(ReadToBuffer(2));
+        }
+
+        public ushort ReadUInt16()
+        {
+#if DEBUG
+            if (Position + 2 > Length)
+                throw new IOException("Reading out of bounds");
+#endif
+            return BinaryPrimitives.ReadUInt16LittleEndian(ReadToBuffer(2));
+        }
+
+        public int ReadInt24()
+        {
+#if DEBUG
+            if (Position + 3 > Length)
+                throw new IOException("Reading out of bounds");
+#endif
+            ReadToBuffer(3);
+            return buffer[0] | buffer[1] << 8 | (sbyte)buffer[2] << 16;
+        }
+
+        public uint ReadUInt24()
+        {
+#if DEBUG
+            if (Position + 3 > Length)
+                throw new IOException("Reading out of bounds");
+#endif
+            ReadToBuffer(3);
+            return (uint)(buffer[0] | buffer[1] << 8 | buffer[2] << 16);
+        }
+
+        public int ReadInt32()
+        {
+#if DEBUG
+            if (Position + 4 > Length)
+                throw new IOException("Reading out of bounds");
+#endif
+            return BinaryPrimitives.ReadInt32LittleEndian(ReadToBuffer(4));
+        }
+
+        public uint ReadUInt32()
+        {
+#if DEBUG
+            if (Position + 4 > Length)
+                throw new IOException("Reading out of bounds");
+#endif
+            return BinaryPrimitives.ReadUInt32LittleEndian(ReadToBuffer(4));
+        }
+
+        public float ReadSingle()
+        {
+#if DEBUG
+            if (Position + 4 > Length)
+                throw new IOException("Reading out of bounds");
+#endif
+            return BitConverter.Int32BitsToSingle(BinaryPrimitives.ReadInt32LittleEndian(ReadToBuffer(4)));
+        }
+
+        public double ReadDouble()
+        {
+#if DEBUG
+            if (Position + 8 > Length)
+                throw new IOException("Reading out of bounds");
+#endif
+            return BitConverter.Int64BitsToDouble(BinaryPrimitives.ReadInt64LittleEndian(ReadToBuffer(8)));
+        }
+
+        public long ReadInt64()
+        {
+#if DEBUG
+            if (Position + 8 > Length)
+                throw new IOException("Reading out of bounds");
+#endif
+            return BinaryPrimitives.ReadInt64LittleEndian(ReadToBuffer(8));
+        }
+
+        public ulong ReadUInt64()
+        {
+#if DEBUG
+            if (Position + 8 > Length)
+                throw new IOException("Reading out of bounds");
+#endif
+            return BinaryPrimitives.ReadUInt64LittleEndian(ReadToBuffer(8));
+        }
+
+        public string ReadGMString()
+        {
+#if DEBUG
+            if (Position + 8 > Length)
+                throw new IOException("Reading out of bounds");
+#endif
+            int length = BinaryPrimitives.ReadInt32LittleEndian(ReadToBuffer(4));
+#if DEBUG
+            if (Position + length + 1 >= Length)
+                throw new IOException("Reading out of bounds");
+#endif
+            string res;
+            if (length > 1024)
+            {
+                byte[] buf = new byte[length];
+                Stream.Read(buf, 0, length);
+                res = encoding.GetString(buf);
+            }
+            else
+            {
+                Span<byte> buf = stackalloc byte[length];
+                Stream.Read(buf);
+                res = encoding.GetString(buf);
+            }
+            
+#if DEBUG
+            if (Stream.ReadByte() != 0)
+                throw new IOException("String not null terminated!");
+#else
+            Position++;
+#endif
+            return res;
+        }
+
+        public void Dispose()
+        {
+            if (Stream is not null)
+            {
+                Stream.Close();
+                Stream.Dispose();
+            }
+        }
+    }
+}

--- a/UndertaleModLib/Util/FileBinaryWriter.cs
+++ b/UndertaleModLib/Util/FileBinaryWriter.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Buffers.Binary;
+using System.IO;
+using System.Text;
+
+namespace UndertaleModLib.Util
+{
+    public class FileBinaryWriter : BinaryWriter
+    {
+        private readonly Encoding encoding = new UTF8Encoding(false);
+
+        public uint Position
+        {
+            get => (uint)OutStream.Position;
+            set => OutStream.Position = value;
+        }
+
+        public Encoding Encoding { get => encoding; }
+        public Stream BaseStream => OutStream;
+
+        public FileBinaryWriter(Stream stream, Encoding encoding = null) : base(stream)
+        {
+            if (encoding is not null)
+                this.encoding = encoding;
+        }
+
+        public void Write(MemoryStream value)
+        {
+            value.CopyTo(OutStream);
+        }
+
+        public override void Write(char[] value)
+        {
+            foreach (char c in value)
+                OutStream.WriteByte(Convert.ToByte(c));
+        }
+
+        public void WriteInt24(int value)
+        {
+            Span<byte> buffer = stackalloc byte[3];
+            buffer[0] = (byte)(value & 0xFF);
+            buffer[1] = (byte)((value >> 8) & 0xFF);
+            buffer[2] = (byte)((value >> 16) & 0xFF);
+            OutStream.Write(buffer);
+        }
+
+        public void WriteUInt24(uint value)
+        {
+            Span<byte> buffer = stackalloc byte[3];
+            buffer[0] = (byte)(value & 0xFF);
+            buffer[1] = (byte)((value >> 8) & 0xFF);
+            buffer[2] = (byte)((value >> 16) & 0xFF);
+            OutStream.Write(buffer);
+        }
+
+        public void WriteGMString(string value)
+        {
+            int len = encoding.GetByteCount(value);
+            Span<byte> buf = stackalloc byte[4];
+            BinaryPrimitives.WriteInt32LittleEndian(buf, len);
+            OutStream.Write(buf);
+
+            if (len > 1024)
+                OutStream.Write(encoding.GetBytes(value));
+            else
+            {
+                Span<byte> stringBuf = stackalloc byte[len];
+                encoding.GetBytes(value.AsSpan(), stringBuf);
+                OutStream.Write(stringBuf);
+            }
+            OutStream.WriteByte(0);
+        }
+    }
+}

--- a/UndertaleModLib/Util/FileBinaryWriter.cs
+++ b/UndertaleModLib/Util/FileBinaryWriter.cs
@@ -16,7 +16,6 @@ namespace UndertaleModLib.Util
         }
 
         public Encoding Encoding { get => encoding; }
-        public Stream BaseStream => OutStream;
 
         public FileBinaryWriter(Stream stream, Encoding encoding = null) : base(stream)
         {

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -924,7 +924,7 @@ namespace UndertaleModTool
                         {
                             CanSave = true;
                             CanSafelySave = true;
-                            UpdateProfile(data, filename);
+                            await UpdateProfile(data, filename);
                             if (data != null)
                             {
                                 data.ToolInfo.ProfileMode = SettingsWindow.ProfileModeEnabled;
@@ -1147,7 +1147,7 @@ namespace UndertaleModTool
                         await SaveGMLCache(filename, true, dialog, isDifferentPath);
 
                         // Also make the changes to the profile system.
-                        ProfileSaveEvent(Data, filename);
+                        await ProfileSaveEvent(Data, filename);
                         SaveTempToMainProfile();
                     }
                     else

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -1110,7 +1110,26 @@ namespace UndertaleModTool
                 }
                 catch (Exception e)
                 {
-                    this.ShowError("An error occured while trying to save:\n" + e.Message, "Save error");
+                    if (!UndertaleIO.IsDictionaryCleared)
+                    {
+                        try
+                        {
+                            var listChunks = Data.FORM.Chunks.Values.Select(x => x as IUndertaleListChunk);
+                            Parallel.ForEach(listChunks.Where(x => x is not null), (chunk) =>
+                            {
+                                chunk.ClearIndexDict();
+                            });
+
+                            UndertaleIO.IsDictionaryCleared = true;
+                        }
+                        catch { }
+                    }
+
+                    Dispatcher.Invoke(() =>
+                    {
+                        this.ShowError("An error occured while trying to save:\n" + e.Message, "Save error");
+                    });
+                    
                     SaveSucceeded = false;
                 }
                 // Don't make any changes unless the save succeeds.
@@ -1142,7 +1161,11 @@ namespace UndertaleModTool
                 }
                 catch (Exception exc)
                 {
-                    this.ShowError("An error occured while trying to save:\n" + exc.Message, "Save error");
+                    Dispatcher.Invoke(() =>
+                    {
+                        this.ShowError("An error occured while trying to save:\n" + exc.Message, "Save error");
+                    });
+                    
                     SaveSucceeded = false;
                 }
                 if (Data != null)

--- a/UndertaleModTool/ProfileSystem.cs
+++ b/UndertaleModTool/ProfileSystem.cs
@@ -207,6 +207,8 @@ namespace UndertaleModTool
         }
         public async Task UpdateProfile(UndertaleData data, string filename)
         {
+            FileMessageEvent?.Invoke("Calculating MD5 hash...");
+
             try
             {
                 await Task.Run(() =>
@@ -310,6 +312,8 @@ an issue on GitHub.");
         }
         public async Task ProfileSaveEvent(UndertaleData data, string filename)
         {
+            FileMessageEvent?.Invoke("Calculating MD5 hash...");
+
             try
             {
                 string deleteIfModeActive = BitConverter.ToString(MD5PreviouslyLoaded).Replace("-", "").ToLowerInvariant();

--- a/UndertaleModTool/ProfileSystem.cs
+++ b/UndertaleModTool/ProfileSystem.cs
@@ -9,6 +9,7 @@ using UndertaleModLib.Scripting;
 using System.Security.Cryptography;
 using UndertaleModLib.Models;
 using UndertaleModLib.Decompiler;
+using System.Threading.Tasks;
 
 namespace UndertaleModTool
 {
@@ -204,19 +205,22 @@ namespace UndertaleModTool
                 this.ShowError("SaveTempToMainProfile error! Send this to Grossley#2869 and make an issue on Github\n" + exc);
             }
         }
-        public void UpdateProfile(UndertaleData data, string filename)
+        public async Task UpdateProfile(UndertaleData data, string filename)
         {
             try
             {
-                using (var md5Instance = MD5.Create())
+                await Task.Run(() =>
                 {
-                    using (var stream = File.OpenRead(filename))
+                    using (var md5Instance = MD5.Create())
                     {
-                        MD5CurrentlyLoaded = md5Instance.ComputeHash(stream);
-                        MD5PreviouslyLoaded = MD5CurrentlyLoaded;
-                        ProfileHash = BitConverter.ToString(MD5PreviouslyLoaded).Replace("-", "").ToLowerInvariant();
+                        using (var stream = File.OpenRead(filename))
+                        {
+                            MD5CurrentlyLoaded = md5Instance.ComputeHash(stream);
+                            MD5PreviouslyLoaded = MD5CurrentlyLoaded;
+                            ProfileHash = BitConverter.ToString(MD5PreviouslyLoaded).Replace("-", "").ToLowerInvariant();
+                        }
                     }
-                }
+                });
 
                 string profDir = Path.Combine(ProfilesFolder, ProfileHash);
                 string profDirTemp = Path.Combine(profDir, "Temp");
@@ -304,23 +308,27 @@ an issue on GitHub.");
                 this.ShowError("UpdateProfile error! Send this to Grossley#2869 and make an issue on Github\n" + exc);
             }
         }
-        public void ProfileSaveEvent(UndertaleData data, string filename)
+        public async Task ProfileSaveEvent(UndertaleData data, string filename)
         {
             try
             {
                 string deleteIfModeActive = BitConverter.ToString(MD5PreviouslyLoaded).Replace("-", "").ToLowerInvariant();
                 bool copyProfile = false;
-                using (var md5Instance = MD5.Create())
+                await Task.Run(() =>
                 {
-                    using (var stream = File.OpenRead(filename))
+                    using (var md5Instance = MD5.Create())
                     {
-                        MD5CurrentlyLoaded = md5Instance.ComputeHash(stream);
-                        if (BitConverter.ToString(MD5PreviouslyLoaded).Replace("-", "").ToLowerInvariant() != BitConverter.ToString(MD5CurrentlyLoaded).Replace("-", "").ToLowerInvariant())
+                        using (var stream = File.OpenRead(filename))
                         {
-                            copyProfile = true;
+                            MD5CurrentlyLoaded = md5Instance.ComputeHash(stream);
+                            if (BitConverter.ToString(MD5PreviouslyLoaded).Replace("-", "").ToLowerInvariant() != BitConverter.ToString(MD5CurrentlyLoaded).Replace("-", "").ToLowerInvariant())
+                            {
+                                copyProfile = true;
+                            }
                         }
                     }
-                }
+                });
+
                 Directory.CreateDirectory(Path.Combine(ProfilesFolder, ProfileHash, "Main"));
                 Directory.CreateDirectory(Path.Combine(ProfilesFolder, ProfileHash, "Temp"));
                 if (!SettingsWindow.ProfileModeEnabled || data.GMS2_3 || data.IsYYC())


### PR DESCRIPTION
## Description
Game data loading and saving improvements:
1. **Game data is now loaded and saved directly, without buffering whole file data in memory** - new `FileBinaryReader` and `FileBinaryWriter` are used for that.
So, it's possible to **load and save data files that larger than 2 GB.**
2. **_"Writing references in parallel..."_ part of the data saving is a lot faster** - added the chunks type and object index dictionaries, added `IUndertaleSingleChunk` and `IUndertale(Simple)ListChunk` interfaces.
3. Messages of the final part of data saving are describing the process more precisely.
4. `ProfileSaveEvent()` and `UpdateProfile()` are running on different thread, so UI won't freeze on MD5 calculation.

Other changes:

1. **Fixed some warning/error message boxes not showing up on load or save.**

### Caveats
Game data loading and saving is now more depending on disk read/write load - if disk will be used while loading/saving the data, then it will process the data longer.

### Notes
Closes #520 