### PR TITLE
Code editor scrolling optimizations.

### DIFF
--- a/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
@@ -798,12 +798,13 @@ namespace UndertaleModTool
             }
         }
 
-        // Based on https://stackoverflow.com/questions/28379206/custom-hyperlinks-using-avalonedit
         public class NumberGenerator : VisualLineElementGenerator
         {
-            private static readonly Regex regex = new Regex(@"-?\d+\.?", RegexOptions.Compiled);
             private readonly IHighlighter highlighterInst;
             private readonly UndertaleCodeEditor codeEditorInst;
+
+            // <offset, length>
+            private readonly Dictionary<int, int> lineNumberSections = new();
 
             public NumberGenerator(UndertaleCodeEditor codeEditorInst, TextArea textAreaInst)
             {
@@ -812,13 +813,36 @@ namespace UndertaleModTool
                 highlighterInst = textAreaInst.GetService(typeof(IHighlighter)) as IHighlighter;
             }
 
-            Match FindMatch(int startOffset, Regex r)
+            public override void StartGeneration(ITextRunConstructionContext context)
             {
-                // fetch the end offset of the VisualLine being generated
-                int endOffset = CurrentContext.VisualLine.LastDocumentLine.EndOffset;
-                TextDocument document = CurrentContext.Document;
-                string relevantText = document.GetText(startOffset, endOffset - startOffset);
-                return r.Match(relevantText);
+                lineNumberSections.Clear();
+
+                var docLine = context.VisualLine.FirstDocumentLine;
+                if (docLine.Length != 0)
+                {
+                    int line = docLine.LineNumber;
+                    var highlighter = highlighterInst;
+                    
+                    HighlightedLine highlighted;
+                    try
+                    {
+                        highlighted = highlighter.HighlightLine(line);
+                    }
+                    catch
+                    {
+                        Debug.WriteLine($"(NumberGenerator) Code editor line {line} highlight error.");
+                        base.StartGeneration(context);
+                        return;
+                    }
+
+                    foreach (var section in highlighted.Sections)
+                    {
+                        if (section.Color.Name == "Number")
+                            lineNumberSections[section.Offset] = section.Length;
+                    }
+                }
+
+                base.StartGeneration(context);
             }
 
             /// Gets the first offset >= startOffset where the generator wants to construct
@@ -826,38 +850,10 @@ namespace UndertaleModTool
             /// Return -1 to signal no interest.
             public override int GetFirstInterestedOffset(int startOffset)
             {
-                Match m = FindMatch(startOffset, regex);
-
-                var highlighter = highlighterInst;
-                int line = CurrentContext.Document.GetLocation(startOffset).Line;
-                HighlightedLine highlighted = null;
-                try
+                foreach (var section in lineNumberSections)
                 {
-                    highlighted = highlighter.HighlightLine(line);
-                }
-                catch
-                {
-                }
-
-                while (m.Success)
-                {
-                    int res = startOffset + m.Index;
-                    int currLine = CurrentContext.Document.GetLocation(res).Line;
-                    if (currLine != line)
-                    {
-                        line = currLine;
-                        highlighted = highlighter.HighlightLine(line);
-                    }
-
-                    foreach (var section in highlighted.Sections)
-                    {
-                        if (section.Color.Name == "Number" &&
-                            section.Offset == res)
-                            return res;
-                    }
-
-                    startOffset += m.Length;
-                    m = FindMatch(startOffset, regex);
+                    if (startOffset <= section.Key)
+                        return section.Key;
                 }
 
                 return -1;
@@ -867,115 +863,121 @@ namespace UndertaleModTool
             /// May return null if no element should be constructed.
             public override VisualLineElement ConstructElement(int offset)
             {
-                Match m = FindMatch(offset, regex);
+                int numLength = -1;
+                if (!lineNumberSections.TryGetValue(offset, out numLength))
+                    return null;
 
-                if (m.Success && m.Index == 0)
+                var doc = CurrentContext.Document;
+                string numText = doc.GetText(offset, numLength); 
+
+                var line = new ClickVisualLineText(numText, CurrentContext.VisualLine, numLength);
+                
+                line.Clicked += (text) =>
                 {
-                    var line = new ClickVisualLineText(m.Value, CurrentContext.VisualLine, m.Length);
-                    var doc = CurrentContext.Document;
-                    line.Clicked += (text) =>
+                    if (int.TryParse(text, out int id))
                     {
-                        if (text.EndsWith("."))
-                            return;
-                        if (int.TryParse(text, out int id))
+                        codeEditorInst.DecompiledFocused = true;
+                        UndertaleData data = mainWindow.Data;
+
+                        List<UndertaleObject> possibleObjects = new List<UndertaleObject>();
+                        if (id >= 0)
                         {
-                            codeEditorInst.DecompiledFocused = true;
-                            UndertaleData data = mainWindow.Data;
-
-                            List<UndertaleObject> possibleObjects = new List<UndertaleObject>();
-                            if (id >= 0)
-                            {
-                                if (id < data.Sprites.Count)
-                                    possibleObjects.Add(data.Sprites[id]);
-                                if (id < data.Rooms.Count)
-                                    possibleObjects.Add(data.Rooms[id]);
-                                if (id < data.GameObjects.Count)
-                                    possibleObjects.Add(data.GameObjects[id]);
-                                if (id < data.Backgrounds.Count)
-                                    possibleObjects.Add(data.Backgrounds[id]);
-                                if (id < data.Scripts.Count)
-                                    possibleObjects.Add(data.Scripts[id]);
-                                if (id < data.Paths.Count)
-                                    possibleObjects.Add(data.Paths[id]);
-                                if (id < data.Fonts.Count)
-                                    possibleObjects.Add(data.Fonts[id]);
-                                if (id < data.Sounds.Count)
-                                    possibleObjects.Add(data.Sounds[id]);
-                                if (id < data.Shaders.Count)
-                                    possibleObjects.Add(data.Shaders[id]);
-                                if (id < data.Timelines.Count)
-                                    possibleObjects.Add(data.Timelines[id]);
-                            }
-
-                            ContextMenu contextMenu = new ContextMenu();
-                            foreach (UndertaleObject obj in possibleObjects)
-                            {
-                                MenuItem item = new MenuItem();
-                                item.Header = obj.ToString().Replace("_", "__");
-                                item.Click += (sender2, ev2) =>
-                                {
-                                    if ((Keyboard.Modifiers & ModifierKeys.Shift) == ModifierKeys.Shift)
-                                        mainWindow.ChangeSelection(obj);
-                                    else
-                                    {
-                                        doc.Replace(line.ParentVisualLine.StartOffset + line.RelativeTextOffset,
-                                                    text.Length, (obj as UndertaleNamedResource).Name.Content, null);
-                                        codeEditorInst.DecompiledChanged = true;
-                                    }
-                                };
-                                contextMenu.Items.Add(item);
-                            }
-                            if (id > 0x00050000)
-                            {
-                                MenuItem item = new MenuItem();
-                                item.Header = "0x" + id.ToString("X6") + " (color)";
-                                item.Click += (sender2, ev2) =>
-                                {
-                                    if (!((Keyboard.Modifiers & ModifierKeys.Shift) == ModifierKeys.Shift))
-                                    {
-                                        doc.Replace(line.ParentVisualLine.StartOffset + line.RelativeTextOffset,
-                                                    text.Length, "0x" + id.ToString("X6"), null);
-                                        codeEditorInst.DecompiledChanged = true;
-                                    }
-                                };
-                                contextMenu.Items.Add(item);
-                            }
-                            BuiltinList list = mainWindow.Data.BuiltinList;
-                            var myKey = list.Constants.FirstOrDefault(x => x.Value == (double)id).Key;
-                            if (myKey != null)
-                            {
-                                MenuItem item = new MenuItem();
-                                item.Header = myKey.Replace("_", "__") + " (constant)";
-                                item.Click += (sender2, ev2) =>
-                                {
-                                    if (!((Keyboard.Modifiers & ModifierKeys.Shift) == ModifierKeys.Shift))
-                                    {
-                                        doc.Replace(line.ParentVisualLine.StartOffset + line.RelativeTextOffset,
-                                                    text.Length, myKey, null);
-                                        codeEditorInst.DecompiledChanged = true;
-                                    }
-                                };
-                                contextMenu.Items.Add(item);
-                            }
-                            contextMenu.Items.Add(new MenuItem() { Header = id + " (number)", IsEnabled = false });
-
-                            contextMenu.IsOpen = true;
+                            if (id < data.Sprites.Count)
+                                possibleObjects.Add(data.Sprites[id]);
+                            if (id < data.Rooms.Count)
+                                possibleObjects.Add(data.Rooms[id]);
+                            if (id < data.GameObjects.Count)
+                                possibleObjects.Add(data.GameObjects[id]);
+                            if (id < data.Backgrounds.Count)
+                                possibleObjects.Add(data.Backgrounds[id]);
+                            if (id < data.Scripts.Count)
+                                possibleObjects.Add(data.Scripts[id]);
+                            if (id < data.Paths.Count)
+                                possibleObjects.Add(data.Paths[id]);
+                            if (id < data.Fonts.Count)
+                                possibleObjects.Add(data.Fonts[id]);
+                            if (id < data.Sounds.Count)
+                                possibleObjects.Add(data.Sounds[id]);
+                            if (id < data.Shaders.Count)
+                                possibleObjects.Add(data.Shaders[id]);
+                            if (id < data.Timelines.Count)
+                                possibleObjects.Add(data.Timelines[id]);
                         }
-                    };
-                    return line;
-                }
 
-                return null;
+                        ContextMenu contextMenu = new ContextMenu();
+                        foreach (UndertaleObject obj in possibleObjects)
+                        {
+                            MenuItem item = new MenuItem();
+                            item.Header = obj.ToString().Replace("_", "__");
+                            item.Click += (sender2, ev2) =>
+                            {
+                                if ((Keyboard.Modifiers & ModifierKeys.Shift) == ModifierKeys.Shift)
+                                    mainWindow.ChangeSelection(obj);
+                                else
+                                {
+                                    doc.Replace(line.ParentVisualLine.StartOffset + line.RelativeTextOffset,
+                                                text.Length, (obj as UndertaleNamedResource).Name.Content, null);
+                                    codeEditorInst.DecompiledChanged = true;
+                                }
+                            };
+                            contextMenu.Items.Add(item);
+                        }
+                        if (id > 0x00050000)
+                        {
+                            MenuItem item = new MenuItem();
+                            item.Header = "0x" + id.ToString("X6") + " (color)";
+                            item.Click += (sender2, ev2) =>
+                            {
+                                if (!((Keyboard.Modifiers & ModifierKeys.Shift) == ModifierKeys.Shift))
+                                {
+                                    doc.Replace(line.ParentVisualLine.StartOffset + line.RelativeTextOffset,
+                                                text.Length, "0x" + id.ToString("X6"), null);
+                                    codeEditorInst.DecompiledChanged = true;
+                                }
+                            };
+                            contextMenu.Items.Add(item);
+                        }
+                        BuiltinList list = mainWindow.Data.BuiltinList;
+                        var myKey = list.Constants.FirstOrDefault(x => x.Value == (double)id).Key;
+                        if (myKey != null)
+                        {
+                            MenuItem item = new MenuItem();
+                            item.Header = myKey.Replace("_", "__") + " (constant)";
+                            item.Click += (sender2, ev2) =>
+                            {
+                                if (!((Keyboard.Modifiers & ModifierKeys.Shift) == ModifierKeys.Shift))
+                                {
+                                    doc.Replace(line.ParentVisualLine.StartOffset + line.RelativeTextOffset,
+                                                text.Length, myKey, null);
+                                    codeEditorInst.DecompiledChanged = true;
+                                }
+                            };
+                            contextMenu.Items.Add(item);
+                        }
+                        contextMenu.Items.Add(new MenuItem() { Header = id + " (number)", IsEnabled = false });
+
+                        contextMenu.IsOpen = true;
+                    }
+                };
+
+                return line;
             }
         }
 
         public class NameGenerator : VisualLineElementGenerator
         {
-            private static readonly Regex regex = new Regex(@"[_a-zA-Z][_a-zA-Z0-9]*", RegexOptions.Compiled);
             private readonly IHighlighter highlighterInst;
             private readonly TextEditor textEditorInst;
             private readonly UndertaleCodeEditor codeEditorInst;
 
+            private static readonly SolidColorBrush FunctionBrush = new(Color.FromRgb(0xFF, 0xB8, 0x71));
+            private static readonly SolidColorBrush GlobalBrush = new(Color.FromRgb(0xF9, 0x7B, 0xF9));
+            private static readonly SolidColorBrush ConstantBrush = new(Color.FromRgb(0xFF, 0x80, 0x80));
+            private static readonly SolidColorBrush InstanceBrush = new(Color.FromRgb(0x58, 0xE3, 0x5A));
+            private static readonly SolidColorBrush LocalBrush = new(Color.FromRgb(0xFF, 0xF8, 0x99));
+
+            // <offset, length>
+            private readonly Dictionary<int, int> lineNameSections = new();
 
             public NameGenerator(UndertaleCodeEditor codeEditorInst, TextArea textAreaInst)
             {
@@ -985,13 +987,36 @@ namespace UndertaleModTool
                 textEditorInst = textAreaInst.GetService(typeof(TextEditor)) as TextEditor;
             }
 
-            Match FindMatch(int startOffset, Regex r)
+            public override void StartGeneration(ITextRunConstructionContext context)
             {
-                // fetch the end offset of the VisualLine being generated
-                int endOffset = CurrentContext.VisualLine.LastDocumentLine.EndOffset;
-                TextDocument document = CurrentContext.Document;
-                string relevantText = document.GetText(startOffset, endOffset - startOffset);
-                return r.Match(relevantText);
+                lineNameSections.Clear();
+
+                var docLine = context.VisualLine.FirstDocumentLine;
+                if (docLine.Length != 0)
+                {
+                    int line = docLine.LineNumber;
+                    var highlighter = highlighterInst;
+
+                    HighlightedLine highlighted;
+                    try
+                    {
+                        highlighted = highlighter.HighlightLine(line);
+                    }
+                    catch
+                    {
+                        Debug.WriteLine($"(NameGenerator) Code editor line {line} highlight error.");
+                        base.StartGeneration(context);
+                        return;
+                    }
+
+                    foreach (var section in highlighted.Sections)
+                    {
+                        if (section.Color.Name == "Identifier" || section.Color.Name == "Function")
+                            lineNameSections[section.Offset] = section.Length;
+                    }
+                }
+
+                base.StartGeneration(context);
             }
 
             /// Gets the first offset >= startOffset where the generator wants to construct
@@ -999,41 +1024,12 @@ namespace UndertaleModTool
             /// Return -1 to signal no interest.
             public override int GetFirstInterestedOffset(int startOffset)
             {
-                Match m = FindMatch(startOffset, regex);
-
-                var highlighter = highlighterInst;
-                int line = CurrentContext.Document.GetLocation(startOffset).Line;
-                HighlightedLine highlighted = null;
-                try
+                foreach (var section in lineNameSections)
                 {
-                    highlighted = highlighter.HighlightLine(line);
-                }
-                catch
-                {
+                    if (startOffset <= section.Key)
+                        return section.Key;
                 }
 
-                while (m.Success)
-                {
-                    int res = startOffset + m.Index;
-                    int currLine = CurrentContext.Document.GetLocation(res).Line;
-                    if (currLine != line)
-                    {
-                        line = currLine;
-                        highlighted = highlighter.HighlightLine(line);
-                    }
-
-                    foreach (var section in highlighted.Sections)
-                    {
-                        if (section.Color.Name == "Identifier" || section.Color.Name == "Function")
-                        {
-                            if (section.Offset == res)
-                                return res;
-                        }
-                    }
-
-                    startOffset += m.Length;
-                    m = FindMatch(startOffset, regex);
-                }
                 return -1;
             }
 
@@ -1041,97 +1037,95 @@ namespace UndertaleModTool
             /// May return null if no element should be constructed.
             public override VisualLineElement ConstructElement(int offset)
             {
-                Match m = FindMatch(offset, regex);
+                int nameLength = -1;
+                if (!lineNameSections.TryGetValue(offset, out nameLength))
+                    return null;
 
-                if (m.Success && m.Index == 0)
+                var doc = CurrentContext.Document;
+                string nameText = doc.GetText(offset, nameLength);
+
+                UndertaleData data = mainWindow.Data;
+                bool func = (offset + nameLength + 1 < CurrentContext.VisualLine.LastDocumentLine.EndOffset) &&
+                            (doc.GetCharAt(offset + nameLength) == '(');
+                UndertaleNamedResource val = null;
+
+                var editor = textEditorInst;
+
+                // Process the content of this identifier/function
+                if (func)
                 {
-                    UndertaleData data = mainWindow.Data;
-                    bool func = (offset + m.Length + 1 < CurrentContext.VisualLine.LastDocumentLine.EndOffset) &&
-                                (CurrentContext.Document.GetCharAt(offset + m.Length) == '(');
-                    UndertaleNamedResource val = null;
-
-                    var editor = textEditorInst;
-
-                    // Process the content of this identifier/function
-                    if (func)
+                    val = null;
+                    if (!data.GMS2_3) // in GMS2.3 every custom "function" is in fact a member variable and scripts are never referenced directly
+                        val = data.Scripts.ByName(nameText);
+                    if (val == null)
                     {
-                        val = null;
-                        if (!data.GMS2_3) // in GMS2.3 every custom "function" is in fact a member variable and scripts are never referenced directly
-                            val = data.Scripts.ByName(m.Value);
-                        if (val == null)
+                        val = data.Functions.ByName(nameText);
+                        if (data.GMS2_3)
                         {
-                            val = data.Functions.ByName(m.Value);
-                            if (data.GMS2_3)
+                            if (val != null)
                             {
-                                if (val != null)
-                                {
-                                    if (data.Code.ByName(val.Name.Content) != null)
-                                        val = null; // in GMS2.3 every custom "function" is in fact a member variable, and the names in functions make no sense (they have the gml_Script_ prefix)
-                                }
-                                else
-                                {
-                                    // Resolve 2.3 sub-functions for their parent entry
-                                    UndertaleFunction f = null;
-                                    if (data.KnownSubFunctions?.TryGetValue(m.Value, out f) == true)
-                                        val = data.Scripts.ByName(f.Name.Content).Code?.ParentEntry;
-                                }
+                                if (data.Code.ByName(val.Name.Content) != null)
+                                    val = null; // in GMS2.3 every custom "function" is in fact a member variable, and the names in functions make no sense (they have the gml_Script_ prefix)
+                            }
+                            else
+                            {
+                                // Resolve 2.3 sub-functions for their parent entry
+                                if (data.KnownSubFunctions?.TryGetValue(nameText, out UndertaleFunction f) == true)
+                                    val = data.Scripts.ByName(f.Name.Content).Code?.ParentEntry;
                             }
                         }
-                        if (val == null)
-                        {
-                            if (data.BuiltinList.Functions.ContainsKey(m.Value))
-                            {
-                                var res = new ColorVisualLineText(m.Value, CurrentContext.VisualLine, m.Length,
-                                                                  new SolidColorBrush(Color.FromRgb(0xFF, 0xB8, 0x71)));
-                                res.Bold = true;
-                                return res;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        val = data.ByName(m.Value);
-                        if (data.GMS2_3 & val is UndertaleScript)
-                            val = null; // in GMS2.3 scripts are never referenced directly
                     }
                     if (val == null)
                     {
-                        if (offset >= 7)
+                        if (data.BuiltinList.Functions.ContainsKey(nameText))
                         {
-                            if (CurrentContext.Document.GetText(offset - 7, 7) == "global.")
-                            {
-                                return new ColorVisualLineText(m.Value, CurrentContext.VisualLine, m.Length,
-                                                                new SolidColorBrush(Color.FromRgb(0xF9, 0x7B, 0xF9)));
-                            }
+                            var res = new ColorVisualLineText(nameText, CurrentContext.VisualLine, nameLength,
+                                                              FunctionBrush);
+                            res.Bold = true;
+                            return res;
                         }
-                        if (data.BuiltinList.Constants.ContainsKey(m.Value))
-                            return new ColorVisualLineText(m.Value, CurrentContext.VisualLine, m.Length,
-                                                            new SolidColorBrush(Color.FromRgb(0xFF, 0x80, 0x80)));
-                        if (data.BuiltinList.GlobalNotArray.ContainsKey(m.Value) ||
-                            data.BuiltinList.Instance.ContainsKey(m.Value) ||
-                            data.BuiltinList.GlobalArray.ContainsKey(m.Value))
-                            return new ColorVisualLineText(m.Value, CurrentContext.VisualLine, m.Length,
-                                                            new SolidColorBrush(Color.FromRgb(0x58, 0xE3, 0x5A)));
-                        if (codeEditorInst.CurrentLocals.Contains(m.Value) == true)
-                            return new ColorVisualLineText(m.Value, CurrentContext.VisualLine, m.Length,
-                                                            new SolidColorBrush(Color.FromRgb(0xFF, 0xF8, 0x99)));
-                        return null;
                     }
-
-                    var line = new ClickVisualLineText(m.Value, CurrentContext.VisualLine, m.Length,
-                                                        func ? new SolidColorBrush(Color.FromRgb(0xFF, 0xB8, 0x71)) :
-                                                               new SolidColorBrush(Color.FromRgb(0xFF, 0x80, 0x80)));
-                    if (func)
-                        line.Bold = true;
-                    line.Clicked += (text) =>
+                }
+                else
+                {
+                    val = data.ByName(nameText);
+                    if (data.GMS2_3 & val is UndertaleScript)
+                        val = null; // in GMS2.3 scripts are never referenced directly
+                }
+                if (val == null)
+                {
+                    if (offset >= 7)
                     {
-                        mainWindow.ChangeSelection(val);
-                    };
-
-                    return line;
+                        if (doc.GetText(offset - 7, 7) == "global.")
+                        {
+                            return new ColorVisualLineText(nameText, CurrentContext.VisualLine, nameLength,
+                                                           GlobalBrush);
+                        }
+                    }
+                    if (data.BuiltinList.Constants.ContainsKey(nameText))
+                        return new ColorVisualLineText(nameText, CurrentContext.VisualLine, nameLength,
+                                                       ConstantBrush);
+                    if (data.BuiltinList.GlobalNotArray.ContainsKey(nameText) ||
+                        data.BuiltinList.Instance.ContainsKey(nameText) ||
+                        data.BuiltinList.GlobalArray.ContainsKey(nameText))
+                        return new ColorVisualLineText(nameText, CurrentContext.VisualLine, nameLength,
+                                                       InstanceBrush);
+                    if (codeEditorInst.CurrentLocals.Contains(nameText) == true)
+                        return new ColorVisualLineText(nameText, CurrentContext.VisualLine, nameLength,
+                                                       LocalBrush);
+                    return null;
                 }
 
-                return null;
+                var line = new ClickVisualLineText(nameText, CurrentContext.VisualLine, nameLength,
+                                                   func ? FunctionBrush : ConstantBrush);
+                if (func)
+                    line.Bold = true;
+                line.Clicked += (text) =>
+                {
+                    mainWindow.ChangeSelection(val);
+                };
+
+                return line;
             }
         }
 

--- a/UndertaleModTool/Resources/GML.xshd
+++ b/UndertaleModTool/Resources/GML.xshd
@@ -79,7 +79,7 @@
             \b0x[0-9a-fA-F]+  # hex number
         |   \$[0-9a-fA-F]+   # alternate hex number
         |
-            (    -?\d+(\.[0-9]+)?  # digits with optional . and -
+            (?:    -?\d+(?:\.[0-9]+)?  # digits with optional . and -
             |    -?\.[0-9]+        # start with ., then digits
             )
             \b

--- a/UndertaleModTool/Resources/VMASM.xshd
+++ b/UndertaleModTool/Resources/VMASM.xshd
@@ -17,12 +17,12 @@
         </Rule>
 
         <Rule color="Label">
-			^(?:\:|\>).*|(?:^|\n)\..*
-		</Rule>
+            ^(?:\:|\>).*|(?:^|\n)\..*
+        </Rule>
 
         <Rule color="String">
-			\"(?:\\.|[^"\\])*\"@\d+
-		</Rule>
+            \"(?:\\.|[^"\\])*\"@\d+
+        </Rule>
         
         <Rule color="Label">
             \[[0-9a-zA-Z_\-]+\]
@@ -43,8 +43,8 @@
 
         <!-- Addresses -->
         <Rule foreground="#E0B0B0">
-			(?:^|\n)\d+(?=:)
-		</Rule>
+            (?:^|\n)\d+(?=:)
+        </Rule>
 
         <!-- Various other things -->
         <Rule foreground="#59c259">

--- a/UndertaleModTool/Resources/VMASM.xshd
+++ b/UndertaleModTool/Resources/VMASM.xshd
@@ -13,16 +13,16 @@
     <!-- This is the main ruleset. -->
     <RuleSet>
         <Rule color="Comment">
-            ^;.*|(^|\n)\..*
+            ^;.*|(?:^|\n)\..*
         </Rule>
 
         <Rule color="Label">
-            ^(\:|\>).*|(^|\n)\..*
-        </Rule>
+			^(?:\:|\>).*|(?:^|\n)\..*
+		</Rule>
 
         <Rule color="String">
-            \"(\\.|[^"\\])*\"@\d+
-        </Rule>
+			\"(?:\\.|[^"\\])*\"@\d+
+		</Rule>
         
         <Rule color="Label">
             \[[0-9a-zA-Z_\-]+\]
@@ -43,8 +43,8 @@
 
         <!-- Addresses -->
         <Rule foreground="#E0B0B0">
-            (^|\n)\d+(?=:)
-        </Rule>
+			(?:^|\n)\d+(?=:)
+		</Rule>
 
         <!-- Various other things -->
         <Rule foreground="#59c259">
@@ -60,7 +60,7 @@
             \b0x[0-9a-fA-F]+  # hex number
         |   \$[0-9a-fA-F]+   # alternate hex number
         |
-            (    -?\d+(\.[0-9]+)?  # digits with optional . and -
+            (?:    -?\d+(?:\.[0-9]+)?  # digits with optional . and -
             |    -?\.[0-9]+        # start with ., then digits
             )
             \b


### PR DESCRIPTION
## Description
1. Reworked `NameGenerator` and `NumberGenerator`, so they are far more optimized now.
2. Made all RegEx groups in the syntax highlighting files (".xshd") non-captive - this should (in theory) also make the scrolling more optimized.
3. Added some named object dictionaries in order to replace all `.ByName()` with `Dictionary.TryGetValue()` (only in the code editor).

**CPU usage data:**
1) Before: **~21%** out of 25% (my CPU has 4 cores, so UI thread takes 25%).
Total RegEx - ~8%.
![Scroll before (RegEx - 8,4)](https://user-images.githubusercontent.com/45438625/213870553-c458459f-de55-44b7-b5ee-4c1714654d8f.png)

2) After: **~3%** out of 25%.
Total RegEx - ~4%.
![Scroll after (RegEx - 3,6)](https://user-images.githubusercontent.com/45438625/213870580-6750d1af-f0c4-49c4-992b-29636002bc29.png)

So, as you can see, the difference is huge.
It's not only about CPU usage, but also about RAM (memory) usage.

### Caveats
None.