### PR TITLE
Fixed TTFFonts.csx

### DIFF
--- a/UndertaleModTool/Scripts/Builtin Scripts/TTFFonts.csx
+++ b/UndertaleModTool/Scripts/Builtin Scripts/TTFFonts.csx
@@ -22,15 +22,15 @@ Data.Functions.EnsureDefined("font_add", Data.Strings); // Allow font_add.
 var obj_time_Create_0 = Data.GameObjects.ByName("obj_time").EventHandlerFor(EventType.Create, Data.Strings, Data.Code, Data.CodeLocals);
 obj_time_Create_0.AppendGML(@"
 // NOTE: According to GMS documentation the font ranges are ignored with ttf fonts, and that seems to be indeed the case
-font_add('wingding.ttf', 12, false, false, 32, 127);
-font_add('8bitoperator_jve.ttf', 24, false, false, 32, 127);
-font_add('8bitoperator_jve.ttf', 12, false, false, 32, 127);
-font_add('CryptOfTomorrow.ttf', 6, false, false, 32, 127);
-font_add('DotumChe.ttf', 12, true, false, 32, 127);
-font_add('DotumChe.ttf', 48, true, false, 32, 127);
-font_add('hachicro.ttf', 24, true, false, 32, 127);
-font_add('Mars Needs Cunnilingus.ttf', 18, false, false, 32, 127);
-font_add('comic.ttf', 10, true, false, 32, 127);
-font_add('PAPYRUS.TTF', 8, true, false, 32, 127);
+font_add(""wingding.ttf"", 12, false, false, 32, 127);
+font_add(""8bitoperator_jve.ttf"", 24, false, false, 32, 127);
+font_add(""8bitoperator_jve.ttf"", 12, false, false, 32, 127);
+font_add(""CryptOfTomorrow.ttf"", 6, false, false, 32, 127);
+font_add(""DotumChe.ttf"", 12, true, false, 32, 127);
+font_add(""DotumChe.ttf"", 48, true, false, 32, 127);
+font_add(""hachicro.ttf"", 24, true, false, 32, 127);
+font_add(""Mars Needs Cunnilingus.ttf"", 18, false, false, 32, 127);
+font_add(""comic.ttf"", 10, true, false, 32, 127);
+font_add(""PAPYRUS.TTF"", 8, true, false, 32, 127);
 ", Data);
 ChangeSelection(obj_time_Create_0);


### PR DESCRIPTION
From line 25-34 the use of **' '** instead of **"" ""** resulted in UMT throwing a compile error.
![Screenshot 2022-11-10 212040](https://user-images.githubusercontent.com/89710975/201199044-ef2e1001-b1b0-42a9-9d92-372444493dfb.png)
