### PR TITLE
Per-tab history.

### DIFF
--- a/UndertaleModTool/Converters/ForwardButtonEnabledConverter.cs
+++ b/UndertaleModTool/Converters/ForwardButtonEnabledConverter.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace UndertaleModTool
+{
+    public class ForwardButtonEnabledConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values[0] is not int pos || values[1] is not int count)
+                return false;
+
+            return pos != count - 1;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/UndertaleModTool/MainWindow.xaml
+++ b/UndertaleModTool/MainWindow.xaml
@@ -451,7 +451,7 @@
                                 <TabControl.ItemTemplate>
                                     <DataTemplate DataType="{x:Type local:Tab}">
                                         <StackPanel Orientation="Horizontal">
-                                            <TextBlock Initialized="TabTitleText_Initialized" DataContextChanged="TabTitleText_DataContextChanged">
+                                            <TextBlock Initialized="TabTitleText_Initialized">
                                             <!-- "TextBlock.Text" binding is set in code-behind -->
                                             </TextBlock>
                                             <Button Background="Transparent" Width="16" Height="16" BorderThickness="0" Margin="12,0,0,0"

--- a/UndertaleModTool/MainWindow.xaml
+++ b/UndertaleModTool/MainWindow.xaml
@@ -44,6 +44,8 @@
         <CommandBinding Command="{x:Static local:MainWindow.RestoreClosedTabCommand}" Executed="Command_RestoreClosedTab" />
         <CommandBinding Command="{x:Static local:MainWindow.SwitchToNextTabCommand}" Executed="Command_SwitchToNextTab" />
         <CommandBinding Command="{x:Static local:MainWindow.SwitchToPrevTabCommand}" Executed="Command_SwitchToPrevTab" />
+        <CommandBinding Command="NavigationCommands.BrowseBack" Executed="Command_GoBack" />
+        <CommandBinding Command="NavigationCommands.BrowseForward" Executed="Command_GoForward" />
     </Window.CommandBindings>
     <Window.InputBindings>
         <KeyBinding Modifiers="Control" Key="N" Command="New"/>

--- a/UndertaleModTool/MainWindow.xaml
+++ b/UndertaleModTool/MainWindow.xaml
@@ -27,6 +27,7 @@
         <BooleanToVisibilityConverter x:Key="BoolToVisConverter"/> <!-- (built-in converter) -->
         <local:TabTitleConverter x:Key="TabTitleConverter"/>
         <local:StringTitleConverter x:Key="StringTitleConverter"/>
+        <local:ForwardButtonEnabledConverter x:Key="ForwardButtonEnabledConverter"/>
     </Window.Resources>
     <Window.CommandBindings>
         <CommandBinding Command="New" Executed="Command_New" />
@@ -128,39 +129,70 @@
                     <ColumnDefinition Width="3*"/>
                 </Grid.ColumnDefinitions>
                 <Grid Grid.Column="0" Grid.Row="0" Margin="5,5,5,0">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
-                    <Button Grid.Column="0" ToolTip="Back" Margin="0,0,5,0" Name="BackButton" Click="BackButton_Click">
-                        <Button.Style>
-                            <Style TargetType="Button">
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding CurrentTab.HistoryPosition}" Value="0">
-                                        <Setter Property="IsEnabled" Value="False" />
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Button.Style>
-                        <Image Name="BackButtonImage">
-                            <Image.Style>
-                                <Style TargetType="Image">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <StackPanel Grid.Row="0" Margin="0,0,0,5" Orientation="Horizontal">
+                        <Button ToolTip="Back" Margin="0,0,2,0" Name="BackButton" Click="BackButton_Click">
+                            <Button.Style>
+                                <Style TargetType="Button">
                                     <Style.Triggers>
-                                        <Trigger Property="IsEnabled" Value="False">
-                                            <Setter Property="Opacity" Value="0.5" />
-                                        </Trigger>
-                                        <Trigger Property="IsMouseOver" Value="False">
-                                            <Setter Property="Source" Value="/Resources/arrow_blue.png" />
-                                        </Trigger>
-                                        <Trigger Property="IsMouseOver" Value="True">
-                                            <Setter Property="Source" Value="/Resources/arrow_red.png" />
-                                        </Trigger>
+                                        <DataTrigger Binding="{Binding CurrentTab.HistoryPosition}" Value="0">
+                                            <Setter Property="IsEnabled" Value="False" />
+                                        </DataTrigger>
                                     </Style.Triggers>
                                 </Style>
-                            </Image.Style>
-                        </Image>
-                    </Button>
-                    <TextBox Grid.Column="1" Name="SearchBox" ToolTip="Search" TextChanged="SearchBox_TextChanged"/>
+                            </Button.Style>
+                            <Image Name="BackButtonImage">
+                                <Image.Style>
+                                    <Style TargetType="Image">
+                                        <Style.Triggers>
+                                            <Trigger Property="IsEnabled" Value="False">
+                                                <Setter Property="Opacity" Value="0.5" />
+                                            </Trigger>
+                                            <Trigger Property="IsMouseOver" Value="False">
+                                                <Setter Property="Source" Value="/Resources/arrow_blue.png" />
+                                            </Trigger>
+                                            <Trigger Property="IsMouseOver" Value="True">
+                                                <Setter Property="Source" Value="/Resources/arrow_red.png" />
+                                            </Trigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Image.Style>
+                            </Image>
+                        </Button>
+                        <Button ToolTip="Forward" Name="ForwardButton" Click="ForwardButton_Click">
+                            <Button.IsEnabled>
+                                <MultiBinding Converter="{StaticResource ForwardButtonEnabledConverter}" Mode="OneWay">
+                                    <Binding Path="CurrentTab.HistoryPosition" Mode="OneWay"/>
+                                    <Binding Path="CurrentTab.History.Count" Mode="OneWay"/>
+                                </MultiBinding>
+                            </Button.IsEnabled>
+                            <Image Name="ForwardButtonImage" RenderTransformOrigin="0.5,0.5">
+                                <Image.RenderTransform>
+                                    <ScaleTransform ScaleX="-1" ScaleY="-1"/>
+                                </Image.RenderTransform>
+                                <Image.Style>
+                                    <Style TargetType="Image">
+                                        <Style.Triggers>
+                                            <Trigger Property="IsEnabled" Value="False">
+                                                <Setter Property="Opacity" Value="0.5" />
+                                            </Trigger>
+                                            <Trigger Property="IsMouseOver" Value="False">
+                                                <Setter Property="Source" Value="/Resources/arrow_blue.png" />
+                                            </Trigger>
+                                            <Trigger Property="IsMouseOver" Value="True">
+                                                <Setter Property="Source" Value="/Resources/arrow_red.png" />
+                                            </Trigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Image.Style>
+                            </Image>
+                        </Button>
+                    </StackPanel>
+                    
+                    <TextBox Grid.Row="1" Name="SearchBox" ToolTip="Search" TextChanged="SearchBox_TextChanged"/>
                 </Grid>
                 <TreeView Grid.Column="0" Grid.Row="1" Name="MainTree" Margin="5" DataContext="{Binding Data}" AllowDrop="True"
                           SelectedItemChanged="TreeView_SelectedItemChanged"
@@ -370,216 +402,223 @@
 
                 <GridSplitter Grid.Column="1" Grid.RowSpan="2" HorizontalAlignment="Center" VerticalAlignment="Stretch" ShowsPreview="True" Width="3"/>
 
-                <Grid Name="TabsGrid" Grid.Column="2" Grid.Row="0" UseLayoutRounding="True">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-                    <ScrollViewer Grid.Column="0" Name="TabScrollViewer" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden" PreviewMouseWheel="TabScrollViewer_PreviewMouseWheel">
-                        <TabControl Name="TabController" Height="22" TabStripPlacement="Top" ItemsSource="{Binding Tabs, Mode=OneWay}" SelectedIndex="{Binding CurrentTabIndex}"
+                <Grid Grid.Column="2" Grid.RowSpan="2">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    
+                    <Grid Grid.Row="0" Name="TabsGrid" UseLayoutRounding="True" Margin="0,0,0,3">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <ScrollViewer Grid.Column="0" Name="TabScrollViewer" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden" PreviewMouseWheel="TabScrollViewer_PreviewMouseWheel">
+                            <TabControl Name="TabController" Height="22" TabStripPlacement="Top" ItemsSource="{Binding Tabs, Mode=OneWay}" SelectedIndex="{Binding CurrentTabIndex}"
                                     SelectionChanged="TabController_SelectionChanged">
-                            <TabControl.Resources>
-                                <ContextMenu x:Key="TabMenu">
-                                    <MenuItem Header="Close" Click="CloseTabMenuItem_Click" InputGestureText="Ctrl+W"/>
-                                    <MenuItem Header="Close other tabs" Click="CloseOtherTabsMenuItem_Click">
-                                        <MenuItem.Style>
-                                            <Style TargetType="MenuItem">
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding Tabs.Count, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:MainWindow}, Mode=OneWay}" Value="1">
-                                                        <Setter Property="IsEnabled" Value="False"/>
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </MenuItem.Style>
-                                    </MenuItem>
-                                    <MenuItem Header="Close all tabs" Command="{x:Static local:MainWindow.CloseAllTabsCommand}" InputGestureText="Ctrl+Shift+W"/>
-                                </ContextMenu>
-                            </TabControl.Resources>
-                            <TabControl.ItemContainerStyle>
-                                <Style TargetType="TabItem">
-                                    <Setter Property="TabIndex" Value="{Binding TabIndex, Mode=OneWay}"/>
-                                    <Setter Property="ContextMenu" Value="{StaticResource TabMenu}"/>
-                                    <Setter Property="AllowDrop" Value="True"/>
-                                    <EventSetter Event="MouseUp" Handler="TabItem_MouseUp"/>
-                                    <EventSetter Event="PreviewMouseMove" Handler="TabItem_PreviewMouseMove"/>
-                                    <EventSetter Event="Drop" Handler="TabItem_Drop"/>
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding TabTitle, Mode=OneTime}" Value="Welcome!">
-                                            <Setter Property="ContextMenu" Value="{x:Null}"/>
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </TabControl.ItemContainerStyle>
-                            <TabControl.ItemTemplate>
-                                <DataTemplate DataType="{x:Type local:Tab}">
-                                    <StackPanel Orientation="Horizontal">
-                                        <TextBlock Initialized="TabTitleText_Initialized" DataContextChanged="TabTitleText_DataContextChanged">
-                                            <!-- "TextBlock.Text" binding is set in code-behind -->
-                                        </TextBlock>
-                                        <Button Background="Transparent" Width="16" Height="16" BorderThickness="0" Margin="12,0,0,0"
-                                                Click="TabCloseButton_OnClick" MouseEnter="TabCloseButton_MouseEnter" MouseLeave="TabCloseButton_MouseLeave">
-                                            <Button.Style>
-                                                <Style TargetType="Button">
+                                <TabControl.Resources>
+                                    <ContextMenu x:Key="TabMenu">
+                                        <MenuItem Header="Close" Click="CloseTabMenuItem_Click" InputGestureText="Ctrl+W"/>
+                                        <MenuItem Header="Close other tabs" Click="CloseOtherTabsMenuItem_Click">
+                                            <MenuItem.Style>
+                                                <Style TargetType="MenuItem">
                                                     <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding TabTitle, Mode=OneTime}" Value="Welcome!">
-                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                        <DataTrigger Binding="{Binding Tabs.Count, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:MainWindow}, Mode=OneWay}" Value="1">
+                                                            <Setter Property="IsEnabled" Value="False"/>
                                                         </DataTrigger>
                                                     </Style.Triggers>
                                                 </Style>
-                                            </Button.Style>
-                                            <Image Source="/Resources/X.png"/>
-                                        </Button>
+                                            </MenuItem.Style>
+                                        </MenuItem>
+                                        <MenuItem Header="Close all tabs" Command="{x:Static local:MainWindow.CloseAllTabsCommand}" InputGestureText="Ctrl+Shift+W"/>
+                                    </ContextMenu>
+                                </TabControl.Resources>
+                                <TabControl.ItemContainerStyle>
+                                    <Style TargetType="TabItem">
+                                        <Setter Property="TabIndex" Value="{Binding TabIndex, Mode=OneWay}"/>
+                                        <Setter Property="ContextMenu" Value="{StaticResource TabMenu}"/>
+                                        <Setter Property="AllowDrop" Value="True"/>
+                                        <EventSetter Event="MouseUp" Handler="TabItem_MouseUp"/>
+                                        <EventSetter Event="PreviewMouseMove" Handler="TabItem_PreviewMouseMove"/>
+                                        <EventSetter Event="Drop" Handler="TabItem_Drop"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding TabTitle, Mode=OneTime}" Value="Welcome!">
+                                                <Setter Property="ContextMenu" Value="{x:Null}"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TabControl.ItemContainerStyle>
+                                <TabControl.ItemTemplate>
+                                    <DataTemplate DataType="{x:Type local:Tab}">
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock Initialized="TabTitleText_Initialized" DataContextChanged="TabTitleText_DataContextChanged">
+                                            <!-- "TextBlock.Text" binding is set in code-behind -->
+                                            </TextBlock>
+                                            <Button Background="Transparent" Width="16" Height="16" BorderThickness="0" Margin="12,0,0,0"
+                                                Click="TabCloseButton_OnClick" MouseEnter="TabCloseButton_MouseEnter" MouseLeave="TabCloseButton_MouseLeave">
+                                                <Button.Style>
+                                                    <Style TargetType="Button">
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding TabTitle, Mode=OneTime}" Value="Welcome!">
+                                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Button.Style>
+                                                <Image Source="/Resources/X.png"/>
+                                            </Button>
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </TabControl.ItemTemplate>
+                                <TabControl.ContentTemplate>
+                                    <DataTemplate DataType="{x:Type local:Tab}"/>
+                                </TabControl.ContentTemplate>
+                            </TabControl>
+                        </ScrollViewer>
+                        <StackPanel Grid.Column="1" Margin="5" Orientation="Horizontal" RenderOptions.BitmapScalingMode="NearestNeighbor">
+                            <StackPanel.Visibility>
+                                <MultiBinding Converter="{StaticResource CompareNumbersConverter}" ConverterParameter=">" Mode="OneWay">
+                                    <Binding Path="ActualWidth" Mode="OneWay" ElementName="TabController"/>
+                                    <Binding Path="ActualWidth" Mode="OneWay" ElementName="TabsGrid"/>
+                                </MultiBinding>
+                            </StackPanel.Visibility>
+                            <Button Width="16" Height="16" Click="TabsScrollLeftButton_Click">
+                                <Image Source="/Resources/tabs_left_button.png" Stretch="None"/>
+                            </Button>
+                            <Button Width="16" Height="16" Click="TabsScrollRightButton_Click">
+                                <Image Source="/Resources/tabs_right_button.png" Stretch="None"/>
+                            </Button>
+                        </StackPanel>
+                    </Grid>
+                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+                        <ContentControl Margin="10" Content="{Binding Selected, Mode=OneWay}" Name="DataEditor">
+                            <ContentControl.Resources>
+                                <DataTemplate DataType="{x:Type local:DescriptionView}">
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding Heading, Mode=OneWay}" FontWeight="Bold"/>
+                                        <Separator/>
+                                        <TextBlock Text="{Binding Description, Mode=OneWay}"/>
                                     </StackPanel>
                                 </DataTemplate>
-                            </TabControl.ItemTemplate>
-                            <TabControl.ContentTemplate>
-                                <DataTemplate DataType="{x:Type local:Tab}"/>
-                            </TabControl.ContentTemplate>
-                        </TabControl>
+
+                                <DataTemplate DataType="{x:Type local:GeneralInfoEditor}">
+                                    <local:UndertaleGeneralInfoEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate DataType="{x:Type local:GlobalInitEditor}">
+                                    <local:UndertaleGlobalInitEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate DataType="{x:Type local:GameEndEditor}">
+                                    <local:UndertaleGameEndEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate DataType="{x:Type undertale:UndertaleAudioGroup}">
+                                    <local:UndertaleAudioGroupEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate DataType="{x:Type undertale:UndertaleSound}">
+                                    <local:UndertaleSoundEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate DataType="{x:Type undertale:UndertaleBackground}">
+                                    <local:UndertaleBackgroundEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate DataType="{x:Type undertale:UndertaleEmbeddedTexture}">
+                                    <local:UndertaleEmbeddedTextureEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate DataType="{x:Type undertale:UndertaleEmbeddedAudio}">
+                                    <local:UndertaleEmbeddedAudioEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate DataType="{x:Type undertale:UndertaleTexturePageItem}">
+                                    <local:UndertaleTexturePageItemEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate DataType="{x:Type undertale:UndertaleEmbeddedImage}">
+                                    <local:UndertaleEmbeddedImageEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate DataType="{x:Type undertale:UndertaleTextureGroupInfo}">
+                                    <local:UndertaleTextureGroupInfoEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate DataType="{x:Type undertale:UndertaleSprite}">
+                                    <local:UndertaleSpriteEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate DataType="{x:Type undertale:UndertaleScript}">
+                                    <local:UndertaleScriptEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate DataType="{x:Type undertale:UndertaleShader}">
+                                    <local:UndertaleShaderEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate DataType="{x:Type undertale:UndertalePath}">
+                                    <local:UndertalePathEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate DataType="{x:Type undertale:UndertaleFont}">
+                                    <local:UndertaleFontEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate DataType="{x:Type undertale:UndertaleTimeline}">
+                                    <local:UndertaleTimelineEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate DataType="{x:Type undertale:UndertaleGameObject}">
+                                    <local:UndertaleGameObjectEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate x:Key="roomRendererTemplate">
+                                    <local:UndertaleRoomRenderer/>
+                                </DataTemplate>
+                                <DataTemplate DataType="{x:Type undertale:UndertaleRoom}">
+                                    <local:UndertaleRoomEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate DataType="{x:Type undertale:UndertaleExtension}">
+                                    <local:UndertaleExtensionEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate DataType="{x:Type undertale:UndertaleExtensionFile}">
+                                    <local:UndertaleExtensionFileEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate DataType="{x:Type undertale:UndertaleExtensionFunction}">
+                                    <local:UndertaleExtensionFunctionEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate DataType="{x:Type undertale:UndertaleCode}">
+                                    <local:UndertaleCodeEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate DataType="{x:Type undertale:UndertaleString}">
+                                    <local:UndertaleStringEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate DataType="{x:Type undertale:UndertaleVariable}">
+                                    <local:UndertaleVariableEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate DataType="{x:Type undertale:UndertaleFunction}">
+                                    <local:UndertaleFunctionEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate DataType="{x:Type undertale:UndertaleCodeLocals}">
+                                    <local:UndertaleCodeLocalsEditor/>
+                                </DataTemplate>
+
+                                <DataTemplate DataType="{x:Type undertalelib:UndertaleChunkVARI}">
+                                    <local:UndertaleVariableChunkEditor/>
+                                </DataTemplate>
+                            </ContentControl.Resources>
+                        </ContentControl>
                     </ScrollViewer>
-                    <StackPanel Grid.Column="1" Margin="5" Orientation="Horizontal" RenderOptions.BitmapScalingMode="NearestNeighbor">
-                        <StackPanel.Visibility>
-                            <MultiBinding Converter="{StaticResource CompareNumbersConverter}" ConverterParameter=">" Mode="OneWay">
-                                <Binding Path="ActualWidth" Mode="OneWay" ElementName="TabController"/>
-                                <Binding Path="ActualWidth" Mode="OneWay" ElementName="TabsGrid"/>
-                            </MultiBinding>
-                        </StackPanel.Visibility>
-                        <Button Width="16" Height="16" Click="TabsScrollLeftButton_Click">
-                            <Image Source="/Resources/tabs_left_button.png" Stretch="None"/>
-                        </Button>
-                        <Button Width="16" Height="16" Click="TabsScrollRightButton_Click">
-                            <Image Source="/Resources/tabs_right_button.png" Stretch="None"/>
-                        </Button>
-                    </StackPanel>
                 </Grid>
-                <ScrollViewer VerticalScrollBarVisibility="Auto" Grid.Column="2" Grid.Row="1">
-                    <ContentControl Margin="10" Content="{Binding Selected, Mode=OneWay}" Name="DataEditor">
-                        <ContentControl.Resources>
-                            <DataTemplate DataType="{x:Type local:DescriptionView}">
-                                <StackPanel>
-                                    <TextBlock Text="{Binding Heading, Mode=OneWay}" FontWeight="Bold"/>
-                                    <Separator/>
-                                    <TextBlock Text="{Binding Description, Mode=OneWay}"/>
-                                </StackPanel>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type local:GeneralInfoEditor}">
-                                <local:UndertaleGeneralInfoEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type local:GlobalInitEditor}">
-                                <local:UndertaleGlobalInitEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type local:GameEndEditor}">
-                                <local:UndertaleGameEndEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type undertale:UndertaleAudioGroup}">
-                                <local:UndertaleAudioGroupEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type undertale:UndertaleSound}">
-                                <local:UndertaleSoundEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type undertale:UndertaleBackground}">
-                                <local:UndertaleBackgroundEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type undertale:UndertaleEmbeddedTexture}">
-                                <local:UndertaleEmbeddedTextureEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type undertale:UndertaleEmbeddedAudio}">
-                                <local:UndertaleEmbeddedAudioEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type undertale:UndertaleTexturePageItem}">
-                                <local:UndertaleTexturePageItemEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type undertale:UndertaleEmbeddedImage}">
-                                <local:UndertaleEmbeddedImageEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type undertale:UndertaleTextureGroupInfo}">
-                                <local:UndertaleTextureGroupInfoEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type undertale:UndertaleSprite}">
-                                <local:UndertaleSpriteEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type undertale:UndertaleScript}">
-                                <local:UndertaleScriptEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type undertale:UndertaleShader}">
-                                <local:UndertaleShaderEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type undertale:UndertalePath}">
-                                <local:UndertalePathEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type undertale:UndertaleFont}">
-                                <local:UndertaleFontEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type undertale:UndertaleTimeline}">
-                                <local:UndertaleTimelineEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type undertale:UndertaleGameObject}">
-                                <local:UndertaleGameObjectEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate x:Key="roomRendererTemplate">
-                                <local:UndertaleRoomRenderer/>
-                            </DataTemplate>
-                            <DataTemplate DataType="{x:Type undertale:UndertaleRoom}">
-                                <local:UndertaleRoomEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type undertale:UndertaleExtension}">
-                                <local:UndertaleExtensionEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type undertale:UndertaleExtensionFile}">
-                                <local:UndertaleExtensionFileEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type undertale:UndertaleExtensionFunction}">
-                                <local:UndertaleExtensionFunctionEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type undertale:UndertaleCode}">
-                                <local:UndertaleCodeEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type undertale:UndertaleString}">
-                                <local:UndertaleStringEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type undertale:UndertaleVariable}">
-                                <local:UndertaleVariableEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type undertale:UndertaleFunction}">
-                                <local:UndertaleFunctionEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type undertale:UndertaleCodeLocals}">
-                                <local:UndertaleCodeLocalsEditor/>
-                            </DataTemplate>
-
-                            <DataTemplate DataType="{x:Type undertalelib:UndertaleChunkVARI}">
-                                <local:UndertaleVariableChunkEditor/>
-                            </DataTemplate>
-                        </ContentControl.Resources>
-                    </ContentControl>
-                </ScrollViewer>
             </Grid>
         </DockPanel>
     </Grid>

--- a/UndertaleModTool/MainWindow.xaml
+++ b/UndertaleModTool/MainWindow.xaml
@@ -149,7 +149,7 @@
                                     <Style TargetType="Image">
                                         <Style.Triggers>
                                             <Trigger Property="IsEnabled" Value="False">
-                                                <Setter Property="Opacity" Value="0.5" />
+                                                <Setter Property="Opacity" Value="0.2" />
                                             </Trigger>
                                             <Trigger Property="IsMouseOver" Value="False">
                                                 <Setter Property="Source" Value="/Resources/arrow_blue.png" />
@@ -177,7 +177,7 @@
                                     <Style TargetType="Image">
                                         <Style.Triggers>
                                             <Trigger Property="IsEnabled" Value="False">
-                                                <Setter Property="Opacity" Value="0.5" />
+                                                <Setter Property="Opacity" Value="0.2" />
                                             </Trigger>
                                             <Trigger Property="IsMouseOver" Value="False">
                                                 <Setter Property="Source" Value="/Resources/arrow_blue.png" />

--- a/UndertaleModTool/MainWindow.xaml
+++ b/UndertaleModTool/MainWindow.xaml
@@ -134,7 +134,7 @@
                         <Button.Style>
                             <Style TargetType="Button">
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding SelectionHistory.Count}" Value="0">
+                                    <DataTrigger Binding="{Binding CurrentTab.HistoryPosition}" Value="0">
                                         <Setter Property="IsEnabled" Value="False" />
                                     </DataTrigger>
                                 </Style.Triggers>

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -1846,7 +1846,10 @@ namespace UndertaleModTool
                 for (int i = 0; i < ClosedTabsHistory.Count - 1; i++)
                 {
                     if (ClosedTabsHistory[i] == ClosedTabsHistory[i + 1])
+                    {
                         ClosedTabsHistory.RemoveAt(i);
+                        i--;
+                    }
                 }
 
                 // remove all deleted object occurrences from all tab histories
@@ -1856,7 +1859,9 @@ namespace UndertaleModTool
                     {
                         if (tab.History[i] == obj)
                         {
-                            tab.HistoryPosition--;
+                            if (i < tab.HistoryPosition)
+                                tab.HistoryPosition--;
+
                             tab.History.RemoveAt(i);
                         }
                     }
@@ -1866,8 +1871,11 @@ namespace UndertaleModTool
                     {
                         if (tab.History[i] == tab.History[i + 1])
                         {
-                            tab.HistoryPosition--;
+                            if (i < tab.HistoryPosition)
+                                tab.HistoryPosition--;
+
                             tab.History.RemoveAt(i);
+                            i--;
                         } 
                     }
                 }
@@ -3388,36 +3396,9 @@ result in loss of work.");
             if (obj is DescriptionView && CurrentTab is not null && !CurrentTab.AutoClose)
                 return;
 
-            bool tabSwitched = true;
-
-            if (!isNewTab)
-            {
-                for (int i = 0; i < Tabs.Count; i++)
-                {
-                    if (Tabs[i].CurrentObject == obj)
-                    {
-                        if (i != CurrentTabIndex)
-                        {
-                            CurrentTabIndex = i;
-
-                            return;
-                        }
-                        else
-                            tabSwitched = false;
-
-                        break;
-                    }
-                }
-            }
-
-            if (tabSwitched)
-            {
-                // close auto-closing tab
-                if (Tabs.Count > 0 && CurrentTabIndex >= 0 && CurrentTab.AutoClose)
-                    CloseTab(CurrentTab.TabIndex, false);
-            }
-            else
-                return;
+            // close auto-closing tab
+            if (Tabs.Count > 0 && CurrentTabIndex >= 0 && CurrentTab.AutoClose)
+                CloseTab(CurrentTab.TabIndex, false);
 
             if (isNewTab || Tabs.Count == 0)
             {
@@ -3432,10 +3413,8 @@ result in loss of work.");
                 if (!TabController.IsLoaded)
                     CurrentTab = newTab;
             }
-            else
+            else if (obj != CurrentTab?.CurrentObject)
             {
-                CurrentTab = Tabs[CurrentTabIndex];
-
                 if (CurrentTab.HistoryPosition < CurrentTab.History.Count - 1)
                 {
                     // Remove all objects after the current one (overwrite)
@@ -3445,6 +3424,7 @@ result in loss of work.");
                 }
 
                 CurrentTab.CurrentObject = obj;
+                UpdateObjectLabel(obj);
 
                 CurrentTab.History.Add(obj);
                 CurrentTab.HistoryPosition++;
@@ -3535,7 +3515,7 @@ result in loss of work.");
 
         public void ChangeSelection(object newsel)
         {
-            OpenInTab(newsel, true);
+            OpenInTab(newsel);
         }
 
         private void TabController_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -231,7 +231,7 @@ namespace UndertaleModTool
 
                 // If both objects have the same type (one of above)
                 // or both objects are not "UndertaleNamedResource",
-                // then there's no need for changing the binding
+                // then there's no need to change the binding
                 if (pObjNamed && objNamed || pObjString && objString || !(pObjNamed || objNamed))
                     return;
             }

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -3265,6 +3265,10 @@ result in loss of work.");
         {
             GoBack();
         }
+        private void ForwardButton_Click(object sender, RoutedEventArgs e)
+        {
+            GoForward();
+        }
 
         public void EnsureDataLoaded()
         {

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -911,6 +911,14 @@ namespace UndertaleModTool
             if (CurrentTabIndex > 0)
                 CurrentTabIndex--;
         }
+        private void Command_GoBack(object sender, ExecutedRoutedEventArgs e)
+        {
+            GoBack();
+        }
+        private void Command_GoForward(object sender, ExecutedRoutedEventArgs e)
+        {
+            GoForward();
+        }
 
         private void DisposeGameData()
         {
@@ -3233,12 +3241,29 @@ result in loss of work.");
             }
         }
 
-        private void BackButton_Click(object sender, RoutedEventArgs e)
+        private void GoBack()
         {
+            if (CurrentTab.HistoryPosition == 0)
+                return;
+
             CurrentTab.HistoryPosition--;
             CurrentTab.CurrentObject = CurrentTab.History[CurrentTab.HistoryPosition];
 
             UpdateObjectLabel(CurrentTab.CurrentObject);
+        }
+        private void GoForward()
+        {
+            if (CurrentTab.HistoryPosition == CurrentTab.History.Count - 1)
+                return;
+
+            CurrentTab.HistoryPosition++;
+            CurrentTab.CurrentObject = CurrentTab.History[CurrentTab.HistoryPosition];
+
+            UpdateObjectLabel(CurrentTab.CurrentObject);
+        }
+        private void BackButton_Click(object sender, RoutedEventArgs e)
+        {
+            GoBack();
         }
 
         public void EnsureDataLoaded()
@@ -3347,6 +3372,8 @@ result in loss of work.");
                 Tabs.Add(newTab);
                 CurrentTabIndex = newIndex;
 
+                newTab.History.Add(obj);
+
                 if (!TabController.IsLoaded)
                     CurrentTab = newTab;
             }
@@ -3354,18 +3381,18 @@ result in loss of work.");
             {
                 CurrentTab = Tabs[CurrentTabIndex];
 
-                if (CurrentTab.HistoryPosition < CurrentTab.History.Count)
+                if (CurrentTab.HistoryPosition < CurrentTab.History.Count - 1)
                 {
                     // Remove all objects after the current one (overwrite)
-                    int count = CurrentTab.History.Count - CurrentTab.HistoryPosition;
+                    int count = CurrentTab.History.Count - CurrentTab.HistoryPosition - 1;
                     for (int i = 0; i < count; i++)
                         CurrentTab.History.RemoveAt(CurrentTab.History.Count - 1);
                 }
 
-                CurrentTab.History.Add(CurrentTab.CurrentObject);
-                CurrentTab.HistoryPosition++;
-
                 CurrentTab.CurrentObject = obj;
+
+                CurrentTab.History.Add(obj);
+                CurrentTab.HistoryPosition++;
             }
         }
 

--- a/UndertaleModTool/Scripts/Resource Unpackers/ExportAllRoomsToPng.csx
+++ b/UndertaleModTool/Scripts/Resource Unpackers/ExportAllRoomsToPng.csx
@@ -69,7 +69,7 @@ async Task DumpRooms()
 
         UndertaleRoom room = Data.Rooms[i];
 
-        mainWindow.Selected = room; 
+        mainWindow.CurrentTab.CurrentObject = room; 
 
         if (roomRenderer is null)
         {


### PR DESCRIPTION
## Description

1. **Tab history is now stored per-tab.**
2. **Tab history can be navigated through in both directions** - added "Forward" button; back and forward mouse buttons work.
3. `Tab.OpenedObject` is renamed to `Tab.CurrentObject`.
4. Added `MainWindow.OnPropertyChanged()`.
5. Fixed object re-opening after closing all tabs with "Close all tabs".
6. Fixed bug that in some cases broke the tab close button after closing other tabs with "Close other tabs".
7. "Open in new tab" option always opens a object in a new tab.
8. Asset items do always open in the current tab on double-click.
9. `ChangeSelection()` (used by `UndertaleObjectReference` and more) opens an object in the current tab.
10. The history navigation button(s) icon opacity is reduced.

### Notes
The  last sub-issue of #827 can be closed.