### PR TITLE
(minor) Create GlobalScript entries in GMS2.3

### DIFF
--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -2184,7 +2184,8 @@ namespace UndertaleModTool
                     if (obj is UndertaleScript)
                     {
                         UndertaleCode code = new UndertaleCode();
-                        code.Name = Data.Strings.MakeString("gml_Script_" + newname);
+                        string prefix = Data.IsVersionAtLeast(2, 3) ? "gml_GlobalScript_" : "gml_Script";
+                        code.Name = Data.Strings.MakeString(prefix + newname);
                         Data.Code.Add(code);
                         if (Data?.GeneralInfo.BytecodeVersion > 14)
                         {

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -2184,7 +2184,7 @@ namespace UndertaleModTool
                     if (obj is UndertaleScript)
                     {
                         UndertaleCode code = new UndertaleCode();
-                        string prefix = Data.IsVersionAtLeast(2, 3) ? "gml_GlobalScript_" : "gml_Script";
+                        string prefix = Data.IsVersionAtLeast(2, 3) ? "gml_GlobalScript_" : "gml_Script_";
                         code.Name = Data.Strings.MakeString(prefix + newname);
                         Data.Code.Add(code);
                         if (Data?.GeneralInfo.BytecodeVersion > 14)


### PR DESCRIPTION
## Description
Creating a Script entry in the tool generally defaults a matching code entry, titled "gml_Script_script1234" or similar. This minor PR causes the code entry to be titled with "gml_GlobalScript" in games that use such for scripts.

### Caveats
N/A

### Notes
It would be nice if it generated an empty function within the code, but that function would have a default name and that default name would likely end up being more hassle to change. I'm sure our fine users can figure out how to use the function keyword!