### PR TITLE
Make version conform to previous scheme

### DIFF
--- a/UndertaleModLib/Properties/AssemblyInfo.cs
+++ b/UndertaleModLib/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // Możesz określić wszystkie wartości lub użyć domyślnych numerów kompilacji i poprawki
 // przy użyciu symbolu „*”, tak jak pokazano poniżej:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.5.0")]
-[assembly: AssemblyFileVersion("0.5.0")]
+[assembly: AssemblyVersion("0.5.0.0")]
+[assembly: AssemblyFileVersion("0.5.0.0")]

--- a/UndertaleModTool/Properties/AssemblyInfo.cs
+++ b/UndertaleModTool/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // Możesz określić wszystkie wartości lub użyć domyślnych numerów kompilacji i poprawki
 // przy użyciu symbolu „*”, tak jak pokazano poniżej:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.5.0")]
-[assembly: AssemblyFileVersion("0.5.0")]
+[assembly: AssemblyVersion("0.5.0.0")]
+[assembly: AssemblyFileVersion("0.5.0.0")]


### PR DESCRIPTION
## Description
The previous version scheme was `X.X.X.X`, the last PRs changed it to `X.X.X`.
This PR fixes that and uses the previous versioning scheme again.
