### PR TITLE
Get rid of GraphViz functionality

### DIFF
--- a/UndertaleModTool/Editors/UndertaleCodeEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleCodeEditor.xaml
@@ -1,11 +1,11 @@
 ﻿<local:DataUserControl x:Class="UndertaleModTool.UndertaleCodeEditor"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:UndertaleModTool"
              xmlns:undertale="clr-namespace:UndertaleModLib.Models;assembly=UndertaleModLib"
-             mc:Ignorable="d" 
+             mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800" d:DataContext="{d:DesignInstance undertale:UndertaleCode}" DataContextChanged="UserControl_DataContextChanged">
     <UserControl.CommandBindings>
         <CommandBinding Command="{x:Static local:UndertaleCodeEditor.Compile}" Executed="Command_Compile" />
@@ -44,7 +44,7 @@
                     <avalonEdit:TextEditor
                         xmlns:avalonEdit="http://icsharpcode.net/sharpdevelop/avalonedit"
                         FontFamily="Consolas"
-                        Name="DecompiledEditor" 
+                        Name="DecompiledEditor"
                         IsReadOnly="True"
                         Background="#222222"
                         LineNumbersForeground="#DBDBDB"
@@ -62,7 +62,7 @@
                     <avalonEdit:TextEditor
                         xmlns:avalonEdit="http://icsharpcode.net/sharpdevelop/avalonedit"
                         FontFamily="Consolas"
-                        Name="DisassemblyEditor" 
+                        Name="DisassemblyEditor"
                         IsReadOnly="True"
                         Background="#222222"
                         Foreground="#C0C0C0"
@@ -72,11 +72,6 @@
                         FontSize="10pt"
                         Padding="4"/>
                 </Grid>
-            </TabItem>
-            <TabItem Header="Graph view" Name="GraphTab">
-                <Viewbox Stretch="UniformToFill" StretchDirection="DownOnly">
-                    <Image Name="GraphView"/>
-                </Viewbox>
             </TabItem>
         </TabControl>
     </Grid>

--- a/UndertaleModTool/Settings.cs
+++ b/UndertaleModTool/Settings.cs
@@ -16,7 +16,6 @@ namespace UndertaleModTool
         public static string ProfilesFolder = Path.Combine(AppDataFolder, "Profiles");
 
         public string Version { get; set; } = MainWindow.Version;
-        public string GraphVizPath { get; set; } = ".\\graphviz\\bin";
         public string GameMakerStudioPath { get; set; } = "%appdata%\\GameMaker-Studio";
         public string GameMakerStudio2RuntimesPath { get; set; } = "%systemdrive%\\ProgramData\\GameMakerStudio2\\Cache\\runtimes"; /* Using %systemdrive% here fixes the runtimes not being found when the system drive is not C:\\ */
         public bool AssetOrderSwappingEnabled { get; set; } = false;
@@ -37,7 +36,7 @@ namespace UndertaleModTool
         // old backups only after 20 is reached (in the family tree, other unrelated mod families don't count)
         // starting with the oldest, with which one to clear determined from a parenting ledger file
         // (whose implementation does not exist yet).
-        // 
+        //
         // This comment should be cleared in the event that the remedies described are implemented.
 
         public bool DeleteOldProfileOnSave { get; set; } = false;

--- a/UndertaleModTool/UndertaleModTool.csproj
+++ b/UndertaleModTool/UndertaleModTool.csproj
@@ -3551,7 +3551,6 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="GraphViz.NET" Version="1.0.0" />
         <PackageReference Include="log4net" Version="2.0.12" />
         <PackageReference Include="Microsoft-WindowsAPICodePack-Shell">
             <Version>1.1.4</Version>

--- a/UndertaleModTool/Windows/SettingsWindow.xaml
+++ b/UndertaleModTool/Windows/SettingsWindow.xaml
@@ -30,9 +30,6 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <TextBlock Grid.Row="0" Grid.Column="0" Margin="3" Text="GraphViz path" ToolTip="Required if you want code decompile graphs"/>
-        <TextBox Grid.Row="0" Grid.Column="1" Margin="3" Text="{Binding GraphVizPath}"/>
-
         <TextBlock Grid.Row="1" Grid.Column="0" Margin="3" Text="Game Maker: Studio 1.4 path" ToolTip="Required only if you want to use the Studio runner rather than the .exe or run the game under debugger."/>
         <TextBox Grid.Row="1" Grid.Column="1" Margin="3" Text="{Binding GameMakerStudioPath}"/>
 

--- a/UndertaleModTool/Windows/SettingsWindow.xaml.cs
+++ b/UndertaleModTool/Windows/SettingsWindow.xaml.cs
@@ -21,16 +21,6 @@ namespace UndertaleModTool
     /// </summary>
     public partial class SettingsWindow : Window
     {
-        public static string GraphVizPath
-        {
-            get => Settings.Instance.GraphVizPath;
-            set
-            {
-                Settings.Instance.GraphVizPath = value;
-                Settings.Save();
-            }
-        }
-
         public static string GameMakerStudioPath
         {
             get => Settings.Instance.GameMakerStudioPath;


### PR DESCRIPTION
## Description
This PR gets rid of all GraphViz functionality that was left in the tool, as it was deemed obsolete.

### Caveats
Considering that the "Show graph" window in the code editor was already broken for a longer time, this doesn't have any caveats.
`ExportFlowGraph` from the decompiler library was kept intact, in case any future decompiler work needs to be done and devs want to generate the graph externally from UMT.