### PR TITLE
CLI: Fixed crash when replacing event scripts, slight refactor

### DIFF
--- a/UndertaleModCli/Program.UMTLibInherited.cs
+++ b/UndertaleModCli/Program.UMTLibInherited.cs
@@ -988,7 +988,7 @@ public partial class Program : IScriptInterface
 
     public void ReassignGUIDs(string guid, uint objectIndex)
     {
-        int eventIdx = (int)Enum.Parse(typeof(EventType), "Collision");
+        int eventIdx = Convert.ToInt32(EventType.Collision);
         for (var i = 0; i < Data.GameObjects.Count; i++)
         {
             UndertaleGameObject obj = Data.GameObjects[i];
@@ -1069,7 +1069,7 @@ public partial class Program : IScriptInterface
 
     public List<uint> GetCollisionValueFromCodeNameGUID(string codeName)
     {
-        int eventIdx = (int)Enum.Parse(typeof(EventType), "Collision");
+        int eventIdx = Convert.ToInt32(EventType.Collision);
         List<uint> possibleValues = new List<uint>();
         for (var i = 0; i < Data.GameObjects.Count; i++)
         {
@@ -1102,7 +1102,7 @@ public partial class Program : IScriptInterface
 
     public List<uint> GetCollisionValueFromGUID(string guid)
     {
-        int eventIdx = (int)Enum.Parse(typeof(EventType), "Collision");
+        int eventIdx = Convert.ToInt32(EventType.Collision);
         List<uint> possibleValues = new List<uint>();
         for (var i = 0; i < Data.GameObjects.Count; i++)
         {

--- a/UndertaleModCli/Program.UMTLibInherited.cs
+++ b/UndertaleModCli/Program.UMTLibInherited.cs
@@ -918,7 +918,7 @@ public partial class Program : IScriptInterface
                 if (!(skipPortions))
                 {
                     obj = Data.GameObjects.ByName(objName);
-                    int eventIdx = (int)Enum.Parse(typeof(EventType), methodName);
+                    int eventIdx = Convert.ToInt32(Enum.Parse(typeof(EventType), methodName));
                     bool duplicate = false;
                     try
                     {


### PR DESCRIPTION
## Description
When trying to replace an event script in a non-undertale title, one is met with an exception:

```
UndertaleModCli replace data.orig
-c gml_Object_obj_light_controller_Draw_0=./Mods/gml_Object_obj_light_controller_Draw_0.gml
-v -o data.win

System.InvalidCastException: Unable to cast object of type 'UndertaleModLib.Models.EventType' to type 'System.Int32'.
   at UndertaleModCli.Program.ImportCode(String codeName, String gmlCode, Boolean isGML, Boolean doParse, Boolean destroyASM, Boolean checkDecompiler, Boolean throwOnError) in /mnt/nex/projekty/undertale-mod-tool/UndertaleModCli/Program.UMTLibInherited.cs:line 921
   at UndertaleModCli.Program.ImportGMLString(String codeName, String gmlCode, Boolean doParse, Boolean checkDecompiler) in /mnt/nex/projekty/undertale-mod-tool/UndertaleModCli/Program.UMTLibInherited.cs:line 607
   at UndertaleModCli.Program.ReplaceCodeEntryWithFile(String codeEntry, FileInfo fileToReplace) in /mnt/nex/projekty/undertale-mod-tool/UndertaleModCli/Program.cs:line 664
   at UndertaleModCli.Program.Replace(ReplaceOptions options) in /mnt/nex/projekty/undertale-mod-tool/UndertaleModCli/Program.cs:line 416
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
```

The following commits fix the issue and introduce enhancements:
- Plain cast to `int` has been substituted to a `Convert.ToInt32` call which does not fault,
- Removed needless reflection (which would also fault on call) when trying to obtain a particular value from an enum.

### Caveats
Hopefully none, the changes introduced shouldn't change any behaviour, just the value handling.

### Notes
Game used: ZERO Sievert
Tested on a Linux box:
```
awoo@~ $ uname -a
Linux [redacted] 6.1.9-zen1-2-zen #1 ZEN SMP PREEMPT_DYNAMIC Sat, 04 Feb 2023 23:45:10 +0000 x86_64 GNU/Linux
```