### PR TITLE
Fix of a crash on GMS 2 room open.

### DIFF
--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -1468,7 +1468,9 @@ namespace UndertaleModTool
                             break;
 
                         case LayerType.Instances:
-                            allObjects.AddRange(layer.InstancesData.Instances);
+                            var instances = layer.InstancesData.Instances
+                                            .Where(g => g.ObjectDefinition?.Sprite?.Textures.Count > 0);
+                            allObjects.AddRange(instances);
                             break;
                     }
                 }


### PR DESCRIPTION
## Description
Fixed #1083 which was caused by a GMS 2 object instance with missing textures.

### Caveats
None.