### PR TITLE
More general approach on fixing non-ui-thread messagebox

### DIFF
--- a/UndertaleModTool/MessageBoxExtensions.cs
+++ b/UndertaleModTool/MessageBoxExtensions.cs
@@ -71,7 +71,7 @@ namespace UndertaleModTool
 		/// <returns>A <see cref="MessageBoxResult"/> value that specifies which message box button is clicked by the user.</returns>
 		private static MessageBoxResult ShowCore(this Window window, string text, string title, MessageBoxButton buttons, MessageBoxImage image)
 		{
-			return MessageBox.Show(window, text, title, buttons, image);
+			return window.Dispatcher.Invoke(() => MessageBox.Show(window, text, title, buttons, image));
 		}
 	}
 }


### PR DESCRIPTION
## Description
Makes it so errors on loading a data.win file are invoked on the UI thread and don't freeze the program.

### Caveats
None

### Notes
Addresses the issue #984 brought up.
