### PR TITLE
Room editor grid width/height fixes.

### DIFF
--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -101,6 +101,9 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
     public uint Right { get; set; } = 1024;
     public uint Bottom { get; set; } = 768;
 
+    private double _gridWidth = 16.0;
+    private double _gridHeight = 16.0;
+
     /// <summary>
     /// The gravity towards x axis using room physics in m/s.
     /// </summary>
@@ -119,12 +122,12 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
     /// <summary>
     /// The width of the room grid in pixels.
     /// </summary>
-    public double GridWidth { get; set; } = 16d;
+    public double GridWidth { get => _gridWidth; set { if (value >= 0) _gridWidth = value; } }
 
     /// <summary>
     /// The height of the room grid in pixels.
     /// </summary>
-    public double GridHeight { get; set; } = 16d;
+    public double GridHeight { get => _gridHeight; set { if (value >= 0) _gridHeight = value; } }
 
     /// <summary>
     /// The thickness of the room grid in pixels.
@@ -416,8 +419,10 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
 
         if (tileSizes.Count <= 0)
         {
-            GridWidth = 16;
-            GridHeight = 16;
+            if (calculateGridWidth)
+                GridWidth = 16;
+            if (calculateGridHeight)
+                GridHeight = 16;
             return;
         }
 

--- a/UndertaleModTool/Settings.cs
+++ b/UndertaleModTool/Settings.cs
@@ -42,9 +42,11 @@ namespace UndertaleModTool
         public bool DeleteOldProfileOnSave { get; set; } = false;
         public bool WarnOnClose { get; set; } = true;
 
-        public double GlobalGridWidth { get; set; } = 20;
+        private double _globalGridWidth = 20;
+        private double _globalGridHeight = 20;
+        public double GlobalGridWidth { get => _globalGridWidth; set { if (value >= 0) _globalGridWidth = value; } }
         public bool GridWidthEnabled { get; set; } = false;
-        public double GlobalGridHeight { get; set; } = 20;
+        public double GlobalGridHeight { get => _globalGridHeight; set { if (value >= 0) _globalGridHeight = value; } }
         public bool GridHeightEnabled { get; set; } = false;
 
         public double GlobalGridThickness { get; set; } = 1;


### PR DESCRIPTION
## Description

1. Fixed a bug, when the global room editor grid width and height settings don't affect the room without tiles.
2. Fixed a crash on negative room editor grid width and height.

Closes #1002 