### PR TITLE
Room layers depth related issues fix.

### DIFF
--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -169,27 +169,22 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
     public void UpdateBGColorLayer() => OnPropertyChanged("BGColorLayer");
 
     /// <summary>
-    /// Checks whether the room layers list is ordered by <see cref="Layer.LayerDepth"/>.
+    /// Checks whether <see cref="Layers"/> is ordered by <see cref="Layer.LayerDepth"/>.
     /// </summary>
-    /// <returns><see langword="true"/> if the room layers list is ordered, and <see langword="false"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if <see cref="Layers"/> is ordered, and <see langword="false"/> otherwise.</returns>
     public bool CheckLayersDepthOrder()
     {
-        bool ordered = true;
-
         for (int i = 0; i < Layers.Count - 1; i++)
         {
             if (Layers[i].LayerDepth > Layers[i + 1].LayerDepth)
-            {
-                ordered = false;
-                break;
-            }
+                return false;
         }
 
-        return ordered;
+        return true;
     }
 
     /// <summary>
-    /// Orders the room layers list by depth.
+    /// Orders <see cref="Layers"/> by depth.
     /// </summary>
     /// <param name="layerProperties">
     /// A <see cref="Tuple"/> that consists of: the selected layer (in the room editor), ordered layers array and selected layer index.

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -169,19 +169,55 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
     public void UpdateBGColorLayer() => OnPropertyChanged("BGColorLayer");
 
     /// <summary>
+    /// Checks whether the room layers list is ordered by <see cref="Layer.LayerDepth"/>.
+    /// </summary>
+    /// <returns><see langword="true"/> if the room layers list is ordered, and <see langword="false"/> otherwise.</returns>
+    public bool CheckLayersDepthOrder()
+    {
+        bool ordered = true;
+
+        for (int i = 0; i < Layers.Count - 1; i++)
+        {
+            if (Layers[i].LayerDepth > Layers[i + 1].LayerDepth)
+            {
+                ordered = false;
+                break;
+            }
+        }
+
+        return ordered;
+    }
+
+    /// <summary>
     /// Orders the room layers list by depth.
     /// </summary>
-    /// <param name="selectedLayer">A <see cref="Layer"/> that's currently selected in the room editor.</param>
-    public void RearrangeLayers(Layer selectedLayer = null)
+    /// <param name="layerProperties">
+    /// A <see cref="Tuple"/> that consists of: the selected layer (in the room editor), ordered layers array and selected layer index.
+    /// This parameter is used only by <c>LayerZIndexConverter</c> (part of the room editor UI).
+    /// </param>
+    public void RearrangeLayers(Tuple<Layer, Layer[], int> layerProperties = null)
     {
         if (Layers.Count == 0)
             return;
 
-        Layer[] orderedLayers = Layers.OrderBy(l => l.LayerDepth).ToArray();
+        Layer[] orderedLayers = null;
+        Layer selectedLayer = null;
+        int selectedLayerIndex = -1;
+        if (layerProperties is not null)
+        {
+            orderedLayers = layerProperties.Item2;
+            selectedLayer = layerProperties.Item1;
+            selectedLayerIndex = layerProperties.Item3;
+        }
+        else
+        {
+            orderedLayers = Layers.OrderBy(l => l.LayerDepth).ToArray();
+            selectedLayerIndex = Array.IndexOf(orderedLayers, selectedLayer);
+        }
 
         // Ensure that room objects tree will have the layer to re-select
         if (selectedLayer is not null)
-            Layers[Array.IndexOf(orderedLayers, selectedLayer)] = selectedLayer;
+            Layers[selectedLayerIndex] = selectedLayer;
 
         for (int i = 0; i < orderedLayers.Length; i++)
         {

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -103,31 +103,6 @@ namespace UndertaleModTool
             visualOffProp.SetValue(roomCanvas, prevOffset);
         }
 
-        /// <summary>
-        /// Checks if the room layers are ordered by depth. If they are not, the user will be prompted,
-        /// whether they want to rearrange them.
-        /// </summary>
-        /// <param name="room">The <see cref="UndertaleRoom"/>, whose layers should be checked and,
-        /// if necessary, rearranged.</param>
-        public static void CheckAndRearrangeLayers(UndertaleRoom room)
-        {
-            bool ordered = true;
-            for (int i = 0; i < room.Layers.Count - 1; i++)
-            {
-                if (room.Layers[i].LayerDepth > room.Layers[i + 1].LayerDepth)
-                {
-                    ordered = false;
-                    break;
-                }
-            }
-
-            if (!ordered)
-            {
-                if (mainWindow.ShowQuestion("Room layers are not ordered by depth.\nRearrange them?", MessageBoxImage.Warning) == MessageBoxResult.Yes)
-                    room.RearrangeLayers();
-            }
-        }
-
         private void ExportAsPNG_Click(object sender, RoutedEventArgs e)
         {
             SaveFileDialog dlg = new();
@@ -192,8 +167,8 @@ namespace UndertaleModTool
                 {
                     LayerZIndexConverter.ProcessOnce = true;
 
-                    if (IsLoaded)
-                        CheckAndRearrangeLayers(room);
+                    if (!room.CheckLayersDepthOrder())
+                        room.RearrangeLayers();
 
                     Parallel.ForEach(room.Layers, (layer) =>
                     {
@@ -1315,9 +1290,12 @@ namespace UndertaleModTool
             room.Layers.Add(layer);
             room.UpdateBGColorLayer();
 
-            LayerZIndexConverter.ProcessOnce = true;
-            foreach (Layer l in room.Layers)
-                l.UpdateZIndex();
+            if (room.Layers.Count > 1)
+            {
+                LayerZIndexConverter.ProcessOnce = true;
+                foreach (Layer l in room.Layers)
+                    l.UpdateZIndex();
+            }
             layer.ParentRoom = room;
 
             if (layer.LayerType == LayerType.Assets)
@@ -1852,11 +1830,24 @@ namespace UndertaleModTool
 
         private static bool suspended;
         private static int remainingCount = -1;
+        private static Layer selectedLayer;
+        private static int selectedLayerIndex = -1;
+
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
             if (values[0] is Layer layer && layer.ParentRoom is UndertaleRoom room)
             {
-                int layerIndex = room.Layers.Count - room.Layers.IndexOf(layer) - 1;
+                int layerZIndex, layerIndex;
+                if (layer == selectedLayer && selectedLayerIndex != -1)
+                {
+                    layerIndex = selectedLayerIndex;
+                }
+                else
+                {
+                    layerIndex = room.Layers.IndexOf(layer);
+                }
+
+                layerZIndex = room.Layers.Count - layerIndex - 1;
 
                 if (ProcessOnce)
                 {
@@ -1873,28 +1864,28 @@ namespace UndertaleModTool
                         }
                     }
                 }
-                else if (!suspended)
+                else if (!suspended && room.Layers.Count > 1)
                 {
-                    bool ordered = true;
-                    for (int i = 0; i < room.Layers.Count - 1; i++)
-                    {
-                        if (room.Layers[i].LayerDepth > room.Layers[i + 1].LayerDepth)
-                        {
-                            ordered = false;
-                            break;
-                        }
-                    }
-
-                    if (!ordered)
+                    if (!room.CheckLayersDepthOrder())
                     {
                         suspended = true;
+
                         var roomEditor = MainWindow.FindVisualChild<UndertaleRoomEditor>((Application.Current.MainWindow as MainWindow).DataEditor);
-                        room.RearrangeLayers(roomEditor?.RoomObjectsTree.SelectedItem as Layer);
+                        selectedLayer = roomEditor?.RoomObjectsTree.SelectedItem as Layer;
+                        
+                        if (selectedLayer is not null)
+                        {
+                            Layer[] orderedLayers = room.Layers.OrderBy(l => l.LayerDepth).ToArray();
+                            selectedLayerIndex = Array.IndexOf(orderedLayers, selectedLayer);
+                            room.RearrangeLayers(new(selectedLayer, orderedLayers, selectedLayerIndex));
+                            selectedLayerIndex = -1;
+                        }
+
                         suspended = false;
                     }
                 }
 
-                return layerIndex;
+                return layerZIndex;
             }
             else
                 return -1;

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -1839,13 +1839,9 @@ namespace UndertaleModTool
             {
                 int layerZIndex, layerIndex;
                 if (layer == selectedLayer && selectedLayerIndex != -1)
-                {
                     layerIndex = selectedLayerIndex;
-                }
                 else
-                {
                     layerIndex = room.Layers.IndexOf(layer);
-                }
 
                 layerZIndex = room.Layers.Count - layerIndex - 1;
 

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -1654,9 +1654,6 @@ namespace UndertaleModTool
 
         private void MainTree_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            if (Highlighted is UndertaleRoom room && Selected is not UndertaleRoom)
-                UndertaleRoomEditor.CheckAndRearrangeLayers(room);
-
             OpenInTab(Highlighted);
         }
         private void MainTree_MouseDown(object sender, MouseButtonEventArgs e)
@@ -1678,9 +1675,6 @@ namespace UndertaleModTool
 
                 if (item.DataContext is not UndertaleResource)
                     return;
-
-                if (Highlighted is UndertaleRoom room && Selected is not UndertaleRoom)
-                    UndertaleRoomEditor.CheckAndRearrangeLayers(room);
 
                 OpenInTab(Highlighted, true);
             }


### PR DESCRIPTION
## Description

1. Fixed #1011.
2. Removed layer rearrangement prompt on room open - the layers always will be rearranged if they are not ordered.
3. Added `UndertaleRoom.CheckLayersDepthOrder()`.
4. Fixed broken layer rearrangement/depth rendering issue for an empty room.