### PR TITLE
A support for GMS2.0 embedded textures without `GeneratedMips`.

### DIFF
--- a/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
+++ b/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
@@ -98,7 +98,8 @@ public class UndertaleEmbeddedTexture : UndertaleNamedResource, IDisposable
     public void Serialize(UndertaleWriter writer)
     {
         writer.Write(Scaled);
-        if (writer.undertaleData.IsGameMaker2())
+        if (!UndertaleChunkTXTR.NoGeneratedMips
+            && writer.undertaleData.IsGameMaker2())
             writer.Write(GeneratedMips);
         if (writer.undertaleData.IsVersionAtLeast(2022, 3))
         {
@@ -123,7 +124,8 @@ public class UndertaleEmbeddedTexture : UndertaleNamedResource, IDisposable
     public void Unserialize(UndertaleReader reader)
     {
         Scaled = reader.ReadUInt32();
-        if (reader.undertaleData.IsGameMaker2())
+        if (!UndertaleChunkTXTR.NoGeneratedMips
+            && reader.undertaleData.IsGameMaker2())
             GeneratedMips = reader.ReadUInt32();
         if (reader.undertaleData.IsVersionAtLeast(2022, 3))
             _textureBlockSize = reader.ReadUInt32();

--- a/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
+++ b/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
@@ -105,8 +105,7 @@ public class UndertaleEmbeddedTexture : UndertaleNamedResource, IDisposable,
     public void Serialize(UndertaleWriter writer)
     {
         writer.Write(Scaled);
-        if (!UndertaleChunkTXTR.NoGeneratedMips
-            && writer.undertaleData.IsGameMaker2())
+        if (writer.undertaleData.IsVersionAtLeast(2, 0, 6))
             writer.Write(GeneratedMips);
         if (writer.undertaleData.IsVersionAtLeast(2022, 3))
         {
@@ -131,8 +130,7 @@ public class UndertaleEmbeddedTexture : UndertaleNamedResource, IDisposable,
     public void Unserialize(UndertaleReader reader)
     {
         Scaled = reader.ReadUInt32();
-        if (!UndertaleChunkTXTR.NoGeneratedMips
-            && reader.undertaleData.IsGameMaker2())
+        if (reader.undertaleData.IsVersionAtLeast(2, 0, 6))
             GeneratedMips = reader.ReadUInt32();
         if (reader.undertaleData.IsVersionAtLeast(2022, 3))
             _textureBlockSize = reader.ReadUInt32();

--- a/UndertaleModLib/UndertaleChunkTypes.cs
+++ b/UndertaleModLib/UndertaleChunkTypes.cs
@@ -89,6 +89,7 @@ namespace UndertaleModLib
                 reader.CopyChunkToBuffer(length);
                 chunk.UnserializeChunk(reader);
 
+                reader.SwitchReaderType(false);
                 if (name != "FORM" && name != reader.LastChunkName)
                 {
                     UndertaleGeneralInfo generalInfo = name == "GEN8" ? ((UndertaleChunkGEN8)chunk).Object : reader.undertaleData.GeneralInfo;
@@ -99,12 +100,12 @@ namespace UndertaleModLib
                     {
                         int e = reader.undertaleData.PaddingAlignException;
                         uint pad = (e == -1 ? 16 : (uint)e);
-                        while (reader.AbsPosition % pad != 0)
+                        while (reader.Position % pad != 0)
                         {
                             if (reader.ReadByte() != 0)
                             {
                                 reader.Position -= 1;
-                                if (reader.AbsPosition % 4 == 0)
+                                if (reader.Position % 4 == 0)
                                     reader.undertaleData.PaddingAlignException = 4;
                                 else
                                     reader.undertaleData.PaddingAlignException = 1;
@@ -114,7 +115,6 @@ namespace UndertaleModLib
                     }
                 }
 
-                reader.SwitchReaderType(false);
                 lenReader.ToHere();
 
                 return chunk;

--- a/UndertaleModLib/UndertaleChunks.cs
+++ b/UndertaleModLib/UndertaleChunks.cs
@@ -737,6 +737,11 @@ namespace UndertaleModLib
 
     public class UndertaleChunkTXTR : UndertaleListChunk<UndertaleEmbeddedTexture>
     {
+        public UndertaleChunkTXTR()
+        {
+            NoGeneratedMips = false;
+        }
+
         public override string Name => "TXTR";
         public static bool NoGeneratedMips { get; private set; }
 

--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml
@@ -29,9 +29,9 @@
         <TextBox Grid.Row="0" Grid.Column="1" Margin="3" Text="{Binding Scaled}"/>
 
         <TextBlock Grid.Row="1" Grid.Column="0" Margin="3"
-                   Visibility="{Binding DataContext.IsGMS2, Mode=OneTime, Converter={StaticResource GeneratedMipsWrapper}, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}">Generated mips</TextBlock>
+                   Visibility="{Binding Data, Mode=OneTime, Converter={StaticResource GeneratedMipsWrapper}, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}">Generated mips</TextBlock>
         <TextBox Grid.Row="1" Grid.Column="1" Margin="3" Text="{Binding GeneratedMips}"
-                 Visibility="{Binding DataContext.IsGMS2, Mode=OneTime, Converter={StaticResource GeneratedMipsWrapper}, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}"/>
+                 Visibility="{Binding Data, Mode=OneTime, Converter={StaticResource GeneratedMipsWrapper}, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}"/>
 
         <TextBlock Grid.Row="2" Grid.Column="0" Margin="3">Size</TextBlock>
         <Grid Grid.Row="2" Grid.Column="1">

--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml
@@ -10,6 +10,7 @@
     <UserControl.Resources>
         <local:BooleanToVisibilityConverter x:Key="BoolFalseToVisConverter" local:trueValue="Collapsed" local:falseValue="Visible"/>
         <local:TextureLoadedWrapper x:Key="TextureLoadedWrapper"/>
+        <local:GeneratedMipsWrapper x:Key="GeneratedMipsWrapper"/>
     </UserControl.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
@@ -27,8 +28,10 @@
         <TextBlock Grid.Row="0" Grid.Column="0" Margin="3">Scaled</TextBlock>
         <TextBox Grid.Row="0" Grid.Column="1" Margin="3" Text="{Binding Scaled}"/>
 
-        <TextBlock Grid.Row="1" Grid.Column="0" Margin="3" Visibility="{Binding DataContext.IsGMS2, Mode=OneTime, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}">Generated mips</TextBlock>
-        <TextBox Grid.Row="1" Grid.Column="1" Margin="3" Text="{Binding GeneratedMips}" Visibility="{Binding DataContext.IsGMS2, Mode=OneTime, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}"/>
+        <TextBlock Grid.Row="1" Grid.Column="0" Margin="3"
+                   Visibility="{Binding DataContext.IsGMS2, Mode=OneTime, Converter={StaticResource GeneratedMipsWrapper}, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}">Generated mips</TextBlock>
+        <TextBox Grid.Row="1" Grid.Column="1" Margin="3" Text="{Binding GeneratedMips}"
+                 Visibility="{Binding DataContext.IsGMS2, Mode=OneTime, Converter={StaticResource GeneratedMipsWrapper}, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}"/>
 
         <TextBlock Grid.Row="2" Grid.Column="0" Margin="3">Size</TextBlock>
         <Grid Grid.Row="2" Grid.Column="1">

--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
@@ -18,6 +18,7 @@ using System.Drawing;
 using UndertaleModLib.Models;
 using UndertaleModLib.Util;
 using System.Globalization;
+using UndertaleModLib;
 
 namespace UndertaleModTool
 {
@@ -136,6 +137,33 @@ namespace UndertaleModTool
         }
 
         public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class GeneratedMipsWrapper : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == DependencyProperty.UnsetValue)
+                return null;
+
+            Visibility isGMS2;
+            try
+            {
+                isGMS2 = (Visibility)value;
+            }
+            catch
+            {
+                return null;
+            }
+
+            return (isGMS2 == Visibility.Visible && !UndertaleChunkTXTR.NoGeneratedMips)
+                   ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
             throw new NotImplementedException();
         }

--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
@@ -118,6 +118,9 @@ namespace UndertaleModTool
     {
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
+            if (values.Any(v => v == DependencyProperty.UnsetValue))
+                return null;
+
             bool textureLoaded, textureExternal;
             try
             {

--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
@@ -146,21 +146,10 @@ namespace UndertaleModTool
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value == DependencyProperty.UnsetValue)
-                return null;
+            if (value is not UndertaleData data)
+                return Visibility.Collapsed;
 
-            Visibility isGMS2;
-            try
-            {
-                isGMS2 = (Visibility)value;
-            }
-            catch
-            {
-                return null;
-            }
-
-            return (isGMS2 == Visibility.Visible && !UndertaleChunkTXTR.NoGeneratedMips)
-                   ? Visibility.Visible : Visibility.Collapsed;
+            return data.IsVersionAtLeast(2, 0, 6) ? Visibility.Visible : Visibility.Collapsed;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)


### PR DESCRIPTION
## Description
It turns out that in the range of GMS version 2.0 - 2.1, embedded texture didn't have a `GeneratedMips`, and UTMT cannot handle that.
This PR fixes that.

Closes #750, closes #1112

### Caveats
Embedded textures chunk unserialization could be unnoticeably slower, I guess.