### PR TITLE
Remove GMS 2.3 checks for profile mode and GMS 2.3 warning upon loading

### DIFF
--- a/UndertaleModCli/Program.UMTLibInherited.cs
+++ b/UndertaleModCli/Program.UMTLibInherited.cs
@@ -645,7 +645,7 @@ public partial class Program : IScriptInterface
         string passBack = "";
         GlobalDecompileContext decompileContext = context is null ? new(Data, false) : context;
 
-        if (!Data.ToolInfo.ProfileMode || Data.GMS2_3)
+        if (!Data.ToolInfo.ProfileMode)
         {
             try
             {
@@ -657,7 +657,7 @@ public partial class Program : IScriptInterface
                 throw new Exception("Error during GML code replacement:\n" + exc);
             }
         }
-        else if (Data.ToolInfo.ProfileMode && !Data.GMS2_3)
+        else if (Data.ToolInfo.ProfileMode)
         {
             try
             {

--- a/UndertaleModLib/Models/UndertaleCode.cs
+++ b/UndertaleModLib/Models/UndertaleCode.cs
@@ -1267,7 +1267,7 @@ public class UndertaleCode : UndertaleNamedResource, UndertaleObjectWithBlobs, I
         {
             // When necessary, write to profile.
             string tempPath = Path.Combine(data.ToolInfo.AppDataProfiles, data.ToolInfo.CurrentMD5, "Temp", Name?.Content + ".gml");
-            if (!data.GMS2_3 && (data.ToolInfo.ProfileMode || File.Exists(tempPath)))
+            if (data.ToolInfo.ProfileMode || File.Exists(tempPath))
                 File.WriteAllText(tempPath, gmlCode);
         }
         catch (Exception exc)

--- a/UndertaleModTool/ImportCodeSystem.cs
+++ b/UndertaleModTool/ImportCodeSystem.cs
@@ -113,7 +113,7 @@ namespace UndertaleModTool
             string codeName = code.Name.Content;
             GlobalDecompileContext DECOMPILE_CONTEXT = context is null ? new(Data, false) : context;
 
-            if (Data.ToolInfo.ProfileMode == false || Data.GMS2_3)
+            if (Data.ToolInfo.ProfileMode == false)
             {
                 try
                 {
@@ -125,7 +125,7 @@ namespace UndertaleModTool
                     throw new Exception("Error during GML code replacement:\n" + exc.ToString());
                 }
             }
-            else if (Data.ToolInfo.ProfileMode && !Data.GMS2_3)
+            else if (Data.ToolInfo.ProfileMode)
             {
                 try
                 {

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -965,10 +965,10 @@ namespace UndertaleModTool
                                 data.ToolInfo.CurrentMD5 = BitConverter.ToString(MD5CurrentlyLoaded).Replace("-", "").ToLowerInvariant();
                             }
                         }
-                        if (data.GMS2_3 && SettingsWindow.Warn_About_GMS23)
+                        /*if (data.GMS2_3 && SettingsWindow.Warn_About_GMS23)
                         {
                             this.ShowWarning("This game was built using GameMaker Studio 2.3 (or above). Support for this version is a work in progress, and you will likely run into issues decompiling code or in other places.", "GMS 2.3");
-                        }
+                        }*/
                         if (data.IsYYC())
                         {
                             this.ShowWarning("This game uses YYC (YoYo Compiler), which means the code is embedded into the game executable. This configuration is currently not fully supported; continue at your own risk.", "YYC");

--- a/UndertaleModTool/ProfileSystem.cs
+++ b/UndertaleModTool/ProfileSystem.cs
@@ -230,12 +230,12 @@ namespace UndertaleModTool
 
                 if (SettingsWindow.ProfileModeEnabled)
                 {
-                    if (data.GMS2_3)
+/*                    if (data.GMS2_3)
                     {
                         this.ShowWarning("Profile mode is not currently supported for GameMaker Studio 2.3 games.");
                         return;
                     }
-
+*/
                     Directory.CreateDirectory(ProfilesFolder);
                     if (Directory.Exists(profDir))
                     {
@@ -335,7 +335,7 @@ an issue on GitHub.");
 
                 Directory.CreateDirectory(Path.Combine(ProfilesFolder, ProfileHash, "Main"));
                 Directory.CreateDirectory(Path.Combine(ProfilesFolder, ProfileHash, "Temp"));
-                if (!SettingsWindow.ProfileModeEnabled || data.GMS2_3 || data.IsYYC())
+                if (!SettingsWindow.ProfileModeEnabled || data.IsYYC())
                 {
                     MD5PreviouslyLoaded = MD5CurrentlyLoaded;
                     ProfileHash = BitConverter.ToString(MD5PreviouslyLoaded).Replace("-", "").ToLowerInvariant();


### PR DESCRIPTION
Remove GMS 2.3 checks for profile mode and GMS 2.3 warning upon loading

## Description
Remove GMS 2.3 checks for profile mode and GMS 2.3 warning upon loading.

### Caveats
I might have missed some checks for profile mode, and there may or may not be reason for that GMS 2.3 warning to still exist.

### Notes
Long overdue, similar warnings need to be removed from the scripts.