### PR TITLE
Disposable "UndertaleData" (and its contained types)

### DIFF
--- a/UndertaleModLib/Models/UndertaleAnimationCurve.cs
+++ b/UndertaleModLib/Models/UndertaleAnimationCurve.cs
@@ -1,10 +1,12 @@
-﻿namespace UndertaleModLib.Models;
+﻿using System;
+
+namespace UndertaleModLib.Models;
 
 /// <summary>
 /// An animation curve entry in a data file.
 /// </summary>
 [PropertyChanged.AddINotifyPropertyChangedInterface]
-public class UndertaleAnimationCurve : UndertaleNamedResource
+public class UndertaleAnimationCurve : UndertaleNamedResource, IDisposable
 {
     public enum GraphTypeEnum : uint
     {
@@ -66,11 +68,23 @@ public class UndertaleAnimationCurve : UndertaleNamedResource
     /// <inheritdoc />
     public override string ToString()
     {
-        return Name.Content;
+        return Name?.Content;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        if (Channels is not null)
+            foreach (Channel channel in Channels)
+                channel?.Dispose();
+        Name = null;
+        Channels = null;
     }
 
     [PropertyChanged.AddINotifyPropertyChangedInterface]
-    public class Channel : UndertaleObject
+    public class Channel : UndertaleObject, IDisposable
     {
         public enum FunctionType : uint
         {
@@ -99,6 +113,15 @@ public class UndertaleAnimationCurve : UndertaleNamedResource
             Function = (FunctionType)reader.ReadUInt32();
             Iterations = reader.ReadUInt32();
             Points = reader.ReadUndertaleObject<UndertaleSimpleList<Point>>();
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+
+            Name = null;
+            Points = null;
         }
 
         public class Point : UndertaleObject

--- a/UndertaleModLib/Models/UndertaleAnimationCurve.cs
+++ b/UndertaleModLib/Models/UndertaleAnimationCurve.cs
@@ -77,8 +77,10 @@ public class UndertaleAnimationCurve : UndertaleNamedResource, IDisposable
         GC.SuppressFinalize(this);
 
         if (Channels is not null)
+        {
             foreach (Channel channel in Channels)
                 channel?.Dispose();
+         }
         Name = null;
         Channels = null;
     }

--- a/UndertaleModLib/Models/UndertaleBackground.cs
+++ b/UndertaleModLib/Models/UndertaleBackground.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace UndertaleModLib.Models;
@@ -9,7 +10,7 @@ namespace UndertaleModLib.Models;
 /// <remarks>For Game Maker Studio: 2, this will only ever be a tileset. For Game Maker Studio: 1, this is usually a background,
 /// but is sometimes repurposed as use for a tileset as well.</remarks>
 [PropertyChanged.AddINotifyPropertyChangedInterface]
-public class UndertaleBackground : UndertaleNamedResource
+public class UndertaleBackground : UndertaleNamedResource, IDisposable
 {
     /// <summary>
     /// A tile id, which can be used for referencing specific tiles in a tileset. Game Maker Studio 2 only.
@@ -180,6 +181,16 @@ public class UndertaleBackground : UndertaleNamedResource
     /// <inheritdoc />
     public override string ToString()
     {
-        return Name.Content + " (" + GetType().Name + ")";
+        return Name?.Content + " (" + GetType().Name + ")";
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        GMS2TileIds = new();
+        Name = null;
+        Texture = null;
     }
 }

--- a/UndertaleModLib/Models/UndertaleEmbeddedAudio.cs
+++ b/UndertaleModLib/Models/UndertaleEmbeddedAudio.cs
@@ -7,7 +7,7 @@ namespace UndertaleModLib.Models;
 /// An embedded audio entry in a data file.
 /// </summary>
 [PropertyChanged.AddINotifyPropertyChangedInterface]
-public class UndertaleEmbeddedAudio : UndertaleNamedResource, PaddedObject
+public class UndertaleEmbeddedAudio : UndertaleNamedResource, PaddedObject, IDisposable
 {
     /// <summary>
     /// The name of the embedded audio entry.
@@ -61,5 +61,14 @@ public class UndertaleEmbeddedAudio : UndertaleNamedResource, PaddedObject
             Name = new UndertaleString("EmbeddedSound Unknown Index");
         }
         return Name.Content + " (" + GetType().Name + ")";
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        Name = null;
+        Data = Array.Empty<byte>();
     }
 }

--- a/UndertaleModLib/Models/UndertaleEmbeddedImage.cs
+++ b/UndertaleModLib/Models/UndertaleEmbeddedImage.cs
@@ -1,4 +1,6 @@
-﻿namespace UndertaleModLib.Models;
+﻿using System;
+
+namespace UndertaleModLib.Models;
 
 /// <summary>
 /// An embedded image entry in a GameMaker data file. This is GMS2 only.<br/>
@@ -20,7 +22,7 @@
 /// 32-bit pointer to something relating to a texture page entry?
 /// </code>
 /// <see href="https://github.com/krzys-h/UndertaleModTool/issues/4#issuecomment-421844420"/>.</remarks>
-public class UndertaleEmbeddedImage : UndertaleNamedResource
+public class UndertaleEmbeddedImage : UndertaleNamedResource, IDisposable
 {
     /// <summary>
     /// The name of the <see cref="UndertaleEmbeddedImage"/>.
@@ -49,6 +51,15 @@ public class UndertaleEmbeddedImage : UndertaleNamedResource
     /// <inheritdoc />
     public override string ToString()
     {
-        return Name.Content + " (" + GetType().Name + ")";
+        return Name?.Content + " (" + GetType().Name + ")";
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        Name = null;
+        TextureEntry = null;
     }
 }

--- a/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
+++ b/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
@@ -14,7 +14,7 @@ namespace UndertaleModLib.Models;
 /// An embedded texture entry in the data file.
 /// </summary>
 [PropertyChanged.AddINotifyPropertyChangedInterface]
-public class UndertaleEmbeddedTexture : UndertaleNamedResource
+public class UndertaleEmbeddedTexture : UndertaleNamedResource, IDisposable
 {
     /// <summary>
     /// The name of the embedded texture entry.
@@ -101,10 +101,19 @@ public class UndertaleEmbeddedTexture : UndertaleNamedResource
         return Name.Content + " (" + GetType().Name + ")";
     }
 
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        TextureData.Dispose();
+        Name = null;
+    }
+
     /// <summary>
     /// Texture data in an <see cref="UndertaleEmbeddedTexture"/>.
     /// </summary>
-    public class TexData : UndertaleObject, INotifyPropertyChanged
+    public class TexData : UndertaleObject, INotifyPropertyChanged, IDisposable
     {
         private byte[] _textureBlob;
 
@@ -213,6 +222,15 @@ public class UndertaleEmbeddedTexture : UndertaleNamedResource
             uint length = reader.Position - startAddress;
             reader.Position = startAddress;
             TextureBlob = reader.ReadBytes((int)length);
+        }
+
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+
+            _textureBlob = null;
         }
     }
 }

--- a/UndertaleModLib/Models/UndertaleExtension.cs
+++ b/UndertaleModLib/Models/UndertaleExtension.cs
@@ -205,8 +205,10 @@ public class UndertaleExtensionFile : UndertaleObject, IDisposable
         GC.SuppressFinalize(this);
 
         if (Functions is not null)
+        {
             foreach (UndertaleExtensionFunction func in Functions)
                 func?.Dispose();
+         }
         Filename = null;
         CleanupScript = null;
         InitScript = null;

--- a/UndertaleModLib/Models/UndertaleExtension.cs
+++ b/UndertaleModLib/Models/UndertaleExtension.cs
@@ -94,7 +94,7 @@ public class UndertaleExtensionFunctionArg : UndertaleObject
 /// A function in a <see cref="UndertaleExtension"/>.
 /// </summary>
 [PropertyChanged.AddINotifyPropertyChangedInterface]
-public class UndertaleExtensionFunction : UndertaleObject
+public class UndertaleExtensionFunction : UndertaleObject, IDisposable
 {
     /// <summary>
     /// The name of the function.
@@ -143,12 +143,22 @@ public class UndertaleExtensionFunction : UndertaleObject
     /// <inheritdoc />
     public override string ToString()
     {
-        return Name.Content + " (" + ExtName.Content + ")";
+        return Name?.Content + " (" + ExtName?.Content + ")";
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        Arguments = new();
+        Name = null;
+        ExtName = null;
     }
 }
 
 [PropertyChanged.AddINotifyPropertyChangedInterface]
-public class UndertaleExtensionFile : UndertaleObject
+public class UndertaleExtensionFile : UndertaleObject, IDisposable
 {
     public UndertaleString Filename { get; set; }
     public UndertaleString CleanupScript { get; set; }
@@ -188,13 +198,27 @@ public class UndertaleExtensionFile : UndertaleObject
             return "(Unknown extension file)";
         }
     }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        if (Functions is not null)
+            foreach (UndertaleExtensionFunction func in Functions)
+                func?.Dispose();
+        Filename = null;
+        CleanupScript = null;
+        InitScript = null;
+        Functions = new();
+    }
 }
 
 /// <summary>
 /// An extension entry in a GameMaker data file.
 /// </summary>
 [PropertyChanged.AddINotifyPropertyChangedInterface]
-public class UndertaleExtension : UndertaleNamedResource
+public class UndertaleExtension : UndertaleNamedResource, IDisposable
 {
     /// <summary>
     /// In which folder the extension is located. TODO: needs more GM8 research.
@@ -214,7 +238,21 @@ public class UndertaleExtension : UndertaleNamedResource
     /// <inheritdoc />
     public override string ToString()
     {
-        return Name.Content + " (" + GetType().Name + ")";
+        return Name?.Content + " (" + GetType().Name + ")";
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        foreach (UndertaleExtensionFile file in Files)
+            file?.Dispose();
+        Files = new();
+        FolderName = null;
+        Name = null;
+        ClassName = null;
+        Files = new();
     }
 
     /// <inheritdoc />

--- a/UndertaleModLib/Models/UndertaleFilterEffect.cs
+++ b/UndertaleModLib/Models/UndertaleFilterEffect.cs
@@ -1,10 +1,12 @@
-﻿namespace UndertaleModLib.Models;
+﻿using System;
+
+namespace UndertaleModLib.Models;
 
 /// <summary>
 /// A filter effect as it's used in a GameMaker data file. These are GameMaker: Studio 2.3.6+ only.
 /// </summary>
 [PropertyChanged.AddINotifyPropertyChangedInterface]
-public class UndertaleFilterEffect : UndertaleNamedResource
+public class UndertaleFilterEffect : UndertaleNamedResource, IDisposable
 {
     /// <summary>
     /// The name of the <see cref="UndertaleFilterEffect"/>.
@@ -33,6 +35,15 @@ public class UndertaleFilterEffect : UndertaleNamedResource
     /// <inheritdoc />
     public override string ToString()
     {
-        return Name.Content + " (" + GetType().Name + ")";
+        return Name?.Content + " (" + GetType().Name + ")";
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        Name = null;
+        Value = null;
     }
 }

--- a/UndertaleModLib/Models/UndertaleFont.cs
+++ b/UndertaleModLib/Models/UndertaleFont.cs
@@ -6,7 +6,7 @@ namespace UndertaleModLib.Models;
 /// A font entry of a data file.
 /// </summary>
 [PropertyChanged.AddINotifyPropertyChangedInterface]
-public class UndertaleFont : UndertaleNamedResource
+public class UndertaleFont : UndertaleNamedResource, IDisposable
 {
     /// <summary>
     /// The name of the font.
@@ -94,7 +94,7 @@ public class UndertaleFont : UndertaleNamedResource
     /// Glyphs that a font can use.
     /// </summary>
     [PropertyChanged.AddINotifyPropertyChangedInterface]
-    public class Glyph : UndertaleObject
+    public class Glyph : UndertaleObject, IDisposable
     {
         /// <summary>
         /// The code point of character for the glyph.
@@ -192,6 +192,14 @@ public class UndertaleFont : UndertaleNamedResource
                 Amount = reader.ReadInt16();
             }
         }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+
+            Kerning = new();
+        }
     }
 
     /// <inheritdoc />
@@ -261,6 +269,19 @@ public class UndertaleFont : UndertaleNamedResource
     /// <inheritdoc />
     public override string ToString()
     {
-        return Name.Content + " (" + GetType().Name + ")";
+        return Name?.Content + " (" + GetType().Name + ")";
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        foreach (Glyph glyph in Glyphs)
+            glyph?.Dispose();
+        Name = null;
+        DisplayName = null;
+        Texture = null;
+        Glyphs = new();
     }
 }

--- a/UndertaleModLib/Models/UndertaleFunction.cs
+++ b/UndertaleModLib/Models/UndertaleFunction.cs
@@ -9,7 +9,7 @@ namespace UndertaleModLib.Models;
 /// A function entry as it's used in a GameMaker data file.
 /// </summary>
 [PropertyChanged.AddINotifyPropertyChangedInterface]
-public class UndertaleFunction : UndertaleNamedResource, UndertaleInstruction.ReferencedObject
+public class UndertaleFunction : UndertaleNamedResource, UndertaleInstruction.ReferencedObject, IDisposable
 {
     public FunctionClassification Classification { get; set; }
 
@@ -75,14 +75,23 @@ public class UndertaleFunction : UndertaleNamedResource, UndertaleInstruction.Re
     /// <inheritdoc />
     public override string ToString()
     {
-        return Name.Content;
+        return Name?.Content;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        Name = null;
+        FirstAddress = null;
     }
 }
 
 // Seems to be unused. You can remove all entries and the game still works normally.
 // Maybe the GM:S debugger uses this data?
 // TODO: INotifyPropertyChanged
-public class UndertaleCodeLocals : UndertaleNamedResource
+public class UndertaleCodeLocals : UndertaleNamedResource, IDisposable
 {
     public UndertaleString Name { get; set; }
     public ObservableCollection<LocalVar> Locals { get; } = new ObservableCollection<LocalVar>();
@@ -117,7 +126,7 @@ public class UndertaleCodeLocals : UndertaleNamedResource
     }
 
     // TODO: INotifyPropertyChanged
-    public class LocalVar : UndertaleObject
+    public class LocalVar : UndertaleObject, IDisposable
     {
         public uint Index { get; set; }
         public UndertaleString Name { get; set; }
@@ -135,11 +144,28 @@ public class UndertaleCodeLocals : UndertaleNamedResource
             Index = reader.ReadUInt32();
             Name = reader.ReadUndertaleString();
         }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+
+            Name = null;
+        }
     }
 
     /// <inheritdoc />
     public override string ToString()
     {
-        return Name.Content + " (" + GetType().Name + ")";
+        return Name?.Content + " (" + GetType().Name + ")";
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        Name = null;
+        Locals.Clear();
     }
 }

--- a/UndertaleModLib/Models/UndertaleGameObject.cs
+++ b/UndertaleModLib/Models/UndertaleGameObject.cs
@@ -374,8 +374,10 @@ public class UndertaleGameObject : UndertaleNamedResource, INotifyPropertyChange
         _textureMaskId.Dispose();
         PhysicsVertices = new();
         foreach (var ev in Events)
+        {
             foreach (var subEv in ev)
                 subEv?.Dispose();
+         }
         Name = null;
         Events = new();
     }

--- a/UndertaleModLib/Models/UndertaleGameObject.cs
+++ b/UndertaleModLib/Models/UndertaleGameObject.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace UndertaleModLib.Models;
 
@@ -28,11 +29,11 @@ public enum CollisionShapeFlags : uint
 /// <summary>
 /// A game object in a data file.
 /// </summary>
-public class UndertaleGameObject : UndertaleNamedResource, INotifyPropertyChanged
+public class UndertaleGameObject : UndertaleNamedResource, INotifyPropertyChanged, IDisposable
 {
-    public UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT> _Sprite = new UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT>();
-    public UndertaleResourceById<UndertaleGameObject, UndertaleChunkOBJT> _ParentId = new UndertaleResourceById<UndertaleGameObject, UndertaleChunkOBJT>();
-    public UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT> _TextureMaskId = new UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT>();
+    public UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT> _sprite = new();
+    public UndertaleResourceById<UndertaleGameObject, UndertaleChunkOBJT> _parentId = new();
+    public UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT> _textureMaskId = new();
 
     /// <summary>
     /// The name of the game object.
@@ -42,7 +43,7 @@ public class UndertaleGameObject : UndertaleNamedResource, INotifyPropertyChange
     /// <summary>
     /// The sprite this game object uses.
     /// </summary>
-    public UndertaleSprite Sprite { get => _Sprite.Resource; set { _Sprite.Resource = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Sprite))); } }
+    public UndertaleSprite Sprite { get => _sprite.Resource; set { _sprite.Resource = value; OnPropertyChanged(); } }
 
     /// <summary>
     /// Whether the game object is visible.
@@ -67,12 +68,12 @@ public class UndertaleGameObject : UndertaleNamedResource, INotifyPropertyChange
     /// <summary>
     /// The parent game object this is inheriting from.
     /// </summary>
-    public UndertaleGameObject ParentId { get => _ParentId.Resource; set { _ParentId.Resource = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ParentId))); } }
+    public UndertaleGameObject ParentId { get => _parentId.Resource; set { _parentId.Resource = value; OnPropertyChanged(); } }
 
     /// <summary>
     /// The texture mask this game object is using.
     /// </summary>
-    public UndertaleSprite TextureMaskId { get => _TextureMaskId.Resource; set { _TextureMaskId.Resource = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(TextureMaskId))); } }
+    public UndertaleSprite TextureMaskId { get => _textureMaskId.Resource; set { _textureMaskId.Resource = value; OnPropertyChanged(); } }
 
     #region Physics related properties
     /// <summary>
@@ -140,10 +141,14 @@ public class UndertaleGameObject : UndertaleNamedResource, INotifyPropertyChange
     /// <summary>
     /// All the events that this game object has.
     /// </summary>
-    public UndertalePointerList<UndertalePointerList<Event>> Events { get; private set; } = new UndertalePointerList<UndertalePointerList<Event>>();
+    public UndertalePointerList<UndertalePointerList<Event>> Events { get; private set; } = new();
 
     /// <inheritdoc />
     public event PropertyChangedEventHandler PropertyChanged;
+    protected void OnPropertyChanged([CallerMemberName] string name = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
 
     /// <summary>
     /// Initialized an instance of <see cref="UndertaleGameObject"/>.
@@ -158,21 +163,21 @@ public class UndertaleGameObject : UndertaleNamedResource, INotifyPropertyChange
     public void Serialize(UndertaleWriter writer)
     {
         writer.WriteUndertaleString(Name);
-        writer.WriteUndertaleObject(_Sprite);
+        writer.WriteUndertaleObject(_sprite);
         writer.Write(Visible);
         writer.Write(Solid);
         writer.Write(Depth);
         writer.Write(Persistent);
         // This apparently has a different notation than everything else...
-        if (_ParentId.Resource == null)
+        if (_parentId.Resource == null)
         {
             writer.Write(-100);
         }
         else
         {
-            writer.WriteUndertaleObject(_ParentId);
+            writer.WriteUndertaleObject(_parentId);
         }
-        writer.WriteUndertaleObject(_TextureMaskId);
+        writer.WriteUndertaleObject(_textureMaskId);
         writer.Write(UsesPhysics);
         writer.Write(IsSensor);
         writer.Write((uint)CollisionShape);
@@ -197,24 +202,24 @@ public class UndertaleGameObject : UndertaleNamedResource, INotifyPropertyChange
     public void Unserialize(UndertaleReader reader)
     {
         Name = reader.ReadUndertaleString();
-        _Sprite = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT>>();
+        _sprite = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT>>();
         Visible = reader.ReadBoolean();
         Solid = reader.ReadBoolean();
         Depth = reader.ReadInt32();
         Persistent = reader.ReadBoolean();
-        _ParentId = new UndertaleResourceById<UndertaleGameObject, UndertaleChunkOBJT>();
+        _parentId = new UndertaleResourceById<UndertaleGameObject, UndertaleChunkOBJT>();
         int parent = reader.ReadInt32();
         if (parent == -100)
         {
-            _ParentId.UnserializeById(reader, -1);
+            _parentId.UnserializeById(reader, -1);
         }
         else
         {
             if (parent < 0 && parent != -1) // Technically can be -100 (undefined), -2 (other), or -1 (self). Other makes no sense here though
                 throw new Exception("Invalid value for parent - should be -100 or object id, got " + parent);
-            _ParentId.UnserializeById(reader, parent);
+            _parentId.UnserializeById(reader, parent);
         }
-        _TextureMaskId = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT>>();
+        _textureMaskId = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT>>();
         UsesPhysics = reader.ReadBoolean();
         IsSensor = reader.ReadBoolean();
         CollisionShape = (CollisionShapeFlags)reader.ReadUInt32();
@@ -237,6 +242,7 @@ public class UndertaleGameObject : UndertaleNamedResource, INotifyPropertyChange
         Events = reader.ReadUndertaleObject<UndertalePointerList<UndertalePointerList<Event>>>();
     }
 
+    #region EventHandlerFor() overloads
     //TODO: what do all these eventhandlers do? can't find any references right now.
 
     public UndertaleCode EventHandlerFor(EventType type, uint subtype, IList<UndertaleString> strg, IList<UndertaleCode> codelist, IList<UndertaleCodeLocals> localslist)
@@ -350,18 +356,35 @@ public class UndertaleGameObject : UndertaleNamedResource, INotifyPropertyChange
             throw new InvalidOperationException();
         return EventHandlerFor(type, (uint)subtype, strg, codelist, localslist);
     }
+    #endregion
 
     /// <inheritdoc />
     public override string ToString()
     {
-        return Name.Content + " (" + GetType().Name + ")";
+        return Name?.Content + " (" + GetType().Name + ")";
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        _sprite.Dispose();
+        _parentId.Dispose();
+        _textureMaskId.Dispose();
+        PhysicsVertices = new();
+        foreach (var ev in Events)
+            foreach (var subEv in ev)
+                subEv?.Dispose();
+        Name = null;
+        Events = new();
     }
 
     /// <summary>
     /// Generic events that an <see cref="UndertaleGameObject"/> uses.
     /// </summary>
     [PropertyChanged.AddINotifyPropertyChangedInterface]
-    public class Event : UndertaleObject
+    public class Event : UndertaleObject, IDisposable
     {
         /// <summary>
         /// The subtype of this event.
@@ -425,12 +448,22 @@ public class UndertaleGameObject : UndertaleNamedResource, INotifyPropertyChange
             EventSubtype = reader.ReadUInt32();
             Actions = reader.ReadUndertaleObject<UndertalePointerList<EventAction>>();
         }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+
+            foreach (EventAction action in Actions)
+                action?.Dispose();
+            Actions = new();
+        }
     }
 
     /// <summary>
     /// An action in an event.
     /// </summary>
-    public class EventAction : UndertaleObject, INotifyPropertyChanged
+    public class EventAction : UndertaleObject, INotifyPropertyChanged, IDisposable
     {
         // All the unknown values seem to be provided for compatibility only - in older versions of GM:S they stored the drag and drop blocks,
         // but newer versions compile them down to GML bytecode anyway
@@ -446,12 +479,12 @@ public class UndertaleGameObject : UndertaleNamedResource, INotifyPropertyChange
         public bool UseApplyTo { get; set; } // always 1
         public uint ExeType { get; set; } // always 2
         public UndertaleString ActionName { get; set; } // always ""
-        private UndertaleResourceById<UndertaleCode, UndertaleChunkCODE> _CodeId = new UndertaleModLib.UndertaleResourceById<UndertaleCode, UndertaleChunkCODE>();
+        private UndertaleResourceById<UndertaleCode, UndertaleChunkCODE> _codeId = new UndertaleResourceById<UndertaleCode, UndertaleChunkCODE>();
 
         /// <summary>
         /// The code entry that gets executed.
         /// </summary>
-        public UndertaleCode CodeId { get => _CodeId.Resource; set { _CodeId.Resource = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CodeId))); } }
+        public UndertaleCode CodeId { get => _codeId.Resource; set { _codeId.Resource = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CodeId))); } }
         public uint ArgumentCount { get; set; } // always 1
         public int Who { get; set; } // always -1
         public bool Relative { get; set; } // always 0
@@ -471,7 +504,7 @@ public class UndertaleGameObject : UndertaleNamedResource, INotifyPropertyChange
             writer.Write(UseApplyTo);
             writer.Write(ExeType);
             writer.WriteUndertaleString(ActionName);
-            writer.WriteUndertaleObject(_CodeId);
+            writer.WriteUndertaleObject(_codeId);
             writer.Write(ArgumentCount);
             writer.Write(Who);
             writer.Write(Relative);
@@ -490,12 +523,21 @@ public class UndertaleGameObject : UndertaleNamedResource, INotifyPropertyChange
             UseApplyTo = reader.ReadBoolean();
             ExeType = reader.ReadUInt32();
             ActionName = reader.ReadUndertaleString();
-            _CodeId = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleCode, UndertaleChunkCODE>>();
+            _codeId = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleCode, UndertaleChunkCODE>>();
             ArgumentCount = reader.ReadUInt32();
             Who = reader.ReadInt32();
             Relative = reader.ReadBoolean();
             IsNot = reader.ReadBoolean();
             UnknownAlwaysZero = reader.ReadUInt32();
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+
+            _codeId.Dispose();
+            ActionName = null;
         }
     }
 

--- a/UndertaleModLib/Models/UndertaleGeneralInfo.cs
+++ b/UndertaleModLib/Models/UndertaleGeneralInfo.cs
@@ -789,8 +789,10 @@ public class UndertaleOptions : UndertaleObject, IDisposable
         GC.SuppressFinalize(this);
 
         if (Constants is not null)
+        {
             foreach (Constant constant in Constants)
                 constant?.Dispose();
+         }
         BackImage = new();
         FrontImage = new();
         LoadImage = new();

--- a/UndertaleModLib/Models/UndertaleGeneralInfo.cs
+++ b/UndertaleModLib/Models/UndertaleGeneralInfo.cs
@@ -873,7 +873,7 @@ public class UndertaleLanguage : UndertaleObject, IDisposable
         // values that correspond to IDs in the main chunk content
 
         /// <summary>
-        /// Serializes the data file into a specified <see cref="UndertaleWriter"/>.
+        /// Serializes <see cref="LanguageData"/> into a specified <see cref="UndertaleWriter"/>.
         /// </summary>
         /// <param name="writer">Where to serialize to.</param>
         public void Serialize(UndertaleWriter writer)
@@ -887,9 +887,10 @@ public class UndertaleLanguage : UndertaleObject, IDisposable
         }
 
         /// <summary>
-        /// Deserializes the object from a specified <see cref="UndertaleReader"/>.
+        /// Deserializes <see cref="LanguageData"/> from a specified <see cref="UndertaleReader"/> and with a specified entries count.
         /// </summary>
         /// <param name="reader">Where to deserialize from.</param>
+        /// <param name="entryCount">Count of entries to read.</param>
         public void Unserialize(UndertaleReader reader, uint entryCount)
         {
             Name = reader.ReadUndertaleString();

--- a/UndertaleModLib/Models/UndertaleGlobalInit.cs
+++ b/UndertaleModLib/Models/UndertaleGlobalInit.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 
 namespace UndertaleModLib.Models;
 
@@ -6,14 +7,14 @@ namespace UndertaleModLib.Models;
 /// A global initialization entry in a data file.
 /// </summary>
 /// <remarks>Never seen in GMS1.4 so uncertain if the structure was the same.</remarks>
-public class UndertaleGlobalInit : UndertaleObject, INotifyPropertyChanged
+public class UndertaleGlobalInit : UndertaleObject, INotifyPropertyChanged, IDisposable
 {
-    private UndertaleResourceById<UndertaleCode, UndertaleChunkCODE> _Code = new UndertaleResourceById<UndertaleCode, UndertaleChunkCODE>();
+    private UndertaleResourceById<UndertaleCode, UndertaleChunkCODE> _code = new();
 
     /// <summary>
     /// The <see cref="UndertaleCode"/> object which contains the code.
     /// </summary>
-    public UndertaleCode Code { get => _Code.Resource; set { _Code.Resource = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Code))); } }
+    public UndertaleCode Code { get => _code.Resource; set { _code.Resource = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Code))); } }
 
     /// <inheritdoc />
     public event PropertyChangedEventHandler PropertyChanged;
@@ -21,13 +22,21 @@ public class UndertaleGlobalInit : UndertaleObject, INotifyPropertyChanged
     /// <inheritdoc />
     public void Serialize(UndertaleWriter writer)
     {
-        _Code.Serialize(writer);
+        _code.Serialize(writer);
     }
 
     /// <inheritdoc />
     public void Unserialize(UndertaleReader reader)
     {
-        _Code = new UndertaleResourceById<UndertaleCode, UndertaleChunkCODE>();
-        _Code.Unserialize(reader); // TODO: reader.ReadUndertaleObject if one object starts with another one
+        _code = new UndertaleResourceById<UndertaleCode, UndertaleChunkCODE>();
+        _code.Unserialize(reader); // TODO: reader.ReadUndertaleObject if one object starts with another one
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        _code.Dispose();
     }
 }

--- a/UndertaleModLib/Models/UndertalePath.cs
+++ b/UndertaleModLib/Models/UndertalePath.cs
@@ -1,10 +1,12 @@
-﻿namespace UndertaleModLib.Models;
+﻿using System;
+
+namespace UndertaleModLib.Models;
 
 /// <summary>
 /// A Path entry in a GameMaker data file.
 /// </summary>
 [PropertyChanged.AddINotifyPropertyChangedInterface]
-public class UndertalePath : UndertaleNamedResource
+public class UndertalePath : UndertaleNamedResource, IDisposable
 {
     /// <summary>
     /// The name of <see cref="UndertalePath"/>.
@@ -94,6 +96,15 @@ public class UndertalePath : UndertaleNamedResource
     /// <inheritdoc />
     public override string ToString()
     {
-        return Name.Content + " (" + GetType().Name + ")";
+        return Name?.Content + " (" + GetType().Name + ")";
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        Name = null;
+        Points = new();
     }
 }

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -1637,17 +1637,26 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
                 GC.SuppressFinalize(this);
 
                 if (LegacyTiles is not null)
+                {
                     foreach (Tile tile in LegacyTiles)
                         tile?.Dispose();
+                }
                 if (Sprites is not null)
+                {
                     foreach (SpriteInstance inst in Sprites)
                         inst?.Dispose();
+                }
                 if (Sequences is not null)
+                {
                     foreach (SequenceInstance inst in Sequences)
                         inst?.Dispose();
+                }
                 if (NineSlices is not null)
+                {
                     foreach (SpriteInstance inst in NineSlices)
                         inst?.Dispose();
+                }
+
                 LegacyTiles = null;
                 Sprites = null;
                 Sequences = null;
@@ -1685,8 +1694,11 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
                 GC.SuppressFinalize(this);
 
                 if (Properties is not null)
+                {
                     foreach (EffectProperty prop in Properties)
                         prop?.Dispose();
+                }
+
                 EffectType = null;
                 Properties = null;
             }

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -163,18 +163,15 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
     public UndertaleSimpleList<UndertaleResourceById<UndertaleSequence, UndertaleChunkSEQN>> Sequences { get; private set; } = new UndertaleSimpleList<UndertaleResourceById<UndertaleSequence, UndertaleChunkSEQN>>();
 
     /// <summary>
-    /// Call <see cref="OnPropertyChanged(string)"/> for <see cref="BGColorLayer"/> to update the room background color.<br/>
-    /// Used for GMS 2 rooms.
+    /// Calls <see cref="OnPropertyChanged(string)"/> for <see cref="BGColorLayer"/> in order to update the room background color.<br/>
+    /// Only used for GameMaker: Studio 2 rooms.
     /// </summary>
     public void UpdateBGColorLayer() => OnPropertyChanged("BGColorLayer");
 
     /// <summary>
     /// Order the room layers list by depth.
     /// </summary>
-    /// <param name="selectedLayer">
-    /// Optional argument.<br/>
-    /// Should be present if called from the room editor to re-select the selected layer.
-    /// </param>
+    /// <param name="selectedLayer">Should be present if called from the room editor to re-select the selected layer.</param>
     public void RearrangeLayers(Layer selectedLayer = null)
     {
         if (Layers.Count == 0)
@@ -182,7 +179,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
 
         Layer[] orderedLayers = Layers.OrderBy(l => l.LayerDepth).ToArray();
 
-        // ensure that room objects tree will have the layer to re-select
+        // Ensure that room objects tree will have the layer to re-select
         if (selectedLayer is not null)
             Layers[Array.IndexOf(orderedLayers, selectedLayer)] = selectedLayer;
 
@@ -365,9 +362,10 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
     }
 
     /// <summary>
-    /// Initialize room by setting <c>ParentRoom</c> property of backgrounds or layers, and calculate room grid size if necessary.
+    /// Initialize the room by setting every <see cref="Background.ParentRoom"/> or <see cref="Layer.ParentRoom"/>,
+    /// and optionally calculate the room grid size.
     /// </summary>
-    /// <param name="calculateGrid">Whether should room grid size be calculated.</param>
+    /// <param name="calculateGrid">Whether to calculate the room grid size.</param>
     public void SetupRoom(bool calculateGrid = true)
     {
         foreach (Layer layer in Layers)
@@ -495,7 +493,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
         private UndertaleRoom _parentRoom;
 
         /// <summary>
-        /// The room parent this background belongs to.
+        /// The room parent this <see cref="Background"/> belongs to.
         /// </summary>
         /// <remarks>
         /// This attribute is UMT-only and does not exist in GameMaker.
@@ -521,7 +519,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
         public float CalcScaleY { get; set; } = 1;
 
         /// <summary>
-        /// Whether this background is enabled.
+        /// Whether this <see cref="Background"/> is enabled.
         /// </summary>
         public bool Enabled { get; set; } = false;
 
@@ -549,13 +547,13 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
         public int Y { get => _y; set { _y = value; OnPropertyChanged(); UpdateStretch(); } }
 
         /// <summary>
-        /// Whether this background is tiled horizontally.<br/>
+        /// Whether this <see cref="Background"/> is tiled horizontally.<br/>
         /// <c>0</c> - <see langword="false"/>, <c>1</c> - <see langword="true"/>.
         /// </summary>
         public int TileX { get; set; } = 1;
 
         /// <summary>
-        /// Whether this background is tiled vertically.<br/>
+        /// Whether this <see cref="Background"/> is tiled vertically.<br/>
         /// <c>0</c> - <see langword="false"/>, <c>1</c> - <see langword="true"/>.
         /// </summary>
         public int TileY { get; set; } = 1;
@@ -578,7 +576,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
         public bool Stretch { get => _stretch; set { _stretch = value; OnPropertyChanged(); UpdateStretch(); } }
 
         /// <summary>
-        /// Indicates whether this background is tiled horizontally.
+        /// Indicates whether this <see cref="Background"/> is tiled horizontally.
         /// </summary>
         /// <remarks>
         /// This attribute is UMT-only and does not exist in GameMaker.
@@ -586,7 +584,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
         public bool TiledHorizontally { get => TileX > 0; set { TileX = value ? 1 : 0; OnPropertyChanged(); } }
 
         /// <summary>
-        /// Indicates whether this background is tiled vertically.
+        /// Indicates whether this <see cref="Background"/> is tiled vertically.
         /// </summary>
         /// <remarks>
         /// This attribute is UMT-only and does not exist in GameMaker.

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -169,9 +169,9 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
     public void UpdateBGColorLayer() => OnPropertyChanged("BGColorLayer");
 
     /// <summary>
-    /// Order the room layers list by depth.
+    /// Orders the room layers list by depth.
     /// </summary>
-    /// <param name="selectedLayer">Should be present if called from the room editor to re-select the selected layer.</param>
+    /// <param name="selectedLayer">A <see cref="Layer"/> that's currently selected in the room editor.</param>
     public void RearrangeLayers(Layer selectedLayer = null)
     {
         if (Layers.Count == 0)
@@ -362,8 +362,8 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
     }
 
     /// <summary>
-    /// Initialize the room by setting every <see cref="Background.ParentRoom"/> or <see cref="Layer.ParentRoom"/>,
-    /// and optionally calculate the room grid size.
+    /// Initialize the room by setting every <see cref="Background.ParentRoom"/> or <see cref="Layer.ParentRoom"/>
+    /// (depending on the GameMaker version), and optionally calculate the room grid size.
     /// </summary>
     /// <param name="calculateGrid">Whether to calculate the room grid size.</param>
     public void SetupRoom(bool calculateGrid = true)

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -11,7 +11,7 @@ namespace UndertaleModLib.Models;
 /// <summary>
 /// A room in a data file.
 /// </summary>
-public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
+public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDisposable
 {
     /// <summary>
     /// Certain flags a room can have.
@@ -82,12 +82,12 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
     /// </summary>
     public bool DrawBackgroundColor { get; set; } = true;
 
-    private UndertaleResourceById<UndertaleCode, UndertaleChunkCODE> _CreationCodeId = new();
+    private UndertaleResourceById<UndertaleCode, UndertaleChunkCODE> _creationCodeId = new();
 
     /// <summary>
     /// The creation code of this room.
     /// </summary>
-    public UndertaleCode CreationCodeId { get => _CreationCodeId.Resource; set { _CreationCodeId.Resource = value; OnPropertyChanged(); } }
+    public UndertaleCode CreationCodeId { get => _creationCodeId.Resource; set { _creationCodeId.Resource = value; OnPropertyChanged(); } }
 
     /// <summary>
     /// The room flags this room has.
@@ -162,7 +162,19 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
     /// </summary>
     public UndertaleSimpleList<UndertaleResourceById<UndertaleSequence, UndertaleChunkSEQN>> Sequences { get; private set; } = new UndertaleSimpleList<UndertaleResourceById<UndertaleSequence, UndertaleChunkSEQN>>();
 
+    /// <summary>
+    /// Call <see cref="OnPropertyChanged(string)"/> for <see cref="BGColorLayer"/> to update the room background color.<br/>
+    /// Used for GMS 2 rooms.
+    /// </summary>
     public void UpdateBGColorLayer() => OnPropertyChanged("BGColorLayer");
+
+    /// <summary>
+    /// Order the room layers list by depth.
+    /// </summary>
+    /// <param name="selectedLayer">
+    /// Optional argument.<br/>
+    /// Should be present if called from the room editor to re-select the selected layer.
+    /// </param>
     public void RearrangeLayers(Layer selectedLayer = null)
     {
         if (Layers.Count == 0)
@@ -245,7 +257,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
         writer.Write(Persistent);
         writer.Write(BackgroundColor ^ 0xFF000000); // remove alpha (background color doesn't have alpha)
         writer.Write(DrawBackgroundColor);
-        writer.WriteUndertaleObject(_CreationCodeId);
+        writer.WriteUndertaleObject(_creationCodeId);
         writer.Write((uint)Flags);
         writer.WriteUndertaleObjectPointer(Backgrounds);
         writer.WriteUndertaleObjectPointer(Views);
@@ -291,7 +303,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
         Persistent = reader.ReadBoolean();
         BackgroundColor = 0xFF000000 | reader.ReadUInt32(); // make alpha 255 (background color doesn't have alpha)
         DrawBackgroundColor = reader.ReadBoolean();
-        _CreationCodeId = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleCode, UndertaleChunkCODE>>();
+        _creationCodeId = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleCode, UndertaleChunkCODE>>();
         Flags = (RoomEntryFlags)reader.ReadUInt32();
         Backgrounds = reader.ReadUndertaleObjectPointer<UndertalePointerList<Background>>();
         Views = reader.ReadUndertaleObjectPointer<UndertalePointerList<View>>();
@@ -328,7 +340,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
                 if (layer.InstancesData != null)
                 {
                     layer.InstancesData.Instances.Clear();
-                    foreach (var id in layer.InstancesData._InstanceIds)
+                    foreach (var id in layer.InstancesData.InstanceIds)
                     {
                         if (GameObjects.ByInstanceID(id) != null)
                             layer.InstancesData.Instances.Add(GameObjects.ByInstanceID(id));
@@ -352,6 +364,10 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
         }
     }
 
+    /// <summary>
+    /// Initialize room by setting <c>ParentRoom</c> property of backgrounds or layers, and calculate room grid size if necessary.
+    /// </summary>
+    /// <param name="calculateGrid">Whether should room grid size be calculated.</param>
     public void SetupRoom(bool calculateGrid = true)
     {
         foreach (Layer layer in Layers)
@@ -415,7 +431,39 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
     /// <inheritdoc />
     public override string ToString()
     {
-        return Name.Content + " (" + GetType().Name + ")";
+        return Name?.Content + " (" + GetType().Name + ")";
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        _creationCodeId.Dispose();
+        if (Flags.HasFlag(RoomEntryFlags.IsGMS2))
+        {
+            foreach (Layer layer in _layers)
+                layer?.Dispose();
+            _layers = null;
+            Sequences = new();
+        }
+        else
+        {
+            foreach (Background bg in Backgrounds)
+                bg?.Dispose();
+            foreach (View view in Views)
+                view?.Dispose();
+            foreach (GameObject obj in GameObjects)
+                obj?.Dispose();
+            foreach (Tile tile in Tiles)
+                tile?.Dispose();
+            Backgrounds = new();
+            Views = new();
+            Tiles = new();
+        }
+        Name = null;
+        Caption = null;
+        GameObjects = new();
     }
 
     /// <summary>
@@ -442,7 +490,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
     /// <summary>
     /// A background with properties as it's used in a room.
     /// </summary>
-    public class Background : UndertaleObject, INotifyPropertyChanged
+    public class Background : UndertaleObject, INotifyPropertyChanged, IDisposable
     {
         private UndertaleRoom _parentRoom;
 
@@ -499,7 +547,17 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
         /// The y coordinate of the background in the room.
         /// </summary>
         public int Y { get => _y; set { _y = value; OnPropertyChanged(); UpdateStretch(); } }
+
+        /// <summary>
+        /// Whether this background is tiled horizontally.<br/>
+        /// <c>0</c> - <see langword="false"/>, <c>1</c> - <see langword="true"/>.
+        /// </summary>
         public int TileX { get; set; } = 1;
+
+        /// <summary>
+        /// Whether this background is tiled vertically.<br/>
+        /// <c>0</c> - <see langword="false"/>, <c>1</c> - <see langword="true"/>.
+        /// </summary>
         public int TileY { get; set; } = 1;
 
         /// <summary>
@@ -594,12 +652,21 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
             SpeedY = reader.ReadInt32();
             Stretch = reader.ReadBoolean();
         }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+
+            _parentRoom = null;
+            _backgroundDefinition.Dispose();
+        }
     }
 
     /// <summary>
     /// A view with properties as it's used in a room.
     /// </summary>
-    public class View : UndertaleObject, INotifyPropertyChanged
+    public class View : UndertaleObject, INotifyPropertyChanged, IDisposable
     {
         /// <summary>
         /// Whether this view is enabled.
@@ -713,12 +780,20 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
             SpeedY = reader.ReadInt32();
             _objectId = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleGameObject, UndertaleChunkOBJT>>();
         }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+
+            _objectId.Dispose();
+        }
     }
 
     /// <summary>
     /// A game object with properties as it's used in a room.
     /// </summary>
-    public class GameObject : UndertaleObjectLenCheck, IRoomObject, INotifyPropertyChanged
+    public class GameObject : UndertaleObjectLenCheck, IRoomObject, INotifyPropertyChanged, IDisposable
     {
         private UndertaleResourceById<UndertaleGameObject, UndertaleChunkOBJT> _objectDefinition = new();
         private UndertaleResourceById<UndertaleCode, UndertaleChunkCODE> _creationCode = new();
@@ -909,12 +984,22 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
         {
             return "Instance " + InstanceID + " of " + (ObjectDefinition?.Name?.Content ?? "?") + " (UndertaleRoom+GameObject)";
         }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+
+            _objectDefinition.Dispose();
+            _creationCode.Dispose();
+            _preCreateCode.Dispose();
+        }
     }
 
     /// <summary>
     /// A tile with properties as it's used in a room.
     /// </summary>
-    public class Tile : UndertaleObject, IRoomObject, INotifyPropertyChanged
+    public class Tile : UndertaleObject, IRoomObject, INotifyPropertyChanged, IDisposable
     {
         /// <summary>
         /// Whether this tile is from an asset layer.<br/>
@@ -1088,6 +1173,15 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
         {
             return "Tile " + InstanceID + " of " + (ObjectDefinition?.Name?.Content ?? "?") + " (UndertaleRoom+Tile)";
         }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+
+            _backgroundDefinition.Dispose();
+            _spriteDefinition.Dispose();
+        }
     }
 
     /// <summary>
@@ -1122,9 +1216,9 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
     /// A layer with properties as it's used in a room. Game Maker: Studio 2 only.
     /// </summary>
     //TODO: everything from here on is mostly gms2 related which i dont have much experience with
-    public class Layer : UndertaleObject, INotifyPropertyChanged
+    public class Layer : UndertaleObject, INotifyPropertyChanged, IDisposable
     {
-        public interface LayerData : UndertaleObject
+        public interface LayerData : UndertaleObject, IDisposable
         {
         }
 
@@ -1257,10 +1351,20 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
             return GetType().FullName + " - \"" + LayerName?.Content + '\"';
         }
 
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+
+            Data?.Dispose();
+            _parentRoom = null;
+            LayerName = null;
+        }
+
         public class LayerInstancesData : LayerData
         {
-            internal uint[] _InstanceIds { get; private set; } // 100000, 100001, 100002, 100003 - instance ids from GameObjects list in the room
-            public ObservableCollection<UndertaleRoom.GameObject> Instances { get; private set; } = new();
+            internal uint[] InstanceIds { get; private set; } // 100000, 100001, 100002, 100003 - instance ids from GameObjects list in the room
+            public ObservableCollection<GameObject> Instances { get; private set; } = new();
 
             /// <inheritdoc />
             public void Serialize(UndertaleWriter writer)
@@ -1274,33 +1378,44 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
             public void Unserialize(UndertaleReader reader)
             {
                 uint InstanceCount = reader.ReadUInt32();
-                _InstanceIds = new uint[InstanceCount];
+                InstanceIds = new uint[InstanceCount];
                 Instances.Clear();
                 for (uint i = 0; i < InstanceCount; i++)
-                    _InstanceIds[i] = reader.ReadUInt32();
+                    InstanceIds[i] = reader.ReadUInt32();
                 // UndertaleRoom.Unserialize resolves these IDs to objects later
+            }
+
+            /// <inheritdoc/>
+            public void Dispose()
+            {
+                GC.SuppressFinalize(this);
+
+                foreach (GameObject obj in Instances)
+                    obj?.Dispose();
+                InstanceIds = null;
+                Instances = new();
             }
         }
 
         public class LayerTilesData : LayerData, INotifyPropertyChanged
         {
-            private UndertaleResourceById<UndertaleBackground, UndertaleChunkBGND> _Background = new(); // In GMS2 backgrounds are just tilesets
-            private uint _TilesX;
-            private uint _TilesY;
-            private uint[][] _TileData; // Each is simply an ID from the tileset/background/sprite
+            private UndertaleResourceById<UndertaleBackground, UndertaleChunkBGND> _background = new(); // In GMS2 backgrounds are just tilesets
+            private uint _tilesX;
+            private uint _tilesY;
+            private uint[][] _tileData; // Each is simply an ID from the tileset/background/sprite
 
             public Layer ParentLayer { get; set; }
-            public UndertaleBackground Background { get => _Background.Resource; set { _Background.Resource = value; OnPropertyChanged(); } }
+            public UndertaleBackground Background { get => _background.Resource; set { _background.Resource = value; OnPropertyChanged(); } }
             public uint TilesX
             {
-                get => _TilesX; set
+                get => _tilesX; set
                 {
-                    _TilesX = value; OnPropertyChanged();
-                    if (_TileData != null)
+                    _tilesX = value; OnPropertyChanged();
+                    if (_tileData != null)
                     {
-                        for (var y = 0; y < _TileData.Length; y++)
+                        for (var y = 0; y < _tileData.Length; y++)
                         {
-                            Array.Resize(ref _TileData[y], (int)value);
+                            Array.Resize(ref _tileData[y], (int)value);
                         }
                         OnPropertyChanged("TileData");
                     }
@@ -1308,22 +1423,22 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
             }
             public uint TilesY
             {
-                get => _TilesY; set
+                get => _tilesY; set
                 {
-                    _TilesY = value; OnPropertyChanged();
-                    if (_TileData != null)
+                    _tilesY = value; OnPropertyChanged();
+                    if (_tileData != null)
                     {
-                        Array.Resize(ref _TileData, (int)value);
-                        for (var y = 0; y < _TileData.Length; y++)
+                        Array.Resize(ref _tileData, (int)value);
+                        for (var y = 0; y < _tileData.Length; y++)
                         {
-                            if (_TileData[y] == null)
-                                _TileData[y] = new uint[TilesX];
+                            if (_tileData[y] == null)
+                                _tileData[y] = new uint[TilesX];
                         }
                         OnPropertyChanged("TileData");
                     }
                 }
             }
-            public uint[][] TileData { get => _TileData; set { _TileData = value; OnPropertyChanged(); } }
+            public uint[][] TileData { get => _tileData; set { _tileData = value; OnPropertyChanged(); } }
 
             /// <inheritdoc />
             public event PropertyChangedEventHandler PropertyChanged;
@@ -1335,7 +1450,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
             /// <inheritdoc />
             public void Serialize(UndertaleWriter writer)
             {
-                _Background.Serialize(writer); // see comment below
+                _background.Serialize(writer); // see comment below
                 writer.Write(TilesX);
                 writer.Write(TilesY);
                 if (TileData.Length != TilesY)
@@ -1352,9 +1467,9 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
             /// <inheritdoc />
             public void Unserialize(UndertaleReader reader)
             {
-                _Background = new UndertaleResourceById<UndertaleBackground, UndertaleChunkBGND>(); // see comment in UndertaleGlobalInit.Unserialize
-                _Background.Unserialize(reader);
-                _TileData = null; // prevent unnecessary resizes
+                _background = new UndertaleResourceById<UndertaleBackground, UndertaleChunkBGND>(); // see comment in UndertaleGlobalInit.Unserialize
+                _background.Unserialize(reader);
+                _tileData = null; // prevent unnecessary resizes
                 TilesX = reader.ReadUInt32();
                 TilesY = reader.ReadUInt32();
                 TileData = new uint[TilesY][];
@@ -1367,27 +1482,37 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
                     }
                 }
             }
+
+            /// <inheritdoc/>
+            public void Dispose()
+            {
+                GC.SuppressFinalize(this);
+
+                _background.Dispose();
+                _tileData = null;
+                ParentLayer = null;
+            }
         }
 
         public class LayerBackgroundData : LayerData, INotifyPropertyChanged
         {
-            private Layer _ParentLayer;
+            private Layer _parentLayer;
 
-            private UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT> _Sprite = new(); // Apparently there's a mode where it's a background reference, but probably not necessary
-            private bool _TiledHorizontally;
-            private bool _TiledVertically;
-            private bool _Stretch;
+            private UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT> _sprite = new(); // Apparently there's a mode where it's a background reference, but probably not necessary
+            private bool _tiledHorizontally;
+            private bool _tiledVertically;
+            private bool _stretch;
 
-            public Layer ParentLayer { get => _ParentLayer; set { _ParentLayer = value; OnPropertyChanged(); UpdateScale(); } }
+            public Layer ParentLayer { get => _parentLayer; set { _parentLayer = value; OnPropertyChanged(); UpdateScale(); } }
             public float CalcScaleX { get; set; }
             public float CalcScaleY { get; set; }
 
             public bool Visible { get; set; } = true;
             public bool Foreground { get; set; }
-            public UndertaleSprite Sprite { get => _Sprite.Resource; set { _Sprite.Resource = value; OnPropertyChanged(); ParentLayer.ParentRoom.UpdateBGColorLayer(); } }
-            public bool TiledHorizontally { get => _TiledHorizontally; set { _TiledHorizontally = value; OnPropertyChanged(); } }
-            public bool TiledVertically { get => _TiledVertically; set { _TiledVertically = value; OnPropertyChanged(); } }
-            public bool Stretch { get => _Stretch; set { _Stretch = value; OnPropertyChanged(); } }
+            public UndertaleSprite Sprite { get => _sprite.Resource; set { _sprite.Resource = value; OnPropertyChanged(); ParentLayer.ParentRoom.UpdateBGColorLayer(); } }
+            public bool TiledHorizontally { get => _tiledHorizontally; set { _tiledHorizontally = value; OnPropertyChanged(); } }
+            public bool TiledVertically { get => _tiledVertically; set { _tiledVertically = value; OnPropertyChanged(); } }
+            public bool Stretch { get => _stretch; set { _stretch = value; OnPropertyChanged(); } }
             public uint Color { get; set; } = 0xFF000000;
             public float FirstFrame { get; set; }
             public float AnimationSpeed { get; set; }
@@ -1421,7 +1546,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
             {
                 writer.Write(Visible);
                 writer.Write(Foreground);
-                writer.WriteUndertaleObject(_Sprite);
+                writer.WriteUndertaleObject(_sprite);
                 writer.Write(TiledHorizontally);
                 writer.Write(TiledVertically);
                 writer.Write(Stretch);
@@ -1436,7 +1561,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
             {
                 Visible = reader.ReadBoolean();
                 Foreground = reader.ReadBoolean();
-                _Sprite = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT>>();
+                _sprite = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT>>();
                 TiledHorizontally = reader.ReadBoolean();
                 TiledVertically = reader.ReadBoolean();
                 Stretch = reader.ReadBoolean();
@@ -1444,6 +1569,15 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
                 FirstFrame = reader.ReadSingle();
                 AnimationSpeed = reader.ReadSingle();
                 AnimationSpeedType = (AnimationSpeedType)reader.ReadUInt32();
+            }
+
+            /// <inheritdoc/>
+            public void Dispose()
+            {
+                GC.SuppressFinalize(this);
+
+                _parentLayer = null;
+                _sprite.Dispose();
             }
         }
 
@@ -1496,6 +1630,29 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
                         reader.ReadUndertaleObject(NineSlices);
                 }
             }
+
+            /// <inheritdoc/>
+            public void Dispose()
+            {
+                GC.SuppressFinalize(this);
+
+                if (LegacyTiles is not null)
+                    foreach (Tile tile in LegacyTiles)
+                        tile?.Dispose();
+                if (Sprites is not null)
+                    foreach (SpriteInstance inst in Sprites)
+                        inst?.Dispose();
+                if (Sequences is not null)
+                    foreach (SequenceInstance inst in Sequences)
+                        inst?.Dispose();
+                if (NineSlices is not null)
+                    foreach (SpriteInstance inst in NineSlices)
+                        inst?.Dispose();
+                LegacyTiles = null;
+                Sprites = null;
+                Sequences = null;
+                NineSlices = null;
+            }
         }
 
         [PropertyChanged.AddINotifyPropertyChangedInterface]
@@ -1521,11 +1678,23 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
                 EffectType = reader.ReadUndertaleString();
                 Properties = reader.ReadUndertaleObject<UndertaleSimpleList<EffectProperty>>();
             }
+
+            /// <inheritdoc/>
+            public void Dispose()
+            {
+                GC.SuppressFinalize(this);
+
+                if (Properties is not null)
+                    foreach (EffectProperty prop in Properties)
+                        prop?.Dispose();
+                EffectType = null;
+                Properties = null;
+            }
         }
     }
 
     [PropertyChanged.AddINotifyPropertyChangedInterface]
-    public class EffectProperty : UndertaleObject
+    public class EffectProperty : UndertaleObject, IDisposable
     {
         public enum PropertyType
         {
@@ -1553,14 +1722,23 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
             Name = reader.ReadUndertaleString();
             Value = reader.ReadUndertaleString();
         }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+
+            Name = null;
+            Value = null;
+        }
     }
 
-    public class SpriteInstance : UndertaleObject, INotifyPropertyChanged
+    public class SpriteInstance : UndertaleObject, INotifyPropertyChanged, IDisposable
     {
-        private UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT> _Sprite = new();
+        private UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT> _sprite = new();
 
         public UndertaleString Name { get; set; }
-        public UndertaleSprite Sprite { get => _Sprite.Resource; set { _Sprite.Resource = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Sprite))); } }
+        public UndertaleSprite Sprite { get => _sprite.Resource; set { _sprite.Resource = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Sprite))); } }
         public int X { get; set; }
         public int Y { get; set; }
         public float ScaleX { get; set; } = 1;
@@ -1606,7 +1784,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
         public void Serialize(UndertaleWriter writer)
         {
             writer.WriteUndertaleString(Name);
-            writer.WriteUndertaleObject(_Sprite);
+            writer.WriteUndertaleObject(_sprite);
             writer.Write(X);
             writer.Write(Y);
             writer.Write(ScaleX);
@@ -1622,7 +1800,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
         public void Unserialize(UndertaleReader reader)
         {
             Name = reader.ReadUndertaleString();
-            _Sprite = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT>>();
+            _sprite = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT>>();
             X = reader.ReadInt32();
             Y = reader.ReadInt32();
             ScaleX = reader.ReadSingle();
@@ -1646,14 +1824,23 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
         {
             return "Sprite " + Name?.Content + " of " + (Sprite?.Name?.Content ?? "?") + " (UndertaleRoom+SpriteInstance)";
         }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+
+            _sprite.Dispose();
+            Name = null;
+        }
     }
 
-    public class SequenceInstance : UndertaleObject, INotifyPropertyChanged
+    public class SequenceInstance : UndertaleObject, INotifyPropertyChanged, IDisposable
     {
-        private UndertaleResourceById<UndertaleSequence, UndertaleChunkSEQN> _Sequence = new();
+        private UndertaleResourceById<UndertaleSequence, UndertaleChunkSEQN> _sequence = new();
 
         public UndertaleString Name { get; set; }
-        public UndertaleSequence Sequence { get => _Sequence.Resource; set { _Sequence.Resource = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Sequence))); } }
+        public UndertaleSequence Sequence { get => _sequence.Resource; set { _sequence.Resource = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Sequence))); } }
         public int X { get; set; }
         public int Y { get; set; }
         public float ScaleX { get; set; }
@@ -1670,7 +1857,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
         public void Serialize(UndertaleWriter writer)
         {
             writer.WriteUndertaleString(Name);
-            writer.WriteUndertaleObject(_Sequence);
+            writer.WriteUndertaleObject(_sequence);
             writer.Write(X);
             writer.Write(Y);
             writer.Write(ScaleX);
@@ -1686,7 +1873,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
         public void Unserialize(UndertaleReader reader)
         {
             Name = reader.ReadUndertaleString();
-            _Sequence = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleSequence, UndertaleChunkSEQN>>();
+            _sequence = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleSequence, UndertaleChunkSEQN>>();
             X = reader.ReadInt32();
             Y = reader.ReadInt32();
             ScaleX = reader.ReadSingle();
@@ -1702,6 +1889,15 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged
         public override string ToString()
         {
             return "Sequence " + Name?.Content + " of " + (Sequence?.Name?.Content ?? "?") + " (UndertaleRoom+SequenceInstance)";
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+
+            _sequence.Dispose();
+            Name = null;
         }
     }
 }

--- a/UndertaleModLib/Models/UndertaleSequence.cs
+++ b/UndertaleModLib/Models/UndertaleSequence.cs
@@ -5,7 +5,7 @@ using System.IO;
 namespace UndertaleModLib.Models;
 
 [PropertyChanged.AddINotifyPropertyChangedInterface]
-public class UndertaleSequence : UndertaleNamedResource
+public class UndertaleSequence : UndertaleNamedResource, IDisposable
 {
     public enum PlaybackType : uint
     {
@@ -78,6 +78,18 @@ public class UndertaleSequence : UndertaleNamedResource
         }
 
         Moments = reader.ReadUndertaleObject<UndertaleSimpleList<Keyframe<Moment>>>();
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        Name = null;
+        BroadcastMessages = null;
+        Moments = null;
+        Tracks = null;
+        FunctionIDs = null;
     }
 
     public class Keyframe<T> : UndertaleObject where T : UndertaleObject, new()

--- a/UndertaleModLib/Models/UndertaleShader.cs
+++ b/UndertaleModLib/Models/UndertaleShader.cs
@@ -1,16 +1,18 @@
-﻿namespace UndertaleModLib.Models;
+﻿using System;
+
+namespace UndertaleModLib.Models;
 
 /// <summary>
 /// A shader entry for a data file.
 /// </summary>
 [PropertyChanged.AddINotifyPropertyChangedInterface]
-public class UndertaleShader : UndertaleNamedResource
+public class UndertaleShader : UndertaleNamedResource, IDisposable
 {
     /// <summary>
     /// The vertex shader attributes a shader can have.
     /// </summary>
     [PropertyChanged.AddINotifyPropertyChangedInterface]
-    public class VertexShaderAttribute : UndertaleObject
+    public class VertexShaderAttribute : UndertaleObject, IDisposable
     {
         /// <summary>
         /// The name of the vertex shader attribute.
@@ -27,6 +29,14 @@ public class UndertaleShader : UndertaleNamedResource
         public void Unserialize(UndertaleReader reader)
         {
             Name = reader.ReadUndertaleString();
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+
+            Name = null;
         }
     }
 
@@ -141,7 +151,41 @@ public class UndertaleShader : UndertaleNamedResource
     /// <inheritdoc />
     public override string ToString()
     {
-        return Name.Content + " (" + GetType().Name + ")";
+        return Name?.Content + " (" + GetType().Name + ")";
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        HLSL11_VertexData?.Dispose();
+        HLSL11_PixelData?.Dispose();
+        PSSL_VertexData?.Dispose();
+        PSSL_PixelData?.Dispose();
+        Cg_PSVita_VertexData?.Dispose();
+        Cg_PSVita_PixelData?.Dispose();
+        Cg_PS3_VertexData?.Dispose();
+        Cg_PS3_PixelData?.Dispose();
+        foreach (var attr in VertexShaderAttributes)
+            attr?.Dispose();
+
+        Name = null;
+        GLSL_ES_Vertex = null;
+        GLSL_ES_Fragment = null;
+        GLSL_Vertex = null;
+        GLSL_Fragment = null;
+        HLSL9_Vertex = null;
+        HLSL9_Fragment = null;
+        HLSL11_VertexData = null;
+        HLSL11_PixelData = null;
+        PSSL_VertexData = null;
+        PSSL_PixelData = null;
+        Cg_PSVita_VertexData = null;
+        Cg_PSVita_PixelData = null;
+        Cg_PS3_VertexData = null;
+        Cg_PS3_PixelData = null;
+        VertexShaderAttributes = new();
     }
 
     private static void WritePadding(UndertaleWriter writer, int amount)
@@ -426,7 +470,7 @@ public class UndertaleShader : UndertaleNamedResource
         Cg_PS3 = 7
     }
 
-    public class UndertaleRawShaderData
+    public class UndertaleRawShaderData : IDisposable
     {
         internal uint _Position;
         internal uint _PointerLocation;
@@ -485,6 +529,14 @@ public class UndertaleShader : UndertaleNamedResource
 
             _Length = (uint)length;
             Data = reader.ReadBytes(length);
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+
+            Data = null;
         }
     }
 }

--- a/UndertaleModLib/Models/UndertaleSprite.cs
+++ b/UndertaleModLib/Models/UndertaleSprite.cs
@@ -218,8 +218,11 @@ public class UndertaleSprite : UndertaleNamedResource, PrePaddedObject, INotifyP
         foreach (MaskEntry entry in CollisionMasks)
             entry?.Dispose();
         if (SpineTextures is not null)
+        {
             foreach (var spineEntry in SpineTextures)
                 spineEntry?.Dispose();
+        }
+
         Textures = new();
         CollisionMasks.Clear();
         SpineTextures = null;

--- a/UndertaleModLib/Models/UndertaleString.cs
+++ b/UndertaleModLib/Models/UndertaleString.cs
@@ -1,10 +1,12 @@
-﻿namespace UndertaleModLib.Models;
+﻿using System;
+
+namespace UndertaleModLib.Models;
 
 /// <summary>
 /// A string entry a data file can have.
 /// </summary>
 [PropertyChanged.AddINotifyPropertyChangedInterface]
-public class UndertaleString : UndertaleResource, ISearchable
+public class UndertaleString : UndertaleResource, ISearchable, IDisposable
 {
     /// <summary>
     /// The contents of the string.
@@ -43,6 +45,14 @@ public class UndertaleString : UndertaleResource, ISearchable
     public override string ToString()
     {
         return ToString(true);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        Content = null;
     }
 
     /// <summary>

--- a/UndertaleModLib/Models/UndertaleTags.cs
+++ b/UndertaleModLib/Models/UndertaleTags.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace UndertaleModLib.Models;
@@ -7,71 +8,34 @@ namespace UndertaleModLib.Models;
 /// A tag entry in a GameMaker data file. Tags are a GameMaker: Studio 2.3+ feature.
 /// </summary>
 [PropertyChanged.AddINotifyPropertyChangedInterface]
-public class UndertaleTags : UndertaleObject
+public class UndertaleTags : UndertaleObject, IDisposable
 {
     public UndertaleSimpleListString Tags { get; set; }
     public Dictionary<int, UndertaleSimpleListString> AssetTags { get; set; }
 
     public static int GetAssetTagID(UndertaleData data, UndertaleNamedResource resource)
     {
-        ResourceType type;
-        IList<UndertaleNamedResource> list;
-        int offset = 0;
-
-        switch (resource)
+        ResourceType type = resource switch
         {
-            case UndertaleGameObject:
-                type = ResourceType.Object;
-                list = (IList<UndertaleNamedResource>) data.GameObjects;
-                break;
-            case UndertaleSprite:
-                type = ResourceType.Sprite;
-                list = (IList<UndertaleNamedResource>) data.Sprites;
-                break;
-            case UndertaleSound:
-                type = ResourceType.Sound;
-                list = (IList<UndertaleNamedResource>) data.Sounds;
-                break;
-            case UndertaleRoom:
-                type = ResourceType.Room;
-                list = (IList<UndertaleNamedResource>) data.Rooms;
-                break;
-            case UndertalePath:
-                type = ResourceType.Path;
-                list = (IList<UndertaleNamedResource>) data.Paths;
-                break;
-            case UndertaleScript:
-                type = ResourceType.Script;
-                list = (IList<UndertaleNamedResource>) data.Scripts;
-                offset = 100000;
-                break;
-            case UndertaleFont:
-                type = ResourceType.Font;
-                list = (IList<UndertaleNamedResource>) data.Fonts;
-                break;
-            case UndertaleTimeline:
-                type = ResourceType.Timeline;
-                list = (IList<UndertaleNamedResource>) data.Timelines;
-                break;
-            case UndertaleBackground:
-                type = ResourceType.Background;
-                list = (IList<UndertaleNamedResource>) data.Backgrounds;
-                break;
-            case UndertaleShader:
-                type = ResourceType.Shader;
-                list = (IList<UndertaleNamedResource>) data.Shaders;
-                break;
-            case UndertaleSequence:
-                type = ResourceType.Sequence;
-                list = (IList<UndertaleNamedResource>) data.Sequences;
-                break;
-            case UndertaleAnimationCurve:
-                type = ResourceType.AnimCurve;
-                list = (IList<UndertaleNamedResource>) data.AnimationCurves;
-                break;
+            UndertaleGameObject => ResourceType.Object,
+            UndertaleSprite => ResourceType.Sprite,
+            UndertaleSound => ResourceType.Sound,
+            UndertaleRoom => ResourceType.Room,
+            UndertalePath => ResourceType.Path,
+            UndertaleScript => ResourceType.Script,
+            UndertaleFont => ResourceType.Font,
+            UndertaleTimeline => ResourceType.Timeline,
+            UndertaleBackground => ResourceType.Background,
+            UndertaleShader => ResourceType.Shader,
+            UndertaleSequence => ResourceType.Sequence,
+            UndertaleAnimationCurve => ResourceType.AnimCurve,
+            _ => throw new ArgumentException("Invalid resource type!")
+        };
+        IList list = data[resource.GetType()] as IList;
 
-            default: throw new ArgumentException("Invalid resource type!");
-        }
+        int offset = 0;
+        if (resource is UndertaleScript)
+            offset = 100000;
 
         return ((int)type << 24) | ((list.IndexOf(resource) + offset) & 0xFFFFFF);
     }
@@ -98,7 +62,16 @@ public class UndertaleTags : UndertaleObject
             AssetTags[t.ID] = t.Tags;
     }
 
-    private class TempAssetTags : UndertaleObject
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        AssetTags = null;
+        Tags = null;
+    }
+
+    private class TempAssetTags : UndertaleObject, IDisposable
     {
         public int ID { get; set; }
         public UndertaleSimpleListString Tags { get; set; }
@@ -115,6 +88,14 @@ public class UndertaleTags : UndertaleObject
         {
             ID = reader.ReadInt32();
             Tags = reader.ReadUndertaleObject<UndertaleSimpleListString>();
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+
+            Tags = null;
         }
     }
 }

--- a/UndertaleModLib/Models/UndertaleTags.cs
+++ b/UndertaleModLib/Models/UndertaleTags.cs
@@ -33,9 +33,7 @@ public class UndertaleTags : UndertaleObject, IDisposable
         };
         IList list = data[resource.GetType()] as IList;
 
-        int offset = 0;
-        if (resource is UndertaleScript)
-            offset = 100000;
+        int offset = resource is UndertaleScript ? 100000 : 0;
 
         return ((int)type << 24) | ((list.IndexOf(resource) + offset) & 0xFFFFFF);
     }

--- a/UndertaleModLib/Models/UndertaleTextureGroupInfo.cs
+++ b/UndertaleModLib/Models/UndertaleTextureGroupInfo.cs
@@ -1,4 +1,6 @@
-﻿namespace UndertaleModLib.Models;
+﻿using System;
+
+namespace UndertaleModLib.Models;
 
 /// <summary>
 /// A texture group info entry in a data file.
@@ -37,7 +39,7 @@
 /// </code>
 /// <see href="https://github.com/krzys-h/UndertaleModTool/wiki/Bytecode-17#tgin-new-chunk"/>.</remarks>
 [PropertyChanged.AddINotifyPropertyChangedInterface]
-public class UndertaleTextureGroupInfo : UndertaleNamedResource
+public class UndertaleTextureGroupInfo : UndertaleNamedResource, IDisposable
 {
     /// <summary>
     /// The name of the texture group info entry.
@@ -122,6 +124,19 @@ public class UndertaleTextureGroupInfo : UndertaleNamedResource
     /// <inheritdoc />
     public override string ToString()
     {
-        return Name.Content + " (" + GetType().Name + ")";
+        return Name?.Content + " (" + GetType().Name + ")";
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        Name = null;
+        TexturePages = null;
+        Sprites = null;
+        SpineSprites = null;
+        Fonts = null;
+        Tilesets = null;
     }
 }

--- a/UndertaleModLib/Models/UndertaleTexturePageItem.cs
+++ b/UndertaleModLib/Models/UndertaleTexturePageItem.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using System.Drawing;
 using UndertaleModLib.Util;
 
@@ -13,7 +14,7 @@ namespace UndertaleModLib.Models;
 /// anything outside of that is just transparent. <br/>
 /// <see cref="SourceX"/>, <see cref="SourceY"/>, <see cref="SourceWidth"/> and <see cref="SourceHeight"/> are part of the texture page which
 /// are drawn over <see cref="TargetX"/>, <see cref="TargetY"/>, <see cref="TargetWidth"/>, <see cref="TargetHeight"/>.</remarks>
-public class UndertaleTexturePageItem : UndertaleNamedResource, INotifyPropertyChanged
+public class UndertaleTexturePageItem : UndertaleNamedResource, INotifyPropertyChanged, IDisposable
 {
     /// <summary>
     /// The name of the texture page item.
@@ -71,12 +72,12 @@ public class UndertaleTexturePageItem : UndertaleNamedResource, INotifyPropertyC
     /// </summary>
     public ushort BoundingHeight { get; set; }
 
-    private UndertaleResourceById<UndertaleEmbeddedTexture, UndertaleChunkTXTR> _TexturePage = new UndertaleResourceById<UndertaleEmbeddedTexture, UndertaleChunkTXTR>();
+    private UndertaleResourceById<UndertaleEmbeddedTexture, UndertaleChunkTXTR> _texturePage = new UndertaleResourceById<UndertaleEmbeddedTexture, UndertaleChunkTXTR>();
 
     /// <summary>
     /// The texture page this item is referencing
     /// </summary>
-    public UndertaleEmbeddedTexture TexturePage { get => _TexturePage.Resource; set { _TexturePage.Resource = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(TexturePage))); } }
+    public UndertaleEmbeddedTexture TexturePage { get => _texturePage.Resource; set { _texturePage.Resource = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(TexturePage))); } }
 
     /// <inheritdoc />
     public event PropertyChangedEventHandler PropertyChanged;
@@ -94,7 +95,7 @@ public class UndertaleTexturePageItem : UndertaleNamedResource, INotifyPropertyC
         writer.Write(TargetHeight);
         writer.Write(BoundingWidth);
         writer.Write(BoundingHeight);
-        writer.Write((short)_TexturePage.SerializeById(writer));
+        writer.Write((short)_texturePage.SerializeById(writer));
     }
 
     /// <inheritdoc />
@@ -110,8 +111,8 @@ public class UndertaleTexturePageItem : UndertaleNamedResource, INotifyPropertyC
         TargetHeight = reader.ReadUInt16();
         BoundingWidth = reader.ReadUInt16();
         BoundingHeight = reader.ReadUInt16();
-        _TexturePage = new UndertaleResourceById<UndertaleEmbeddedTexture, UndertaleChunkTXTR>();
-        _TexturePage.UnserializeById(reader, reader.ReadInt16()); // This one is special as it uses a short instead of int
+        _texturePage = new UndertaleResourceById<UndertaleEmbeddedTexture, UndertaleChunkTXTR>();
+        _texturePage.UnserializeById(reader, reader.ReadInt16()); // This one is special as it uses a short instead of int
     }
 
     /// <inheritdoc />
@@ -126,6 +127,15 @@ public class UndertaleTexturePageItem : UndertaleNamedResource, INotifyPropertyC
             Name = new UndertaleString("PageItem Unknown Index");
         }
         return Name.Content + " (" + GetType().Name + ")";
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        _texturePage.Dispose();
+        Name = null;
     }
 
     /// <summary>

--- a/UndertaleModLib/Models/UndertaleTimeline.cs
+++ b/UndertaleModLib/Models/UndertaleTimeline.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System;
+using System.Collections.ObjectModel;
 
 namespace UndertaleModLib.Models;
 
@@ -6,13 +7,13 @@ namespace UndertaleModLib.Models;
 /// A timeline in a data file.
 /// </summary>
 [PropertyChanged.AddINotifyPropertyChangedInterface]
-public class UndertaleTimeline : UndertaleNamedResource
+public class UndertaleTimeline : UndertaleNamedResource, IDisposable
 {
     /// <summary>
     /// A specific moment in a timeline.
     /// </summary>
     [PropertyChanged.AddINotifyPropertyChangedInterface]
-    public class UndertaleTimelineMoment : UndertaleObject
+    public class UndertaleTimelineMoment : UndertaleObject, IDisposable
     {
         /// <summary>
         /// After how many steps this moment gets executed.
@@ -57,6 +58,14 @@ public class UndertaleTimeline : UndertaleNamedResource
         {
             // Same goes for unserializing.
         }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+
+            Event = null;
+        }
     }
 
     /// <summary>
@@ -72,7 +81,18 @@ public class UndertaleTimeline : UndertaleNamedResource
     /// <inheritdoc />
     public override string ToString()
     {
-        return Name.Content + " (" + GetType().Name + ")";
+        return Name?.Content + " (" + GetType().Name + ")";
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        foreach (var moment in Moments)
+            moment?.Dispose();
+        Name = null;
+        Moments = new();
     }
 
     /// <inheritdoc />

--- a/UndertaleModLib/Models/UndertaleVariable.cs
+++ b/UndertaleModLib/Models/UndertaleVariable.cs
@@ -6,7 +6,7 @@ namespace UndertaleModLib.Models;
 /// A variable entry in a GameMaker data file.
 /// </summary>
 // TODO: INotifyPropertyChanged
-public class UndertaleVariable : UndertaleNamedResource, ISearchable, UndertaleInstruction.ReferencedObject
+public class UndertaleVariable : UndertaleNamedResource, ISearchable, UndertaleInstruction.ReferencedObject, IDisposable
 {
     /// The name of the Variable.
     public UndertaleString Name { get; set; }
@@ -79,7 +79,16 @@ public class UndertaleVariable : UndertaleNamedResource, ISearchable, UndertaleI
     /// <inheritdoc />
     public override string ToString()
     {
-        return Name != null && Name.Content != null ? Name.Content : "<NULL_VAR_NAME>";
+        return Name?.Content != null ? Name.Content : "<NULL_VAR_NAME>";
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        Name = null;
+        FirstAddress = null;
     }
 
     /// <inheritdoc />

--- a/UndertaleModLib/UndertaleBaseTypes.cs
+++ b/UndertaleModLib/UndertaleBaseTypes.cs
@@ -10,13 +10,13 @@ namespace UndertaleModLib
     public interface UndertaleObject
     {
         /// <summary>
-        /// Serializes the object into a specified <see cref="UndertaleWriter"/>.
+        /// Serializes this <see cref="UndertaleObject"/> into a specified <see cref="UndertaleWriter"/>.
         /// </summary>
         /// <param name="writer">Where to serialize to.</param>
         void Serialize(UndertaleWriter writer);
 
         /// <summary>
-        /// Deserializes the object from a specified <see cref="UndertaleReader"/>.
+        /// Deserializes this <see cref="UndertaleObject"/> from a specified <see cref="UndertaleReader"/>.
         /// </summary>
         /// <param name="reader">Where to deserialize from.</param>
         void Unserialize(UndertaleReader reader);

--- a/UndertaleModLib/UndertaleBaseTypes.cs
+++ b/UndertaleModLib/UndertaleBaseTypes.cs
@@ -10,13 +10,13 @@ namespace UndertaleModLib
     public interface UndertaleObject
     {
         /// <summary>
-        /// Serializes the data file into a specified <see cref="UndertaleWriter"/>.
+        /// Serializes the object into a specified <see cref="UndertaleWriter"/>.
         /// </summary>
         /// <param name="writer">Where to serialize to.</param>
         void Serialize(UndertaleWriter writer);
 
         /// <summary>
-        /// Deserializes from a specified <see cref="UndertaleReader"/> to the current data file.
+        /// Deserializes the object from a specified <see cref="UndertaleReader"/>.
         /// </summary>
         /// <param name="reader">Where to deserialize from.</param>
         void Unserialize(UndertaleReader reader);

--- a/UndertaleModLib/UndertaleIO.cs
+++ b/UndertaleModLib/UndertaleIO.cs
@@ -24,7 +24,7 @@ namespace UndertaleModLib
         int SerializeById(UndertaleWriter writer);
     }
 
-    public class UndertaleResourceById<T, ChunkT> : UndertaleResourceRef where T : UndertaleResource, new() where ChunkT : UndertaleListChunk<T>
+    public class UndertaleResourceById<T, ChunkT> : UndertaleResourceRef, IDisposable where T : UndertaleResource, new() where ChunkT : UndertaleListChunk<T>
     {
         public int CachedId { get; set; } = -1;
         public T Resource { get; set; }
@@ -110,9 +110,18 @@ namespace UndertaleModLib
             }
         }
 
+        /// <inheritdoc/>
         public override string ToString()
         {
             return (Resource?.ToString() ?? "(null)") + GetMarkerSuffix();
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+
+            Resource = default;
         }
 
         public string GetMarkerSuffix()

--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -337,6 +337,11 @@ namespace UndertaleModTool
 
         public static void Reset()
         {
+            foreach (Bitmap bmp in TileCache.Values)
+                bmp.Dispose();
+            foreach (Bitmap bmp in tilePageCache.Values)
+                bmp.Dispose();
+
             TileCache.Clear();
             tilePageCache.Clear();
             TileRectanglesConverter.TileCache.Clear();

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -864,7 +864,7 @@ namespace UndertaleModTool
         {
             if (Data is not null)
             {
-                // This also clears all theirs game object references
+                // This also clears all their game object references
                 CurrentTab = null;
                 Tabs.Clear();
                 SelectionHistory.Clear();

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -1166,6 +1166,9 @@ namespace UndertaleModTool
             });
             dialog.ShowDialog();
             await t;
+
+            GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce;
+            GC.Collect();
         }
 
         public string GenerateMD5(string filename)


### PR DESCRIPTION
## Description

1. `UndertaleData` _(and all `Undertale-` data models)_ is `IDisposable`; **when loading another game data, old data is disposed from memory** _(so less memory is used)_.
2. `CachedTileDataLoader.Reset()` disposes all cached `Bitmap`s before clearing the dictionaries.
3. `ToString()` overloads of some data models don't throw `NullReferenceException` if `Name` is null.
4. Most of backing fields of the data models are properly named _("\_Name" -> "\_name")_.
5. Code of `UndertaleTags.GetAssetTagID()` is simplified.
6. **Improved (de)serialization methods description.**
7. **Added some descriptions within `UndertaleRoom`**.