### PR TITLE
Make error on load show on UI thread

### DIFF
--- a/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
@@ -466,7 +466,7 @@ namespace UndertaleModTool
                     }
                     catch (Exception exc)
                     {
-                        mainWindow.ShowError(exc.ToString());
+                        mainWindow.ShowErrorInvoke(exc.ToString());
                     }
 
                     if (decompiled != null)
@@ -595,14 +595,14 @@ namespace UndertaleModTool
                     catch (Exception e)
                     {
                         Debug.WriteLine(e.ToString());
-                        if (mainWindow.ShowQuestion("Unable to execute GraphViz: " + e.Message + "\nMake sure you have downloaded it and set the path in settings.\nDo you want to open the download page now?", MessageBoxImage.Error) == MessageBoxResult.Yes)
+                        if (mainWindow.ShowQuestionInvoke("Unable to execute GraphViz: " + e.Message + "\nMake sure you have downloaded it and set the path in settings.\nDo you want to open the download page now?", MessageBoxImage.Error) == MessageBoxResult.Yes)
                             MainWindow.OpenBrowser("https://graphviz.gitlab.io/_pages/Download/Download_windows.html");
                     }
                 }
                 catch (Exception e)
                 {
                     Debug.WriteLine(e.ToString());
-                    mainWindow.ShowError(e.Message, "Graph generation failed");
+                    mainWindow.ShowErrorInvoke(e.Message, "Graph generation failed");
                 }
 
                 Dispatcher.Invoke(() =>
@@ -692,21 +692,21 @@ namespace UndertaleModTool
             if (compileContext == null)
             {
                 dialog.TryClose();
-                mainWindow.ShowError("Compile context was null for some reason...", "This shouldn't happen");
+                mainWindow.ShowErrorInvoke("Compile context was null for some reason...", "This shouldn't happen");
                 return;
             }
 
             if (compileContext.HasError)
             {
                 dialog.TryClose();
-                mainWindow.ShowError(Truncate(compileContext.ResultError, 512), "Compiler error");
+                mainWindow.ShowErrorInvoke(Truncate(compileContext.ResultError, 512), "Compiler error");
                 return;
             }
 
             if (!compileContext.SuccessfulCompile)
             {
                 dialog.TryClose();
-                mainWindow.ShowError("(unknown error message)", "Compile failed");
+                mainWindow.ShowErrorInvoke("(unknown error message)", "Compile failed");
                 return;
             }
 
@@ -733,7 +733,7 @@ namespace UndertaleModTool
                 }
                 catch (Exception exc)
                 {
-                    mainWindow.ShowError("Error during writing of GML code to profile:\n" + exc);
+                    mainWindow.ShowErrorInvoke("Error during writing of GML code to profile:\n" + exc);
                 }
             }
 

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -504,7 +504,7 @@ namespace UndertaleModTool
                             }
 
                             if (!deleted)
-                                this.ShowWarning($"The updater temp folder can't be deleted.\nError - {exMessage}.");
+                                this.ShowWarningInvoke($"The updater temp folder can't be deleted.\nError - {exMessage}.");
                         }
                     });
                 }
@@ -624,7 +624,7 @@ namespace UndertaleModTool
         {
             if (Data != null)
             {
-                if (this.ShowQuestion("Warning: you currently have a project open.\nAre you sure you want to make a new project?") == MessageBoxResult.No)
+                if (this.ShowQuestionInvoke("Warning: you currently have a project open.\nAre you sure you want to make a new project?") == MessageBoxResult.No)
                     return false;
             }
             this.Dispatcher.Invoke(() =>
@@ -923,7 +923,7 @@ namespace UndertaleModTool
                     {
                         data = UndertaleIO.Read(stream, warning =>
                         {
-                            this.ShowWarning(warning, "Loading warning");
+                            this.ShowWarningInvoke(warning, "Loading warning");
                             hadWarnings = true;
                         }, message =>
                         {
@@ -935,7 +935,7 @@ namespace UndertaleModTool
                 }
                 catch (Exception e)
                 {
-                    this.ShowError("An error occured while trying to load:\n" + e.Message, "Load error");
+                    this.ShowErrorInvoke("An error occured while trying to load:\n" + e.Message, "Load error");
                 }
 
                 Dispatcher.Invoke(async () =>
@@ -1153,10 +1153,7 @@ namespace UndertaleModTool
                         catch { }
                     }
 
-                    Dispatcher.Invoke(() =>
-                    {
-                        this.ShowError("An error occured while trying to save:\n" + e.Message, "Save error");
-                    });
+                    this.ShowErrorInvoke("An error occured while trying to save:\n" + e.Message, "Save error");
 
                     SaveSucceeded = false;
                 }
@@ -1189,10 +1186,7 @@ namespace UndertaleModTool
                 }
                 catch (Exception exc)
                 {
-                    Dispatcher.Invoke(() =>
-                    {
-                        this.ShowError("An error occured while trying to save:\n" + exc.Message, "Save error");
-                    });
+                    this.ShowErrorInvoke("An error occured while trying to save:\n" + exc.Message, "Save error");
 
                     SaveSucceeded = false;
                 }
@@ -1257,8 +1251,7 @@ namespace UndertaleModTool
 
                     if (!File.Exists(Path.Combine(cacheDirPath, num.ToString())))
                     {
-                        this.ShowWarning("Decompiled code cache file for open data is missing, but its name present in the index.");
-
+                        this.ShowWarningInvoke("Decompiled code cache file for open data is missing, but its name present in the index.");
                         return;
                     }
 
@@ -1269,7 +1262,7 @@ namespace UndertaleModTool
                         string prevHash = fs.ReadLine();
 
                         if (!Regex.IsMatch(prevHash, "^[0-9a-fA-F]{32}$")) //if first 32 bytes of cache file are not a valid MD5
-                            this.ShowWarning("Decompiled code cache for open file is broken.\nThe cache will be generated again.");
+                            this.ShowWarningInvoke("Decompiled code cache for open file is broken.\nThe cache will be generated again.");
                         else
                         {
                             if (hash == prevHash)
@@ -1288,7 +1281,7 @@ namespace UndertaleModTool
                                 }
                                 catch
                                 {
-                                    this.ShowWarning("Decompiled code cache for open file is broken.\nThe cache will be generated again.");
+                                    this.ShowWarningInvoke("Decompiled code cache for open file is broken.\nThe cache will be generated again.");
 
                                     Data.GMLCache = null;
                                     Data.GMLCacheFailed = null;
@@ -1300,7 +1293,7 @@ namespace UndertaleModTool
                                 string[] invalidNames = Data.GMLCache.Keys.Except(codeNames).ToArray();
                                 if (invalidNames.Length > 0)
                                 {
-                                    this.ShowWarning($"Decompiled code cache for open file contains one or more non-existent code names (first - \"{invalidNames[0]}\").\nThe cache will be generated again.");
+                                    this.ShowWarningInvoke($"Decompiled code cache for open file contains one or more non-existent code names (first - \"{invalidNames[0]}\").\nThe cache will be generated again.");
 
                                     Data.GMLCache = null;
 
@@ -1312,7 +1305,7 @@ namespace UndertaleModTool
                                 Data.GMLCacheWasSaved = true;
                             }
                             else
-                                this.ShowWarning("Open file differs from the one the cache was generated for.\nThat decompiled code cache will be generated again.");
+                                this.ShowWarningInvoke("Open file differs from the one the cache was generated for.\nThat decompiled code cache will be generated again.");
                         }
                     }
                 }
@@ -2341,7 +2334,7 @@ namespace UndertaleModTool
             {
                 Console.WriteLine(exc.ToString());
                 Dispatcher.Invoke(() => CommandBox.Text = exc.Message);
-                this.ShowError(exc.Message, "Script compile error");
+                this.ShowErrorInvoke(exc.Message, "Script compile error");
                 ScriptExecutionSuccess = false;
                 ScriptErrorMessage = exc.Message;
                 ScriptErrorType = "CompilationErrorException";
@@ -2358,7 +2351,7 @@ namespace UndertaleModTool
 
                 Console.WriteLine(exc.ToString());
                 Dispatcher.Invoke(() => CommandBox.Text = exc.Message);
-                this.ShowError(isScriptException ? exc.Message : excString, "Script error");
+                this.ShowErrorInvoke(isScriptException ? exc.Message : excString, "Script error");
                 ScriptExecutionSuccess = false;
                 ScriptErrorMessage = exc.Message;
                 ScriptErrorType = "Exception";
@@ -2626,8 +2619,7 @@ namespace UndertaleModTool
                                   "the Nightly builds if you don't have a GitHub account, or compile UTMT yourself.\n" +
                                   "For any questions or more information, ask in the Underminers Discord server.");
                 window.UpdateButtonEnabled = true;
-                    return;
-
+                return;
             }
 
             string sysDriveLetter = Path.GetTempPath()[0].ToString();
@@ -3209,7 +3201,7 @@ result in loss of work.");
                         }
                         catch (Exception ex)
                         {
-                            this.ShowError("An error occured while trying to load:\n" + ex.Message, "Load error");
+                            this.ShowErrorInvoke("An error occured while trying to load:\n" + ex.Message, "Load error");
                         }
 
                         Dispatcher.Invoke(() =>

--- a/UndertaleModTool/MessageBoxExtensions.cs
+++ b/UndertaleModTool/MessageBoxExtensions.cs
@@ -61,6 +61,59 @@ namespace UndertaleModTool
 		}
 
 		/// <summary>
+		/// Invokes <paramref name="window"/> to show an informational <see cref="MessageBox"/> with <paramref name="window"/> as the parent.
+		/// </summary>
+		/// <param name="window">The parent from which the <see cref="MessageBox"/> will show.</param>
+		/// <param name="messageBoxText">A <see cref="string"/> that specifies the text to display.</param>
+		/// <param name="title">A <see cref="string"/> that specifies the title bar caption to display.</param>
+		/// <returns><see cref="MessageBoxResult.OK"/> or <see cref="MessageBoxResult.None"/> if
+		/// the <see cref="MessageBox"/> was cancelled.</returns>
+		public static MessageBoxResult ShowMessageInvoke(this Window window, string messageBoxText, string title = "UndertaleModTool")
+		{
+			return window.Dispatcher.Invoke(() => ShowCore(window, messageBoxText, title, MessageBoxButton.OK, MessageBoxImage.Information));
+		}
+
+		/// <summary>
+		/// Invokes <paramref name="window"/> to show a <see cref="MessageBox"/> prompting for a yes/no question with <paramref name="window"/> as the parent.
+		/// </summary>
+		/// <param name="window">The parent from which the <see cref="MessageBox"/> will show.</param>
+		/// <param name="messageBoxText">A <see cref="string"/> that specifies the text to display.</param>
+		/// <param name="icon">The <see cref="MessageBoxImage"/> to display.</param>
+		/// <param name="title">A <see cref="string"/> that specifies the title bar caption to display.</param>
+		/// <returns><see cref="MessageBoxResult.Yes"/> or <see cref="MessageBoxResult.No"/> depending on the users' answer.
+		/// <see cref="MessageBoxResult.None"/> if the <see cref="MessageBox"/> was cancelled.</returns>
+		public static MessageBoxResult ShowQuestionInvoke(this Window window, string messageBoxText, MessageBoxImage icon = MessageBoxImage.Question, string title = "UndertaleModTool")
+		{
+			return window.Dispatcher.Invoke(() => ShowCore(window, messageBoxText, title, MessageBoxButton.YesNo, icon));
+		}
+
+		/// <summary>
+		/// Invokes <paramref name="window"/> to show a warning <see cref="MessageBox"/> with <paramref name="window"/> as the parent.
+		/// </summary>
+		/// <param name="window">The parent from which the <see cref="MessageBox"/> will show.</param>
+		/// <param name="messageBoxText">A <see cref="string"/> that specifies the text to display.</param>
+		/// <param name="title">A <see cref="string"/> that specifies the title bar caption to display.</param>
+		/// <returns><see cref="MessageBoxResult.OK"/> or <see cref="MessageBoxResult.None"/> if
+		/// the <see cref="MessageBox"/> was cancelled.</returns>
+		public static MessageBoxResult ShowWarningInvoke(this Window window, string messageBoxText, string title = "Warning")
+		{
+			return window.Dispatcher.Invoke(() => ShowCore(window, messageBoxText, title, MessageBoxButton.OK, MessageBoxImage.Warning));
+		}
+
+		/// <summary>
+		/// Invokes <paramref name="window"/> to show an error <see cref="MessageBox"/> with <paramref name="window"/> as the parent.
+		/// </summary>
+		/// <param name="window">The parent from which the <see cref="MessageBox"/> will show.</param>
+		/// <param name="messageBoxText">A <see cref="string"/> that specifies the text to display.</param>
+		/// <param name="title">A <see cref="string"/> that specifies the title bar caption to display.</param>
+		/// <returns><see cref="MessageBoxResult.OK"/> or <see cref="MessageBoxResult.None"/> if
+		/// the <see cref="MessageBox"/> was cancelled.</returns>
+		public static MessageBoxResult ShowErrorInvoke(this Window window, string messageBoxText, string title = "Error")
+		{
+			return window.Dispatcher.Invoke(() => ShowCore(window, messageBoxText, title, MessageBoxButton.OK, MessageBoxImage.Error));
+		}
+
+		/// <summary>
 		/// The wrapper for the extensions to directly call <see cref="MessageBox.Show(Window, string, string, MessageBoxButton, MessageBoxImage)"/>.
 		/// </summary>
 		/// <param name="window">A Window that represents the owner window of the message box.</param>

--- a/UndertaleModTool/ProfileSystem.cs
+++ b/UndertaleModTool/ProfileSystem.cs
@@ -280,7 +280,7 @@ namespace UndertaleModTool
 
                     if (!SettingsWindow.ProfileMessageShown)
                     {
-                        this.ShowMessage(@"The profile for your game loaded successfully!
+                        this.ShowMessageInvoke(@"The profile for your game loaded successfully!
 
 UndertaleModTool now uses the ""Profile"" system by default for code.
 Using the profile system, many new features are available to you!
@@ -383,7 +383,7 @@ an issue on GitHub.");
                     Directory.CreateDirectory(profDir);
                     Directory.CreateDirectory(Path.Combine(profDir, "Main"));
                     Directory.CreateDirectory(Path.Combine(profDir, "Temp"));
-                    this.ShowMessage("Profile saved successfully to " + ProfileHash);
+                    this.ShowMessageInvoke("Profile saved successfully to " + ProfileHash);
                 }
                 if (SettingsWindow.DeleteOldProfileOnSave && copyProfile)
                 {


### PR DESCRIPTION
## Description
Makes it so errors on loading a data.win file are invoked on the UI thread and don't freeze the program.

### Caveats
None

### Notes
Addresses the issue #984 brought up.