### PR TITLE
Allow entries from the left list to be middle-mouse button'ed

### DIFF
--- a/UndertaleModTool/MainWindow.xaml
+++ b/UndertaleModTool/MainWindow.xaml
@@ -181,7 +181,7 @@
                 <TreeView Grid.Column="0" Grid.Row="1" Margin="5" DataContext="{Binding Data}" SelectedItemChanged="TreeView_SelectedItemChanged" MouseDoubleClick="MainTree_MouseDoubleClick" KeyUp="MainTree_KeyUp" AllowDrop="True" Name="MainTree" KeyDown="MainTree_KeyDown" PreviewMouseRightButtonDown="MainTree_PreviewMouseRightButtonDown"
                     VirtualizingStackPanel.IsVirtualizing="True"
                     VirtualizingStackPanel.VirtualizationMode="Recycling">
-                    <TreeView.Resources>
+                    <TreeView.Resources >
                         <ContextMenu x:Key="AddMenu">
                             <MenuItem Header="Add" Click="MenuItem_Add_Click"/>
                         </ContextMenu>
@@ -196,6 +196,7 @@
                             <EventSetter Event="TreeViewItem.DragOver" Handler="TreeView_DragOver"/>
                             <EventSetter Event="TreeViewItem.Drop" Handler="TreeView_Drop"/>
                             <EventSetter Event="TreeViewItem.MouseMove" Handler="TreeView_MouseMove"/>
+                            <EventSetter Event="TreeViewItem.MouseDown" Handler="MainTree_OnMouseDown"/>
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding ., Converter={StaticResource ImplementsInterfaceConverter}, ConverterParameter={x:Type undertalelib:UndertaleResource}}" Value="True">
                                     <Setter Property="ContextMenu" Value="{StaticResource UndertaleResourceMenu}"/>

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -1614,6 +1614,15 @@ namespace UndertaleModTool
             e.Handled = true;
         }
 
+        private void MainTree_OnMouseDown(object sender, MouseButtonEventArgs e)
+        {
+            var senderTree = sender as TreeViewItem;
+            HighlightObject(senderTree.Header);
+            if (senderTree.Header is string) return;
+            if (Data != null && e.ButtonState == MouseButtonState.Pressed && e.ChangedButton == System.Windows.Input.MouseButton.Middle)
+                OpenInTab(Highlighted, true);
+        }
+
         public static T VisualUpwardSearch<T>(DependencyObject element) where T : class
         {
             T container = element as T;


### PR DESCRIPTION
## Description
This PR makes it so that entries from the left list can be middle-mouse button'ed, which opens them in another tab.
Fixes #981 

### Caveats
- If you attempt to MMB the headers, they won't get highlighted, which may look a little weird
- MMB'ing results in the treeview centering the item that was clicked, which may look a little weird.
