### PR TITLE
Correctly set the names of sub-functions.

### DIFF
--- a/UndertaleModLib/Decompiler/Decompiler.cs
+++ b/UndertaleModLib/Decompiler/Decompiler.cs
@@ -1373,7 +1373,15 @@ namespace UndertaleModLib.Decompiler
                         if (IsStatement)
                         {
                             sb.Append(" ");
-                            sb.Append((context.Statements[0].Last() as AssignmentStatement).Destination.Var.Name.Content);
+                            
+                            string funcName = (context.Statements[0].Last() as AssignmentStatement).Destination.Var.Name.Content;
+                            Dictionary<string, UndertaleFunction> subFuncs = context.GlobalContext.Data.KnownSubFunctions;
+                            KeyValuePair<string, UndertaleFunction> kvp = subFuncs.FirstOrDefault(x => x.Value == Function);
+
+                            if (kvp.Key != null)
+                                funcName = kvp.Key;
+                            
+                            sb.Append(funcName);
                         }
                         sb.Append("(");
                         for (int i = 0; i < FunctionBodyCodeEntry.ArgumentsCount; ++i)


### PR DESCRIPTION
*Resolves #1035.*

## Description

Changes function decompilation behavior to use the associated sub-function name if possible. Without this, ever sub-function takes on the name of the function defined in the first statement of the decompilation context, which of course spells issues.

### Caveats

No caveats that I am aware of - everything works the same, and I confirmed that recompilation works as well.

### Notes

I have confirmed that recompilation and everything works fine. I'm not too familiar with the codebase and the inner workings of everything, so please verify this PR if needed.