### PR TITLE
LayerEffectData fixes

### DIFF
--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -1363,6 +1363,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
                 EffectType = reader.ReadUndertaleString();
                 EffectProperties = reader.ReadUndertaleObject<UndertaleSimpleList<EffectProperty>>();
             }
+
             switch (LayerType)
             {
                 case LayerType.Instances: Data = reader.ReadUndertaleObject<LayerInstancesData>(); break;

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -1363,14 +1363,19 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
                 EffectType = reader.ReadUndertaleString();
                 EffectProperties = reader.ReadUndertaleObject<UndertaleSimpleList<EffectProperty>>();
             }
-
             switch (LayerType)
             {
                 case LayerType.Instances: Data = reader.ReadUndertaleObject<LayerInstancesData>(); break;
                 case LayerType.Tiles: Data = reader.ReadUndertaleObject<LayerTilesData>(); break;
                 case LayerType.Background: Data = reader.ReadUndertaleObject<LayerBackgroundData>(); break;
                 case LayerType.Assets: Data = reader.ReadUndertaleObject<LayerAssetsData>(); break;
-                case LayerType.Effect: Data = reader.ReadUndertaleObject<LayerEffectData>(); break;
+                case LayerType.Effect:
+                    // Because effect data is empty in 2022.1+, it would erroneously read the next object.
+                    Data =
+                        reader.undertaleData.GMS2022_1
+                        ? new LayerEffectData() { EffectType = EffectType, Properties = EffectProperties }
+                        : reader.ReadUndertaleObject<LayerEffectData>();
+                    break;
                 default: throw new Exception("Unsupported layer type " + LayerType);
             }
         }

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
@@ -241,6 +241,11 @@
                                         <TextBlock Text="{Binding LayerName.Content, Mode=OneWay}" />
                                     </HierarchicalDataTemplate>
                                 </local:LayerDataTemplateSelector.BackgroundDataTemplate>
+                                <local:LayerDataTemplateSelector.EffectDataTemplate>
+                                    <HierarchicalDataTemplate ItemTemplateSelector="{x:Null}">
+                                        <TextBlock Text="{Binding LayerName.Content, Mode=OneWay}" />
+                                    </HierarchicalDataTemplate>
+                                </local:LayerDataTemplateSelector.EffectDataTemplate>
                             </local:LayerDataTemplateSelector>
                         </TreeViewItem.ItemTemplateSelector>
                     </TreeViewItem>

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -1264,20 +1264,20 @@ namespace UndertaleModTool
                     {
                         baseName = name[..^numMatch.Length];
                         nameNum = Int32.Parse(numMatch.Groups[0].Value) + 1;
-
-                        name = baseName + nameNum;
                     }
                     // Name doesn't have a trailing number, so it's the first duplicate.
-                    // Thus we append append "1" to it ("name" -> "name1")
+                    // Thus we set baseName and nameNum to produce "name1" on the next loop.
                     else
-                        name += "1";
+                    {
+                        baseName = name;
+                        nameNum = 1;
+                    }
                 }
                 // If base name is already extracted, increment "nameNum" and append it to the base name
                 else
-                {
                     nameNum++;
-                    name = baseName + nameNum;
-                }
+                // Update name using baseName and nameNum
+                name = baseName + nameNum;
             }
 
             Layer layer = new()

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -1730,6 +1730,7 @@ namespace UndertaleModTool
         public DataTemplate TilesDataTemplate { get; set; }
         public DataTemplate AssetsDataTemplate { get; set; }
         public DataTemplate BackgroundDataTemplate { get; set; }
+        public DataTemplate EffectDataTemplate { get; set; }
 
         public override DataTemplate SelectTemplate(object item, DependencyObject container)
         {
@@ -1745,6 +1746,8 @@ namespace UndertaleModTool
                         return AssetsDataTemplate;
                     case LayerType.Background:
                         return BackgroundDataTemplate;
+                    case LayerType.Effect:
+                        return EffectDataTemplate;
                 }
             }
 


### PR DESCRIPTION
## Description
Fixes handling of effect layers in 2022.1+, as well as their display in the room editor. Resolves #825.

### Caveats
None.

### Notes
Effect layers previously displayed as: 
![image](https://user-images.githubusercontent.com/32578221/178158098-91b79ac2-5858-46b1-ae6b-6179b5341938.png)
