### PR TITLE
SourceWidth/SourceHeight grammar mistake fix.

### DIFF
--- a/UndertaleModLib/Models/UndertaleFont.cs
+++ b/UndertaleModLib/Models/UndertaleFont.cs
@@ -112,12 +112,12 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
         public ushort SourceY { get; set; }
 
         /// <summary>
-        /// The width of the glyph in pixel.
+        /// The width of the glyph in pixels.
         /// </summary>
         public ushort SourceWidth { get; set; }
 
         /// <summary>
-        /// The height of the glyph in pixel.
+        /// The height of the glyph in pixels.
         /// </summary>
         public ushort SourceHeight { get; set; }
 


### PR DESCRIPTION
## Description
Fixed minor grammar mistake in the descriptions of `Glyph.SourceWidth` and `Glyph.SourceHeight`.