### PR TITLE
Easier deletion of a room object.

### DIFF
--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -867,6 +867,7 @@ namespace UndertaleModTool
                 if (resListView.ItemContainerGenerator.ContainerFromItem(obj1) is TreeViewItem resItem)
                 {
                     resItem.IsSelected = true;
+                    resItem.Focus();
 
                     mainTreeViewer.UpdateLayout();
                     mainTreeViewer.ScrollToHorizontalOffset(0);


### PR DESCRIPTION
## Description
Clicking to an object in room editor preview properly selects the corresponding item in the object list.
This allows deleting it just by clicking on it in the preview and pressing `Delete`.

## Notes
This is the last part of https://github.com/krzys-h/UndertaleModTool/pull/931