### PR TITLE
Fix a (presumeably) rare issue with sound playing.

### DIFF
--- a/UndertaleModTool/Editors/UndertaleEmbeddedAudioEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedAudioEditor.xaml.cs
@@ -94,7 +94,7 @@ namespace UndertaleModTool
         private void InitAudio()
         {
             if (waveOut == null)
-                waveOut = new WaveOutEvent();
+                waveOut = new WaveOutEvent() { DeviceNumber = 0 };
             else if (waveOut.PlaybackState != PlaybackState.Stopped)
                 waveOut.Stop();
         }

--- a/UndertaleModTool/Editors/UndertaleSoundEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleSoundEditor.xaml.cs
@@ -48,7 +48,7 @@ namespace UndertaleModTool
         private void InitAudio()
         {
             if (waveOut == null)
-                waveOut = new WaveOutEvent();
+                waveOut = new WaveOutEvent() { DeviceNumber = 0 };
             else if (waveOut.PlaybackState != PlaybackState.Stopped)
                 waveOut.Stop();
         }


### PR DESCRIPTION
## Description
One of the users experienced a bug - a "BadDeviceId calling waveOutOpen" error appears when trying to play any sound.
And somehow, explicitly setting `DeviceNumber` to `0` (default audio device) fixes this error.

### Caveats
None.