### PR TITLE
Bytecode v17 Bandaid for big Switch Statements in Decompiler.cs

### DIFF
--- a/UndertaleModLib/Decompiler/Decompiler.cs
+++ b/UndertaleModLib/Decompiler/Decompiler.cs
@@ -3556,7 +3556,13 @@ namespace UndertaleModLib.Decompiler
                         var x = caseEntries.ElementAt(i);
                         Block temp = x.Key;
 
-                        Block switchEnd = DetermineSwitchEnd(temp, caseEntries.Count > (i + 1) ? caseEntries.ElementAt(i + 1).Key : null, meetPoint);
+                        // RadixComet: New bytecode (Mostly from Pizza Tower it seems) hangs here infinitely for some scripts
+                        // RadixComet: So I'm adding a special exception that seems to bandaid the issue for now
+                        Block switchEnd = null;
+                        if (context.GlobalContext.Data.GeneralInfo.BytecodeVersion == 17)
+                            switchEnd = meetPoint;
+                        else
+                            switchEnd = DetermineSwitchEnd(temp, caseEntries.Count > (i + 1) ? caseEntries.ElementAt(i + 1).Key : null, meetPoint);
 
                         HLSwitchCaseStatement result = new HLSwitchCaseStatement(x.Value, HLDecompileBlocks(context, ref temp, blocks, loops, reverseDominators, alreadyVisited, currentLoop, switchEnd, switchEnd, false, depth + 1));
                         cases.Add(result);
@@ -3876,11 +3882,11 @@ namespace UndertaleModLib.Decompiler
 
         private static Block DetermineSwitchEnd(Block start, Block end, Block meetPoint)
         {
+
             if (end == null)
                 return meetPoint;
 
             Queue<Block> blocks = new Queue<Block>();
-
             blocks.Enqueue(start);
             while (blocks.Count > 0)
             {


### PR DESCRIPTION
Haven't entirely figured out why but in v17 bytecode, some switch statements can break entirely and eat literal gigabytes of memory infinitely trying to determine the end of the switch statement. I have tested with existing and working scripts inside of Pizza-Tower and found no noticeable differences before or after the patch, and the entire switch statement seems in-tact. Not entirely sure, very strange!