### PR TITLE
A CLI fix and an improvement.

### DIFF
--- a/UndertaleModCli/Program.UMTLibInherited.cs
+++ b/UndertaleModCli/Program.UMTLibInherited.cs
@@ -389,7 +389,7 @@ public partial class Program : IScriptInterface
             Console.Write("Path: ");
             path = RemoveQuotes(Console.ReadLine());
             directoryInfo = new DirectoryInfo(path);
-        } while (directoryInfo.Exists);
+        } while (!directoryInfo.Exists);
         return path;
     }
 

--- a/UndertaleModCli/Program.cs
+++ b/UndertaleModCli/Program.cs
@@ -792,7 +792,7 @@ public partial class Program : IScriptInterface
     private static string RemoveQuotes(string s)
 
     {
-        return s.TrimStart('"').TrimEnd('"');
+        return s.Trim('"', '\'');
     }
 
     /// <summary>


### PR DESCRIPTION
## Description
1. Fixes #1177.
2. Improved `RemoveQuotes(s)` method so that it passes through the string once and removes both `"` and `'`.

### Caveats
None.