### PR TITLE
String-related fixes and improvements.

### DIFF
--- a/UndertaleModTool/Converters/StringTitleConverter.cs
+++ b/UndertaleModTool/Converters/StringTitleConverter.cs
@@ -8,6 +8,7 @@ namespace UndertaleModTool
     public class StringTitleConverter : IValueConverter
     {
         public static readonly Regex NewLineRegex = new(@"\r\n?|\n", RegexOptions.Compiled);
+        public static StringTitleConverter Instance { get; } = new();
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {

--- a/UndertaleModTool/MainWindow.xaml
+++ b/UndertaleModTool/MainWindow.xaml
@@ -426,15 +426,8 @@
                             <TabControl.ItemTemplate>
                                 <DataTemplate DataType="{x:Type local:Tab}">
                                     <StackPanel Orientation="Horizontal">
-                                        <TextBlock>
-                                            <TextBlock.Text>
-                                                <MultiBinding Converter="{StaticResource TabTitleConverter}" Mode="OneWay">
-                                                    <Binding Mode="OneTime"/>
-                                                    <Binding Path="OpenedObject" Mode="OneWay"/>
-                                                    <!-- for notification only -->
-                                                    <Binding Path="OpenedObject.Name.Content" Mode="OneWay"/>
-                                                </MultiBinding>
-                                            </TextBlock.Text>
+                                        <TextBlock Initialized="TabTitleText_Initialized" DataContextChanged="TabTitleText_DataContextChanged">
+                                            <!-- "TextBlock.Text" binding is set in code-behind -->
                                         </TextBlock>
                                         <Button Background="Transparent" Width="16" Height="16" BorderThickness="0" Margin="12,0,0,0"
                                                 Click="TabCloseButton_OnClick" MouseEnter="TabCloseButton_MouseEnter" MouseLeave="TabCloseButton_MouseLeave">

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -140,9 +140,12 @@ namespace UndertaleModTool
             else if (obj is UndertaleString str)
             {
                 string stringFirstLine = str.Content;
-                int stringLength = StringTitleConverter.NewLineRegex.Match(stringFirstLine).Index;
-                if (stringLength != 0)
-                    stringFirstLine = stringFirstLine[..stringLength] + " ...";
+                if (stringFirstLine is not null)
+                {
+                    int stringLength = StringTitleConverter.NewLineRegex.Match(stringFirstLine).Index;
+                    if (stringLength != 0)
+                        stringFirstLine = stringFirstLine[..stringLength] + " ...";
+                }
 
                 title = "String - " + stringFirstLine;
             }
@@ -167,7 +170,7 @@ namespace UndertaleModTool
                 Debug.WriteLine($"Could not handle type {obj.GetType()}");
             }
 
-            if (title.Length > 64)
+            if (title?.Length > 64)
                 title = title[..64] + "...";
 
             return title;

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -141,7 +141,7 @@ namespace UndertaleModTool
             {
                 string stringFirstLine = str.Content;
                 int stringLength = StringTitleConverter.NewLineRegex.Match(stringFirstLine).Index;
-                if (stringLength != -1)
+                if (stringLength != 0)
                     stringFirstLine = stringFirstLine[..stringLength] + " ...";
 
                 title = "String - " + stringFirstLine;

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -1713,10 +1713,17 @@ namespace UndertaleModTool
                 }
             }
         }
-        private void CopyItemName(UndertaleNamedResource namedRes)
+        private void CopyItemName(object obj)
         {
-            if (namedRes.Name?.Content is not null)
-                Clipboard.SetText(namedRes.Name.Content);
+            string name = null;
+
+            if (obj is UndertaleNamedResource namedRes)
+                name = namedRes.Name?.Content;
+            else if (obj is UndertaleString str)
+                name = StringTitleConverter.Instance.Convert(str.Content, null, null, null) as string;
+
+            if (name is not null)
+                Clipboard.SetText(name);
             else
                 this.ShowWarning("Item name is null.");
         }
@@ -1801,8 +1808,7 @@ namespace UndertaleModTool
         }
         private void MenuItem_CopyName_Click(object sender, RoutedEventArgs e)
         {
-            if (Highlighted is UndertaleNamedResource namedRes)
-                CopyItemName(namedRes);
+            CopyItemName(Highlighted);
         }
         private void MenuItem_Delete_Click(object sender, RoutedEventArgs e)
         {


### PR DESCRIPTION
## Description

1. Fixed missing `UndertaleString` name in the tab titles.
2. **Fixed crash on new `UndertaleString` addition.**
3. "Copy name to clipboard" feature now works with `UndertaleString` items.
4. `UndertaleString` tab title updates on string content change and properly shortens if it contains tab characters.
5. Fixed all the instances of "Name property not found on object of type ..." WPF binding error.