### PR TITLE
Add global grid width, height and thickness settings

### DIFF
--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -365,8 +365,9 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
     /// Initialize the room by setting every <see cref="Background.ParentRoom"/> or <see cref="Layer.ParentRoom"/>
     /// (depending on the GameMaker version), and optionally calculate the room grid size.
     /// </summary>
-    /// <param name="calculateGrid">Whether to calculate the room grid size.</param>
-    public void SetupRoom(bool calculateGrid = true)
+    /// <param name="calculateGridWidth">Whether to calculate the room grid width.</param>
+    /// <param name="calculateGridHeight">Whether to calculate the room grid height.</param>
+    public void SetupRoom(bool calculateGridWidth = true, bool calculateGridHeight = true)
     {
         foreach (Layer layer in Layers)
         {
@@ -376,54 +377,50 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
         foreach (UndertaleRoom.Background bgnd in Backgrounds)
             bgnd.ParentRoom = this;
 
-        if (calculateGrid)
+        if (!(calculateGridWidth || calculateGridHeight)) return;
+
+        // Automatically set the grid size to whatever most tiles are sized
+
+        Dictionary<Point, uint> tileSizes = new();
+        IEnumerable<Tile> tileList;
+
+        if (Layers.Count > 0)
         {
-            // Automagically set the grid size to whatever most tiles are sized
-
-            Dictionary<Point, uint> tileSizes = new();
-            IEnumerable<Tile> tileList;
-
-            if (Layers.Count > 0)
+            tileList = new List<Tile>();
+            foreach (Layer layer in Layers)
             {
-                tileList = new List<Tile>();
-                foreach (Layer layer in Layers)
+                if (layer.LayerType == LayerType.Assets)
+                    tileList = tileList.Concat(layer.AssetsData.LegacyTiles);
+                else if (layer.LayerType == LayerType.Tiles && layer.TilesData.TileData.Length != 0)
                 {
-                    if (layer.LayerType == LayerType.Assets)
-                        tileList = tileList.Concat(layer.AssetsData.LegacyTiles);
-                    else if (layer.LayerType == LayerType.Tiles && layer.TilesData.TileData.Length != 0)
-                    {
-                        int w = (int)(Width / layer.TilesData.TilesX);
-                        int h = (int)(Height / layer.TilesData.TilesY);
-                        tileSizes[new(w, h)] = layer.TilesData.TilesX * layer.TilesData.TilesY;
-                    }
-                }
-
-            }
-            else
-                tileList = Tiles;
-
-            // Loop through each tile and save how many times their sizes are used
-            foreach (Tile tile in tileList)
-            {
-                Point scale = new((int)tile.Width, (int)tile.Height);
-                if (tileSizes.ContainsKey(scale))
-                {
-                    tileSizes[scale]++;
-                }
-                else
-                {
-                    tileSizes.Add(scale, 1);
+                    int w = (int) (Width / layer.TilesData.TilesX);
+                    int h = (int) (Height / layer.TilesData.TilesY);
+                    tileSizes[new(w, h)] = layer.TilesData.TilesX * layer.TilesData.TilesY;
                 }
             }
 
-            // If tiles exist at all, grab the most used tile size and use that as our grid size
-            if (tileSizes.Count > 0)
-            {
-                var largestKey = tileSizes.Aggregate((x, y) => x.Value > y.Value ? x : y).Key;
-                GridWidth = largestKey.X;
-                GridHeight = largestKey.Y;
-            }
         }
+        else
+            tileList = Tiles;
+
+        // Loop through each tile and save how many times their sizes are used
+        foreach (Tile tile in tileList)
+        {
+            Point scale = new((int) tile.Width, (int) tile.Height);
+            if (tileSizes.ContainsKey(scale))
+                tileSizes[scale]++;
+            else
+                tileSizes.Add(scale, 1);
+        }
+
+        // If tiles exist at all, grab the most used tile size and use that as our grid size
+        if (tileSizes.Count <= 0) return;
+
+        var largestKey = tileSizes.Aggregate((x, y) => x.Value > y.Value ? x : y).Key;
+        if (calculateGridWidth)
+            GridWidth = largestKey.X;
+        if (calculateGridHeight)
+            GridHeight = largestKey.Y;
     }
 
     /// <inheritdoc />

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -413,9 +413,15 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
                 tileSizes.Add(scale, 1);
         }
 
-        // If tiles exist at all, grab the most used tile size and use that as our grid size
-        if (tileSizes.Count <= 0) return;
 
+        if (tileSizes.Count <= 0)
+        {
+            GridWidth = 16;
+            GridHeight = 16;
+            return;
+        }
+
+        // If tiles exist at all, grab the most used tile size and use that as our grid size
         var largestKey = tileSizes.Aggregate((x, y) => x.Value > y.Value ? x : y).Key;
         if (calculateGridWidth)
             GridWidth = largestKey.X;

--- a/UndertaleModTool/Controls/UndertaleRoomRenderer.xaml.cs
+++ b/UndertaleModTool/Controls/UndertaleRoomRenderer.xaml.cs
@@ -53,8 +53,11 @@ namespace UndertaleModTool
 
         private void RoomRenderer_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
-            (DataContext as UndertaleRoom)?.SetupRoom(!bgGridDisabled, !bgGridDisabled);
-            UndertaleRoomEditor.GenerateSpriteCache(DataContext as UndertaleRoom);
+            if (DataContext is not UndertaleRoom room)
+                return;
+
+            UndertaleRoomEditor.SetupRoomWithGrids(room);
+            UndertaleRoomEditor.GenerateSpriteCache(room);
         }
 
         private void RoomCanvas_Loaded(object sender, RoutedEventArgs e)

--- a/UndertaleModTool/Controls/UndertaleRoomRenderer.xaml.cs
+++ b/UndertaleModTool/Controls/UndertaleRoomRenderer.xaml.cs
@@ -53,7 +53,7 @@ namespace UndertaleModTool
 
         private void RoomRenderer_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
-            (DataContext as UndertaleRoom)?.SetupRoom(!bgGridDisabled);
+            (DataContext as UndertaleRoom)?.SetupRoom(!bgGridDisabled, !bgGridDisabled);
             UndertaleRoomEditor.GenerateSpriteCache(DataContext as UndertaleRoom);
         }
 

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -185,7 +185,7 @@ namespace UndertaleModTool
                 GameObjItems.Header = room.Flags.HasFlag(RoomEntryFlags.IsGMS2)
                                       ? "Game objects (from all layers)"
                                       : "Game objects";
-                this.SetupRoomWithGrids(room);
+                SetupRoomWithGrids(room);
                 GenerateSpriteCache(DataContext as UndertaleRoom);
 
                 if (room.Layers.Count > 0) // if GMS 2+
@@ -476,7 +476,7 @@ namespace UndertaleModTool
                 }
 
                 // recalculates room grid size
-                this.SetupRoomWithGrids(room);
+                SetupRoomWithGrids(room);
             }
             else if (obj is GameObject gameObj)
             {
@@ -1692,14 +1692,20 @@ namespace UndertaleModTool
                 ObjElemDict.Remove(canvas.CurrentLayer);
         }
 
-        private void SetupRoomWithGrids(UndertaleRoom room)
+        public static void SetupRoomWithGrids(UndertaleRoom room)
         {
             if (Settings.Instance.GridWidthEnabled)
                 room.GridWidth = Settings.Instance.GlobalGridWidth;
             if (Settings.Instance.GridHeightEnabled)
                 room.GridHeight = Settings.Instance.GlobalGridHeight;
+
+            // SetupRoom already overrides GridWidth and GridHeight if the global setting is disabled, but does
+            // not do that for the thickness. Hence why we're overriding it here manually to the default value should
+            // the setting be disabled.
             if (Settings.Instance.GridThicknessEnabled)
                 room.GridThicknessPx = Settings.Instance.GlobalGridThickness;
+            else
+                room.GridThicknessPx = 1;
             room.SetupRoom(!Settings.Instance.GridWidthEnabled, !Settings.Instance.GridHeightEnabled);
         }
     }

--- a/UndertaleModTool/Settings.cs
+++ b/UndertaleModTool/Settings.cs
@@ -42,6 +42,14 @@ namespace UndertaleModTool
         public bool DeleteOldProfileOnSave { get; set; } = false;
         public bool WarnOnClose { get; set; } = true;
 
+        public double GlobalGridWidth { get; set; } = 20;
+        public bool GridWidthEnabled { get; set; } = false;
+        public double GlobalGridHeight { get; set; } = 20;
+        public bool GridHeightEnabled { get; set; } = false;
+
+        public double GlobalGridThickness { get; set; } = 1;
+        public bool GridThicknessEnabled { get; set; } = false;
+
         public static Settings Instance;
 
         public static JsonSerializerOptions JsonOptions = new JsonSerializerOptions

--- a/UndertaleModTool/Windows/SettingsWindow.xaml
+++ b/UndertaleModTool/Windows/SettingsWindow.xaml
@@ -41,19 +41,19 @@
             <TextBlock Grid.Row="2" Grid.Column="0" Margin="3" Text="Game Maker: Studio 2 runtimes path" ToolTip="Required only if you want to run GMS2 games using the Studio runner rather than the .exe"/>
             <TextBox Grid.Row="2" Grid.Column="1" Margin="3" Grid.ColumnSpan="3" Text="{Binding GameMakerStudio2RuntimesPath}"/>
 
-            <CheckBox Grid.Row="3" Grid.Column="0" Margin="3"  Content="" IsChecked="{Binding AssetOrderSwappingEnabled}"/>
+            <CheckBox Grid.Row="3" Grid.Column="0" Margin="3" Content="" IsChecked="{Binding AssetOrderSwappingEnabled}"/>
             <TextBlock Grid.Row="3" Grid.Column="0" Margin="25 2 2 2" Text="Enable asset order swapping" ToolTip="Toggles dragging &amp; dropping assets in the asset tabs to different positions in the list. Disabled by default."/>
-            <CheckBox Grid.Row="3" Grid.Column="2" Margin="3"  Content="" IsChecked="{Binding WarnOnClose}"/>
+            <CheckBox Grid.Row="3" Grid.Column="2" Margin="3" Content="" IsChecked="{Binding WarnOnClose}"/>
             <TextBlock Grid.Row="3" Grid.Column="2" Margin="25 2 2 2" Text="Warn about saving before closing" ToolTip="Warn about saving before closing. Enabled by default."/>
 
             <CheckBox Grid.Row="4" Grid.Column="0" Margin="3" Content="" IsChecked="{Binding AutomaticFileAssociation}"/>
             <TextBlock Grid.Row="4" Grid.Column="0" Margin="25 2 2 2" Text="Automatically associate .win files" ToolTip="Automatic file association. Enabled by default."/>
-            <CheckBox Grid.Row="4" Grid.Column="2" Margin="3" Content=""  IsChecked="{Binding TempRunMessageShow}"/>
+            <CheckBox Grid.Row="4" Grid.Column="2" Margin="3" Content="" IsChecked="{Binding TempRunMessageShow}"/>
             <TextBlock Grid.Row="4" Grid.Column="2" Margin="25 2 2 2" Text="Warn about temp running" ToolTip="Warn about temp running. Enabled by default."/>
 
-            <CheckBox Grid.Row="5" Grid.Column="0" Margin="3"  Content="" IsChecked="{Binding Warn_About_GMS23}"/>
+            <CheckBox Grid.Row="5" Grid.Column="0" Margin="3" Content="" IsChecked="{Binding Warn_About_GMS23}"/>
             <TextBlock Grid.Row="5" Grid.Column="0" Margin="25 2 2 2" Text="Warn about GMS 2.3" ToolTip="Warn about GMS 2.3. Enabled by default."/>
-            <CheckBox Grid.Row="5" Grid.Column="2" Margin="3"  Content="" IsChecked="{Binding UseGMLCache}"/>
+            <CheckBox Grid.Row="5" Grid.Column="2" Margin="3" Content="" IsChecked="{Binding UseGMLCache}"/>
             <TextBlock Grid.Row="5" Grid.Column="2" Margin="25 2 2 2" Text="Use decompiled code cache (experimental)" ToolTip="Used by some scripts (e.g. &quot;Search.csx&quot;) for acceleration. Disabled by default."/>
 
             <Separator Grid.Row="6" Grid.ColumnSpan="4" Margin="10"/>
@@ -67,7 +67,7 @@
             <TextBox Grid.Row="8" Grid.Column="1" Margin="3" IsEnabled="{Binding ElementName=gridHeightCheckbox, Path=IsChecked}" Text="{Binding GlobalGridHeight}"/>
 
             <CheckBox Grid.Row="7" Grid.Column="2" Margin="3" VerticalAlignment="Center" Name="gridThicknessCheckBox" Content="" IsChecked="{Binding GridThicknessEnabled}"/>
-            <TextBlock Grid.Row="7" Grid.Column="2" Margin="25 2 2 2"  VerticalAlignment="Center" Text="Global grid thickness" ToolTip="This option globally overrides the automatic assignment of a room's grid thickness."/>
+            <TextBlock Grid.Row="7" Grid.Column="2" Margin="25 2 2 2" VerticalAlignment="Center" Text="Global grid thickness" ToolTip="This option globally overrides the automatic assignment of a room's grid thickness."/>
             <TextBox Grid.Row="7" Grid.Column="3" Margin="3" IsEnabled="{Binding ElementName=gridThicknessCheckBox, Path=IsChecked}" Text="{Binding GlobalGridThickness}"/>
 
             <Separator Grid.Row="11" Grid.ColumnSpan="4" Margin="10"/>

--- a/UndertaleModTool/Windows/SettingsWindow.xaml
+++ b/UndertaleModTool/Windows/SettingsWindow.xaml
@@ -41,36 +41,47 @@
             <TextBlock Grid.Row="2" Grid.Column="0" Margin="3" Text="Game Maker: Studio 2 runtimes path" ToolTip="Required only if you want to run GMS2 games using the Studio runner rather than the .exe"/>
             <TextBox Grid.Row="2" Grid.Column="1" Margin="3" Grid.ColumnSpan="3" Text="{Binding GameMakerStudio2RuntimesPath}"/>
 
-            <CheckBox Grid.Row="3" Grid.Column="0" Margin="3" Content="" IsChecked="{Binding AssetOrderSwappingEnabled}"/>
-            <TextBlock Grid.Row="3" Grid.Column="0" Margin="25 2 2 2"  Text="Enable asset order swapping" ToolTip="Toggles dragging &amp; dropping assets in the asset tabs to different positions in the list. Disabled by default."/>
-            <CheckBox Grid.Row="3" Grid.Column="2" Margin="3" Content="" IsChecked="{Binding WarnOnClose}"/>
+            <CheckBox Grid.Row="3" Grid.Column="0" Margin="3"  Content="" IsChecked="{Binding AssetOrderSwappingEnabled}"/>
+            <TextBlock Grid.Row="3" Grid.Column="0" Margin="25 2 2 2" Text="Enable asset order swapping" ToolTip="Toggles dragging &amp; dropping assets in the asset tabs to different positions in the list. Disabled by default."/>
+            <CheckBox Grid.Row="3" Grid.Column="2" Margin="3"  Content="" IsChecked="{Binding WarnOnClose}"/>
             <TextBlock Grid.Row="3" Grid.Column="2" Margin="25 2 2 2" Text="Warn about saving before closing" ToolTip="Warn about saving before closing. Enabled by default."/>
 
             <CheckBox Grid.Row="4" Grid.Column="0" Margin="3" Content="" IsChecked="{Binding AutomaticFileAssociation}"/>
             <TextBlock Grid.Row="4" Grid.Column="0" Margin="25 2 2 2" Text="Automatically associate .win files" ToolTip="Automatic file association. Enabled by default."/>
-            <CheckBox Grid.Row="4" Grid.Column="2" Margin="3" Content="" IsChecked="{Binding TempRunMessageShow}"/>
+            <CheckBox Grid.Row="4" Grid.Column="2" Margin="3" Content=""  IsChecked="{Binding TempRunMessageShow}"/>
             <TextBlock Grid.Row="4" Grid.Column="2" Margin="25 2 2 2" Text="Warn about temp running" ToolTip="Warn about temp running. Enabled by default."/>
 
-            <CheckBox Grid.Row="5" Grid.Column="0" Margin="3" Content="" IsChecked="{Binding Warn_About_GMS23}"/>
+            <CheckBox Grid.Row="5" Grid.Column="0" Margin="3"  Content="" IsChecked="{Binding Warn_About_GMS23}"/>
             <TextBlock Grid.Row="5" Grid.Column="0" Margin="25 2 2 2" Text="Warn about GMS 2.3" ToolTip="Warn about GMS 2.3. Enabled by default."/>
-            <CheckBox Grid.Row="5" Grid.Column="2" Margin="3" Content="" IsChecked="{Binding UseGMLCache}"/>
+            <CheckBox Grid.Row="5" Grid.Column="2" Margin="3"  Content="" IsChecked="{Binding UseGMLCache}"/>
             <TextBlock Grid.Row="5" Grid.Column="2" Margin="25 2 2 2" Text="Use decompiled code cache (experimental)" ToolTip="Used by some scripts (e.g. &quot;Search.csx&quot;) for acceleration. Disabled by default."/>
 
+            <Separator Grid.Row="6" Grid.ColumnSpan="4" Margin="10"/>
 
+            <CheckBox Grid.Row="7" Grid.Column="0" Margin="3" VerticalAlignment="Center" Name="gridWidthCheckbox" Content="" IsChecked="{Binding GridWidthEnabled}"/>
+            <TextBlock Grid.Row="7" Grid.Column="0" Margin="25 2 2 2" VerticalAlignment="Center" Text="Global grid width" ToolTip="This option globally overrides the automatic assignment of a room's grid width based on the most used tile's width in that room."/>
+            <TextBox Grid.Row="7" Grid.Column="1" Margin="3" IsEnabled="{Binding ElementName=gridWidthCheckbox, Path=IsChecked}" Text="{Binding GlobalGridWidth}"/>
+
+            <CheckBox Grid.Row="8" Grid.Column="0" Margin="3" VerticalAlignment="Center" Name="gridHeightCheckbox" Content="" IsChecked="{Binding GridHeightEnabled}"/>
+            <TextBlock Grid.Row="8" Grid.Column="0" Margin="25 2 2 2"  VerticalAlignment="Center" Text="Global grid height" ToolTip="This option globally overrides the automatic assignment of a room's grid height based on the most used tile's height in that room."/>
+            <TextBox Grid.Row="8" Grid.Column="1" Margin="3" IsEnabled="{Binding ElementName=gridHeightCheckbox, Path=IsChecked}" Text="{Binding GlobalGridHeight}"/>
+
+            <CheckBox Grid.Row="7" Grid.Column="2" Margin="3" VerticalAlignment="Center" Name="gridThicknessCheckBox" Content="" IsChecked="{Binding GridThicknessEnabled}"/>
+            <TextBlock Grid.Row="7" Grid.Column="2" Margin="25 2 2 2"  VerticalAlignment="Center" Text="Global grid thickness" ToolTip="This option globally overrides the automatic assignment of a room's grid thickness."/>
+            <TextBox Grid.Row="7" Grid.Column="3" Margin="3" IsEnabled="{Binding ElementName=gridThicknessCheckBox, Path=IsChecked}" Text="{Binding GlobalGridThickness}"/>
 
             <Separator Grid.Row="11" Grid.ColumnSpan="4" Margin="10"/>
 
-
             <TextBlock Grid.Row="12" Grid.Column="0" Grid.ColumnSpan="4" Margin="3" TextWrapping="Wrap" Foreground="Red" FontWeight="Bold" Text="Warning: the following options are currently experimental, as the profile system is a work in progress. Usage of the system is at your own risk, and though it is relatively stable, it may not be compatible in the future."/>
 
-            <CheckBox Grid.Row="13" Grid.Column="0" Margin="3" Content="" IsChecked="{Binding ProfileModeEnabled}"/>
-            <TextBlock Grid.Row="13" Grid.Column="0" Margin="25 2 2 2" Text="Enable profile mode" ToolTip="Toggles the 'decompile once and compile many' profile mode. Enabled by default. May need to be disabled for certain operations."/>
+            <CheckBox Grid.Row="13" Grid.Column="0" Margin="3" VerticalAlignment="Center" Content="" IsChecked="{Binding ProfileModeEnabled}"/>
+            <TextBlock Grid.Row="13" Grid.Column="0" Margin="25 2 2 2" VerticalAlignment="Center" Text="Enable profile mode" ToolTip="Toggles the 'decompile once and compile many' profile mode. Enabled by default. May need to be disabled for certain operations."/>
 
-            <CheckBox Grid.Row="13" Grid.Column="2" Margin="3" Content="" IsChecked="{Binding ProfileMessageShown}"/>
-            <TextBlock Grid.Row="13" Grid.Column="2" Margin="25 2 2 2" Text="Profile mode message shown" ToolTip="On first load, this will show you the profile mode loaded message. If this somehow breaks, you can manually toggle it here."/>
+            <CheckBox Grid.Row="13" Grid.Column="2" Margin="3" VerticalAlignment="Center" Content="" IsChecked="{Binding ProfileMessageShown}"/>
+            <TextBlock Grid.Row="13" Grid.Column="2" Margin="25 2 2 2" VerticalAlignment="Center" Text="Profile mode message shown" ToolTip="On first load, this will show you the profile mode loaded message. If this somehow breaks, you can manually toggle it here."/>
 
-            <CheckBox Grid.Row="15" Grid.Column="0" Margin="3" Content="" IsChecked="{Binding DeleteOldProfileOnSave}"/>
-            <TextBlock Grid.Row="15" Grid.Column="0" Margin="25 2 2 2" Text="Delete old profile on saving" ToolTip="Deletes the profile obsoleted on saving. Saves on file space at the expense of losing code information for variants. Enabled by default."/>
+            <CheckBox Grid.Row="15" Grid.Column="0" Margin="3" VerticalAlignment="Center" Content="" IsChecked="{Binding DeleteOldProfileOnSave}"/>
+            <TextBlock Grid.Row="15" Grid.Column="0" Margin="25 2 2 2" VerticalAlignment="Center" Text="Delete old profile on saving" ToolTip="Deletes the profile obsoleted on saving. Saves on file space at the expense of losing code information for variants. Enabled by default."/>
 
             <Separator Grid.Row="16" Grid.ColumnSpan="4" Margin="10"/>
             <Button Grid.Row="17" Grid.Column="0" Grid.ColumnSpan="1" Margin="5" Click="AppDataButton_Click">Open application data folder</Button>

--- a/UndertaleModTool/Windows/SettingsWindow.xaml.cs
+++ b/UndertaleModTool/Windows/SettingsWindow.xaml.cs
@@ -129,6 +129,66 @@ namespace UndertaleModTool
             }
         }
 
+        public static double GlobalGridWidth
+        {
+            get => Settings.Instance.GlobalGridWidth;
+            set
+            {
+                Settings.Instance.GlobalGridWidth = value;
+                Settings.Save();
+            }
+        }
+
+        public static bool GridWidthEnabled
+        {
+            get => Settings.Instance.GridWidthEnabled;
+            set
+            {
+                Settings.Instance.GridWidthEnabled = value;
+                Settings.Save();
+            }
+        }
+
+        public static double GlobalGridHeight
+        {
+            get => Settings.Instance.GlobalGridHeight;
+            set
+            {
+                Settings.Instance.GlobalGridHeight = value;
+                Settings.Save();
+            }
+        }
+
+        public static bool GridHeightEnabled
+        {
+            get => Settings.Instance.GridHeightEnabled;
+            set
+            {
+                Settings.Instance.GridHeightEnabled = value;
+                Settings.Save();
+            }
+        }
+
+        public static double GlobalGridThickness
+        {
+            get => Settings.Instance.GlobalGridThickness;
+            set
+            {
+                Settings.Instance.GlobalGridThickness = value;
+                Settings.Save();
+            }
+        }
+
+        public static bool GridThicknessEnabled
+        {
+            get => Settings.Instance.GridThicknessEnabled;
+            set
+            {
+                Settings.Instance.GridThicknessEnabled = value;
+                Settings.Save();
+            }
+        }
+
         public bool UpdateButtonEnabled
         {
             get => UpdateAppButton.IsEnabled;


### PR DESCRIPTION
## Description
This PR adds global room grid width, height and thickness settings, which override the automatically calculated grid width / height and hardcoded grid thickness.

### Caveats
None

### Notes
This is Change 2 of #931.