### PR TITLE
Add #line directive when running scripts

### DIFF
--- a/UndertaleModCli/Program.cs
+++ b/UndertaleModCli/Program.cs
@@ -703,6 +703,7 @@ public partial class Program : IScriptInterface
             throw;
         }
 
+        lines = $"#line 1 \"{path}\"\n" + lines;
         ScriptPath = path;
         RunCSharpCode(lines, ScriptPath);
     }

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -2436,7 +2436,7 @@ namespace UndertaleModTool
             if (excLineNums.Count > 0) //if line number(s) is found
             {
                 string[] scriptLines = scriptText.Split('\n');
-                string excLines = string.Join('\n', excLineNums.Select(n => $"Line {n}: {scriptLines[n - 1].TrimStart(new char[] { '\t', ' ' })}"));
+                string excLines = string.Join('\n', excLineNums.Select(n => $"Line {n}: {scriptLines[n].TrimStart(new char[] { '\t', ' ' })}"));
                 if (exTypesDict is not null)
                 {
                     string exTypesStr = string.Join(",\n", exTypesDict.Select(x => $"{x.Key}{((x.Value > 1) ? " (x" + x.Value + ")" : string.Empty)}"));
@@ -2477,7 +2477,7 @@ namespace UndertaleModTool
 
         private async Task RunScriptNow(string path)
         {
-            string scriptText = File.ReadAllText(path);
+            string scriptText = $"#line 1 \"{path}\"\n" + File.ReadAllText(path);
             Debug.WriteLine(path);
 
             Dispatcher.Invoke(() => CommandBox.Text = "Running " + Path.GetFileName(path) + " ...");


### PR DESCRIPTION
According to https://www.michalkomorowski.com/2016/10/roslyn-how-to-create-custom-debuggable_27.html, we can add `#line` directive to let the debugger know where the exception occurs

Before, the debugger doesn't point to the exact line in the custom script:
![before](https://user-images.githubusercontent.com/6135313/182040293-99301a99-a1af-4c93-a413-a516da11227b.png)

After, now the line is highlighted:
![after](https://user-images.githubusercontent.com/6135313/182040298-a7de2bdc-665f-4193-ab57-1f7481ea0a6b.png)