### PR TITLE
Fix of a crash when a texture page item source size is zero.

### DIFF
--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -96,6 +96,8 @@ namespace UndertaleModTool
                     return null;
             }
 
+            if (texture.SourceWidth == 0 || texture.SourceHeight == 0)
+                return null;
 
             if (tileRectList is not null)
             {


### PR DESCRIPTION
## Description
Fixes #1079 

### Caveats
None.