### PR TITLE
Fix UMT_REPLACE_ALL on UMTCLI

### DIFF
--- a/UndertaleModCli/Program.cs
+++ b/UndertaleModCli/Program.cs
@@ -407,7 +407,7 @@ public partial class Program : IScriptInterface
             {
                 string directory = codeDict[UMT_REPLACE_ALL].FullName;
                 foreach (FileInfo file in new DirectoryInfo(directory).GetFiles())
-                    program.ReplaceCodeEntryWithFile(file.Name, file);
+                    program.ReplaceCodeEntryWithFile(Path.GetFileNameWithoutExtension(file.Name), file);
             }
             // Otherwise, just replace every file which was given
             else
@@ -440,7 +440,7 @@ public partial class Program : IScriptInterface
             {
                 string directory = textureDict[UMT_REPLACE_ALL].FullName;
                 foreach (FileInfo file in new DirectoryInfo(directory).GetFiles())
-                    program.ReplaceTextureWithFile(file.Name, file);
+                    program.ReplaceTextureWithFile(Path.GetFileNameWithoutExtension(file.Name), file);
             }
             // Otherwise, just replace every file which was given
             else


### PR DESCRIPTION
## Description
This fixes UMT_REPLACE not working due to it wanting to replace a file, instead of wanting to replace an entry.
Fixes #1058 

### Caveats
None as far as I'm aware