### PR TITLE
Fix potential crash when addnig new code

### DIFF
--- a/UndertaleModCli/Program.UMTLibInherited.cs
+++ b/UndertaleModCli/Program.UMTLibInherited.cs
@@ -766,7 +766,7 @@ public partial class Program : IScriptInterface
         if (doParse)
         {
             // This portion links code.
-            if (codeName.Substring(0, 10).Equals("gml_Script"))
+            if (codeName.StartsWith("gml_Script"))
             {
                 // Add code to scripts section.
                 if (Data.Scripts.ByName(codeName.Substring(11)) == null)
@@ -782,7 +782,7 @@ public partial class Program : IScriptInterface
                     scr.Code = code;
                 }
             }
-            else if (codeName.Substring(0, 16).Equals("gml_GlobalScript"))
+            else if (codeName.StartsWith("gml_GlobalScript"))
             {
                 // Add code to global init section.
                 UndertaleGlobalInit initEntry = null;
@@ -807,7 +807,7 @@ public partial class Program : IScriptInterface
                     NewInit.Code = code;
                 }
             }
-            else if (codeName.Substring(0, 10).Equals("gml_Object"))
+            else if (codeName.StartsWith("gml_Object"))
             {
                 string afterPrefix = codeName.Substring(11);
                 int underCount = 0;

--- a/UndertaleModTool/ImportCodeSystem.cs
+++ b/UndertaleModTool/ImportCodeSystem.cs
@@ -219,7 +219,7 @@ namespace UndertaleModTool
             if (doParse)
             {
                 // This portion links code.
-                if (codeName.Substring(0, 10).Equals("gml_Script"))
+                if (codeName.StartsWith("gml_Script"))
                 {
                     // Add code to scripts section.
                     if (Data.Scripts.ByName(codeName.Substring(11)) == null)
@@ -235,7 +235,7 @@ namespace UndertaleModTool
                         scr.Code = code;
                     }
                 }
-                else if (codeName.Substring(0, 16).Equals("gml_GlobalScript"))
+                else if (codeName.StartsWith("gml_GlobalScript"))
                 {
                     // Add code to global init section.
                     UndertaleGlobalInit init_entry = null;
@@ -260,7 +260,7 @@ namespace UndertaleModTool
                         NewInit.Code = code;
                     }
                 }
-                else if (codeName.Substring(0, 10).Equals("gml_Object"))
+                else if (codeName.StartsWith("gml_Object"))
                 {
                     string afterPrefix = codeName.Substring(11);
                     int underCount = 0;
@@ -447,4 +447,3 @@ namespace UndertaleModTool
         }
     }
 }
-


### PR DESCRIPTION
## Description
Currently when adding code entries, UMT tries to parse the names. This is done using `substring`, which can fail if the codename is less than what it checks for.
This was changed to use `StartsWith` instead.

### Caveats
None that I'm aware off.
