### PR TITLE
Add 2022.5 handling

### DIFF
--- a/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
+++ b/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
@@ -208,6 +208,8 @@ public class UndertaleEmbeddedTexture : UndertaleNamedResource, IDisposable
                     if (sharedStream.Length != 0)
                         sharedStream.Seek(0, SeekOrigin.Begin);
                     BZip2.Compress(input, sharedStream, false, 9);
+                    if (writer.undertaleData.GM2022_5)
+                        writer.Write((uint)data.Length);
                     writer.Write(sharedStream.GetBuffer().AsSpan()[..(int)sharedStream.Position]);
                 }
                 else
@@ -239,7 +241,7 @@ public class UndertaleEmbeddedTexture : UndertaleNamedResource, IDisposable
                     reader.undertaleData.UseBZipFormat = true;
 
                     // Don't really care about the width/height, so skip them, as well as header
-                    reader.Position += 8;
+                    reader.Position += (uint)(reader.undertaleData.GM2022_5 ? 12 : 8);
 
                     // Need to fully decompress and convert the QOI data to PNG for compatibility purposes (at least for now)
                     if (sharedStream.Length != 0)

--- a/UndertaleModLib/Models/UndertaleGameObject.cs
+++ b/UndertaleModLib/Models/UndertaleGameObject.cs
@@ -50,6 +50,9 @@ public class UndertaleGameObject : UndertaleNamedResource, INotifyPropertyChange
     /// </summary>
     public bool Visible { get; set; } = true;
 
+    // TODO: This summary
+    public bool Managed { get; set; }
+
     /// <summary>
     /// Whether the game object is solid.
     /// </summary>
@@ -165,6 +168,8 @@ public class UndertaleGameObject : UndertaleNamedResource, INotifyPropertyChange
         writer.WriteUndertaleString(Name);
         writer.WriteUndertaleObject(_sprite);
         writer.Write(Visible);
+        if (writer.undertaleData.GM2022_5)
+            writer.Write(Managed);
         writer.Write(Solid);
         writer.Write(Depth);
         writer.Write(Persistent);
@@ -204,6 +209,8 @@ public class UndertaleGameObject : UndertaleNamedResource, INotifyPropertyChange
         Name = reader.ReadUndertaleString();
         _sprite = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT>>();
         Visible = reader.ReadBoolean();
+        if (reader.undertaleData.GM2022_5)
+            Managed = reader.ReadBoolean();
         Solid = reader.ReadBoolean();
         Depth = reader.ReadInt32();
         Persistent = reader.ReadBoolean();

--- a/UndertaleModLib/UndertaleData.cs
+++ b/UndertaleModLib/UndertaleData.cs
@@ -328,6 +328,11 @@ namespace UndertaleModLib
         /// Whether the data file is from version GMS2022.3.
         /// </summary>
         public bool GM2022_3 = false;
+        
+        /// <summary>
+        /// Whether the data file is from version GMS2022.5.
+        /// </summary>
+        public bool GM2022_5 = false;
 
         /// <summary>
         /// Some info for the editor to store data on.


### PR DESCRIPTION
## Description
Adds support for GM2022.5 by performing a quick check on the game's first object alignment. Resolves #945.

### Caveats
Adds yet another bool that should be made a big version enum at some point.

### Notes
N/A