### PR TITLE
Fix of the annoying XAML binding error.

### DIFF
--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -3418,6 +3418,12 @@ result in loss of work.");
 
                 int currIndex = CurrentTabIndex;
 
+                // Getting rid of the XAML binding error.
+                // See https://stackoverflow.com/a/21001501/12136394
+                var item = TabController.ItemContainerGenerator.ContainerFromIndex(tabIndex) as TabItem;
+                if (item is not null)
+                    item.Template = null;
+
                 // "CurrentTabIndex" changes here (bound to "TabController.SelectedIndex")
                 Tabs.RemoveAt(tabIndex);
 


### PR DESCRIPTION
## Description
Apparently, that XAML binding error on tab opening is caused by Windows 8+ default `TabControl` template.
And there's a fix for that.
https://stackoverflow.com/questions/14419248/cannot-find-source-for-binding

Closes #1227 