### PR TITLE
Prevent Infinite Recursion Whilst Decompiling Structs (GMS 2.3)

### DIFF
--- a/UndertaleModLib/Decompiler/Decompiler.cs
+++ b/UndertaleModLib/Decompiler/Decompiler.cs
@@ -1767,7 +1767,7 @@ namespace UndertaleModLib.Decompiler
                         if (name == "argument" && context.DecompilingStruct && context.ArgumentReplacements != null && ArrayIndices.Count == 1)
                         {
                             var replacements = context.ArgumentReplacements;
-                            if (int.TryParse(ArrayIndices[0].ToString(context), out int index) && index >= 0 && index < replacements.Count)
+                            if (int.TryParse(ArrayIndices[0].ToString(context), out int index) && index >= 0 && index < replacements.Count && this != replacements[index])
                                 return replacements[index].ToString(context);
                         }
                         foreach (Expression e in ArrayIndices)


### PR DESCRIPTION
*Resolves #1037.*

This seems to correct decompiler behavior.

## Description

Adds a check to ensure the decompiler doesn't start recursing infinitely when decompiling expressions.

### Caveats

None that I know of, everything works fine.

### Notes

It may be worthwhile to verify that doesn't mess up anything else. From my testing, the new behavior makes sense, but there may be nuances or other cases where this is incorrect.