### PR TITLE
More ways of opening an object in a new tab.

### DIFF
--- a/UndertaleModCli/Program.UMTLibInherited.cs
+++ b/UndertaleModCli/Program.UMTLibInherited.cs
@@ -371,7 +371,7 @@ public partial class Program : IScriptInterface
     }
 
     /// <inheritdoc/>
-    public void ChangeSelection(object newSelection)
+    public void ChangeSelection(object newSelection, bool inNewTab = false)
     {
         //this does *not* make sense, as CLI does not have any selections
         //however, since Selection is a public object, it could potentially be used by scripts

--- a/UndertaleModLib/Scripting/IScriptInterface.cs
+++ b/UndertaleModLib/Scripting/IScriptInterface.cs
@@ -515,7 +515,8 @@ namespace UndertaleModLib.Scripting
         /// Changes the currently selected in the GUI.
         /// </summary>
         /// <param name="newSelection">The new object that should now be selected.</param>
-        void ChangeSelection(object newSelection);
+        /// <param name="inNewTab">Whether the object should be open in a new tab.</param>
+        void ChangeSelection(object newSelection, bool inNewTab = false);
 
         /// <summary>
         /// Used to prompt the user for a directory.

--- a/UndertaleModTool/Controls/AudioFileReference.xaml
+++ b/UndertaleModTool/Controls/AudioFileReference.xaml
@@ -6,6 +6,11 @@
              xmlns:local="clr-namespace:UndertaleModTool"
              mc:Ignorable="d" 
              d:DesignHeight="20" d:DesignWidth="300">
+    <UserControl.Resources>
+        <local:ContextMenuDark x:Key="contextMenu">
+            <local:MenuItemDark Header="Open in new tab" Click="OpenInNewTabItem_Click"/>
+        </local:ContextMenuDark>
+    </UserControl.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="1*"/>
@@ -17,7 +22,7 @@
             <TextBox.Style>
                 <Style TargetType="{x:Type TextBox}">
                     <Style.Triggers>
-                        <DataTrigger Binding="{Binding GroupID, RelativeSource={RelativeSource AncestorType=UserControl}}" Value="0">
+                        <DataTrigger Binding="{Binding GroupID}" Value="0">
                             <DataTrigger.Setters>
                                 <Setter Property="IsReadOnly" Value="True"/>
                             </DataTrigger.Setters>
@@ -26,13 +31,14 @@
                 </Style>
             </TextBox.Style>
         </TextBox>
-        <TextBox Grid.Column="1" IsReadOnly="True" Cursor="Arrow" ToolTip="This is an object reference. Drag and drop an object of matching type from the tree on the left to change it!" AllowDrop="True" PreviewDragOver="TextBox_DragOver" PreviewDrop="TextBox_Drop" PreviewMouseDoubleClick="TextBox_MouseDoubleClick">
+        <TextBox Grid.Column="1" Name="ObjectText" IsReadOnly="True" Cursor="Arrow" ToolTip="This is an object reference. Drag and drop an object of matching type from the tree on the left to change it!" AllowDrop="True"
+                 PreviewDragOver="TextBox_DragOver" PreviewDrop="TextBox_Drop" PreviewMouseDoubleClick="TextBox_MouseDoubleClick" PreviewMouseDown="Details_MouseDown">
             <TextBox.Style>
                 <Style TargetType="{x:Type TextBox}">
                     <Setter Property="Text">
                         <Setter.Value>
                             <MultiBinding StringFormat="{}(UndertaleEmbeddedAudio#{0})">
-                                <Binding Path="AudioID" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
+                                <Binding Path="AudioID"/>
                             </MultiBinding>
                         </Setter.Value>
                     </Setter>
@@ -42,8 +48,8 @@
                                 <Setter Property="Text">
                                     <Setter.Value>
                                         <MultiBinding StringFormat="{}(UndertaleEmbeddedAudio#{0} in UndertaleAudioGroup#{1}:{2})">
-                                            <Binding Path="AudioID" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                            <Binding Path="GroupID" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
+                                            <Binding Path="AudioID"/>
+                                            <Binding Path="GroupID"/>
                                             <Binding Path="GroupReference.Name.Content" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
                                         </MultiBinding>
                                     </Setter.Value>
@@ -59,7 +65,7 @@
                 </Style>
             </TextBox.Style>
         </TextBox>
-        <local:ButtonDark Grid.Column="2" Click="Details_Click" Content=" ... " ToolTip="Open referenced object">
+        <local:ButtonDark Grid.Column="2" Click="Details_Click" MouseDown="Details_MouseDown" Content=" ... " ToolTip="Open referenced object">
             <Button.Style>
                 <Style TargetType="{x:Type Button}">
                     <Style.Triggers>

--- a/UndertaleModTool/Controls/AudioFileReference.xaml.cs
+++ b/UndertaleModTool/Controls/AudioFileReference.xaml.cs
@@ -28,7 +28,23 @@ namespace UndertaleModTool
             DependencyProperty.Register("AudioReference", typeof(UndertaleEmbeddedAudio),
                 typeof(AudioFileReference),
                 new FrameworkPropertyMetadata(null,
-                    FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+                    FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, (sender, e) =>
+                    {
+                        var inst = sender as AudioFileReference;
+                        if (inst is null)
+                            return;
+
+                        if (e.NewValue is null)
+                            inst.ObjectText.ContextMenu = null;
+                        else
+                        {
+                            try
+                            {
+                                inst.ObjectText.ContextMenu = inst.Resources["contextMenu"] as ContextMenu;
+                            }
+                            catch { }
+                        }
+                    }));
 
         public static readonly DependencyProperty GroupReferenceProperty =
             DependencyProperty.Register("GroupReference", typeof(UndertaleAudioGroup),
@@ -77,6 +93,15 @@ namespace UndertaleModTool
         {
             OpenReference();
         }
+        private void Details_MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (e.ChangedButton == MouseButton.Middle && e.ButtonState == MouseButtonState.Pressed)
+                OpenReference(true);
+        }
+        private void OpenInNewTabItem_Click(object sender, RoutedEventArgs e)
+        {
+            OpenReference(true);
+        }
 
         private void Remove_Click(object sender, RoutedEventArgs e)
         {
@@ -88,7 +113,7 @@ namespace UndertaleModTool
             OpenReference();
         }
 
-        private void OpenReference()
+        private void OpenReference(bool inNewTab = false)
         {
             if (GroupID != 0 && AudioID != -1)
             {
@@ -99,7 +124,7 @@ namespace UndertaleModTool
             if (AudioReference == null)
                 return;
 
-            (Application.Current.MainWindow as MainWindow).ChangeSelection(AudioReference);
+            (Application.Current.MainWindow as MainWindow).ChangeSelection(AudioReference, inNewTab);
         }
 
         private void TextBox_DragOver(object sender, DragEventArgs e)

--- a/UndertaleModTool/Controls/UndertaleObjectReference.xaml
+++ b/UndertaleModTool/Controls/UndertaleObjectReference.xaml
@@ -7,6 +7,11 @@
              xmlns:undertale="clr-namespace:UndertaleModLib.Models;assembly=UndertaleModLib"
              mc:Ignorable="d" 
              d:DesignHeight="20" d:DesignWidth="300">
+    <UserControl.Resources>
+        <local:ContextMenuDark x:Key="contextMenu">
+            <local:MenuItemDark Header="Open in new tab" Click="OpenInNewTabItem_Click"/>
+        </local:ContextMenuDark>
+    </UserControl.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*"/>
@@ -15,9 +20,9 @@
         </Grid.ColumnDefinitions>
         <TextBox Grid.Column="0" Name="ObjectText" IsReadOnly="True" Cursor="Arrow" AllowDrop="True"
                  ToolTip="This is an object reference. Drag and drop an object of matching type from the tree on the left to change it!"
-                 PreviewDragOver="TextBox_DragOver" PreviewDrop="TextBox_Drop" PreviewMouseDoubleClick="TextBox_MouseDoubleClick"
+                 PreviewDragOver="TextBox_DragOver" PreviewDrop="TextBox_Drop" PreviewMouseDoubleClick="TextBox_MouseDoubleClick" PreviewMouseDown="Details_MouseDown"
                  Text="{Binding ObjectReference, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
-        <local:ButtonDark Grid.Column="1" x:Name="DetailsButton" Click="Details_Click">
+        <local:ButtonDark Grid.Column="1" x:Name="DetailsButton" Click="Details_Click" MouseDown="Details_MouseDown">
             <Button.Style>
                 <Style TargetType="{x:Type Button}">
                     <Setter Property="Content" Value=" ... " />

--- a/UndertaleModTool/Controls/UndertaleStringReference.xaml
+++ b/UndertaleModTool/Controls/UndertaleStringReference.xaml
@@ -4,15 +4,21 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:UndertaleModTool"
-             xmlns:x1="clr-namespace:System;assembly=mscorlib"
              mc:Ignorable="d" 
              d:DesignHeight="20" d:DesignWidth="300">
+    <UserControl.Resources>
+        <local:ContextMenuDark x:Key="contextMenu">
+            <local:MenuItemDark Header="Open in new tab" Click="OpenInNewTabItem_Click"/>
+        </local:ContextMenuDark>
+    </UserControl.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*"/>
             <ColumnDefinition Width="Auto"/>
         </Grid.ColumnDefinitions>
-        <TextBox Grid.Column="0" ToolTip="This is an string reference. Change the value here to edit this just this value of all referenced values, or drag and drop another string instance from the tree on the left to change the reference" AllowDrop="True" PreviewDragOver="TextBox_DragOver" PreviewDrop="TextBox_Drop" Text="{Binding ObjectReference.Content, RelativeSource={RelativeSource AncestorType=UserControl}, UpdateSourceTrigger=Explicit}" LostFocus="TextBox_LostFocus">
+        <TextBox Grid.Column="0" Name="ObjectText" ToolTip="This is an string reference. Change the value here to edit this just this value of all referenced values, or drag and drop another string instance from the tree on the left to change the reference"
+                 AllowDrop="True" Text="{Binding ObjectReference.Content, RelativeSource={RelativeSource AncestorType=UserControl}, UpdateSourceTrigger=Explicit}"
+                 PreviewDragOver="TextBox_DragOver" PreviewDrop="TextBox_Drop" LostFocus="TextBox_LostFocus" PreviewMouseDown="Details_MouseDown">
             <TextBox.Style>
                 <Style TargetType="{x:Type TextBox}">
                     <Style.Resources>
@@ -43,7 +49,7 @@
                 </Style>
             </TextBox.Style>
         </TextBox>
-        <local:ButtonDark Grid.Column="1" Click="Details_Click" Content=" ... " ToolTip="Open referenced object">
+        <local:ButtonDark Grid.Column="1" Click="Details_Click" MouseDown="Details_MouseDown" Content=" ... " ToolTip="Open referenced object">
             <Button.Style>
                 <Style TargetType="{x:Type Button}">
                     <Style.Triggers>

--- a/UndertaleModTool/Controls/UndertaleStringReference.xaml.cs
+++ b/UndertaleModTool/Controls/UndertaleStringReference.xaml.cs
@@ -23,11 +23,29 @@ namespace UndertaleModTool
     /// </summary>
     public partial class UndertaleStringReference : UserControl
     {
+        private static readonly MainWindow mainWindow = Application.Current.MainWindow as MainWindow;
+
         public static DependencyProperty ObjectReferenceProperty =
             DependencyProperty.Register("ObjectReference", typeof(UndertaleString),
                 typeof(UndertaleStringReference),
                 new FrameworkPropertyMetadata(null,
-                    FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+                    FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, (sender, e) =>
+                    {
+                        var inst = sender as UndertaleStringReference;
+                        if (inst is null)
+                            return;
+
+                        if (e.NewValue is null)
+                            inst.ObjectText.ContextMenu = null;
+                        else
+                        {
+                            try
+                            {
+                                inst.ObjectText.ContextMenu = inst.Resources["contextMenu"] as ContextMenu;
+                            }
+                            catch { }
+                        }
+                    }));
 
         public UndertaleString ObjectReference
         {
@@ -42,7 +60,19 @@ namespace UndertaleModTool
 
         private void Details_Click(object sender, RoutedEventArgs e)
         {
-            (Application.Current.MainWindow as MainWindow).ChangeSelection(ObjectReference);
+            mainWindow.ChangeSelection(ObjectReference);
+        }
+        private void Details_MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (ObjectReference is null)
+                return;
+
+            if (e.ChangedButton == MouseButton.Middle && e.ButtonState == MouseButtonState.Pressed)
+                mainWindow.ChangeSelection(ObjectReference, true);
+        }
+        private void OpenInNewTabItem_Click(object sender, RoutedEventArgs e)
+        {
+            mainWindow.ChangeSelection(ObjectReference, true);
         }
 
         private void Remove_Click(object sender, RoutedEventArgs e)

--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml
@@ -62,9 +62,14 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
-            <Viewbox Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" Stretch="Uniform" StretchDirection="DownOnly"
+            <TextBlock Grid.Row="0" Grid.ColumnSpan="3" Margin="3" HorizontalAlignment="Center" Foreground="DarkGray" FontStyle="Italic" TextWrapping="Wrap" TextAlignment="Center">
+                Hint: You can open a texture page item by clicking on its region below.<LineBreak/>
+                The middle (wheel) mouse button will open it in a new tab.
+            </TextBlock>
+            <Viewbox Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3" Stretch="Uniform" StretchDirection="DownOnly"
                      SnapsToDevicePixels="True" RenderOptions.BitmapScalingMode="NearestNeighbor">
                 <Border>
                     <Border.Background>
@@ -78,12 +83,12 @@
                         </DrawingBrush>
                     </Border.Background>
 
-                    <Image Source="{Binding TextureData.TextureBlob, Mode=OneWay}" MouseLeftButtonDown="Image_MouseLeftButtonDown"/>
+                    <Image Source="{Binding TextureData.TextureBlob, Mode=OneWay}" MouseDown="Image_MouseDown" Cursor="Hand"/>
                 </Border>
             </Viewbox>
 
-            <local:ButtonDark Grid.Row="1" Grid.Column="0" Content="Import" Click="Import_Click"/>
-            <local:ButtonDark Grid.Row="1" Grid.Column="3" Content="Export" Click="Export_Click"/>
+            <local:ButtonDark Grid.Row="2" Grid.Column="0" Margin="0,2" Content="Import" Click="Import_Click"/>
+            <local:ButtonDark Grid.Row="2" Grid.Column="3" Margin="0,2" Content="Export" Click="Export_Click"/>
         </Grid>
     </Grid>
 </local:DataUserControl>

--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
@@ -100,18 +100,23 @@ namespace UndertaleModTool
             }
         }
 
-        private void Image_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        private void Image_MouseDown(object sender, MouseButtonEventArgs e)
         {
+            if (e.ChangedButton == MouseButton.Right)
+                return;
+
             var pos = e.GetPosition(sender as IInputElement);
             var tex = this.DataContext as UndertaleEmbeddedTexture;
-            var tpag = (Application.Current.MainWindow as MainWindow).Data.TexturePageItems.Where((x) =>
+            var tpag = mainWindow.Data.TexturePageItems.Where((x) =>
             {
                 if (x.TexturePage != tex)
                     return false;
                 return pos.X > x.SourceX && pos.X < x.SourceX + x.SourceWidth && pos.Y > x.SourceY && pos.Y < x.SourceY + x.SourceHeight;
             }).FirstOrDefault();
             if (tpag != null)
-                (Application.Current.MainWindow as MainWindow).ChangeSelection(tpag);
+                mainWindow.ChangeSelection(tpag, e.ChangedButton == MouseButton.Middle);
+            else
+                mainWindow.ShowWarning("Cannot find a texture page item located at the click position.");
         }
     }
 

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
@@ -78,7 +78,7 @@
             </Grid.ColumnDefinitions>
 
             <TreeView Grid.Column="0" Margin="0,0,3,0" SelectedItemChanged="TreeView_SelectedItemChanged" Name="RoomObjectsTree"
-                      KeyDown="RoomObjectsTree_KeyDown" MouseDoubleClick="RoomObjectsTree_MouseDoubleClick">
+                      KeyDown="RoomObjectsTree_KeyDown" MouseDoubleClick="RoomObjectsTree_MouseDoubleClick" MouseDown="RoomObjectsTree_MouseDown">
                 <TreeView.Resources>
                     <DataTemplate DataType="{x:Type undertale:UndertaleRoom+GameObject}">
                         <TextBlock>

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -1119,14 +1119,43 @@ namespace UndertaleModTool
         private void RoomObjectsTree_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
             object sel = (sender as TreeView).SelectedItem;
-            if (sel is GameObject)
-                mainWindow.ChangeSelection((sel as GameObject).ObjectDefinition);
-            if (sel is Background)
-                mainWindow.ChangeSelection((sel as Background).BackgroundDefinition);
-            if (sel is Tile)
-                mainWindow.ChangeSelection((sel as Tile).ObjectDefinition);
-            if (sel is SpriteInstance)
-                mainWindow.ChangeSelection((sel as SpriteInstance).Sprite);
+            if (sel is GameObject gameObj)
+                mainWindow.ChangeSelection(gameObj.ObjectDefinition);
+            if (sel is Background bg)
+                mainWindow.ChangeSelection(bg.BackgroundDefinition);
+            if (sel is Tile tile)
+                mainWindow.ChangeSelection(tile.ObjectDefinition);
+            if (sel is SpriteInstance sprInst)
+                mainWindow.ChangeSelection(sprInst.Sprite);
+        }
+        private async void RoomObjectsTree_MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (e.ChangedButton != MouseButton.Middle)
+                return;
+
+            TreeViewItem treeViewItem = MainWindow.VisualUpwardSearch<TreeViewItem>(e.OriginalSource as DependencyObject);
+            treeViewItem?.Focus();
+
+            RoomObjectsTree.UpdateLayout();
+            ObjectEditor.UpdateLayout();
+            await Task.Run(async () =>
+            {
+                // Added a little delay in order to see that selection was changed
+                await Task.Delay(25);
+
+                Dispatcher.Invoke(() =>
+                {
+                    object sel = (sender as TreeView).SelectedItem;
+                    if (sel is GameObject gameObj)
+                        mainWindow.ChangeSelection(gameObj.ObjectDefinition, true);
+                    if (sel is Background bg)
+                        mainWindow.ChangeSelection(bg.BackgroundDefinition, true);
+                    if (sel is Tile tile)
+                        mainWindow.ChangeSelection(tile.ObjectDefinition, true);
+                    if (sel is SpriteInstance sprInst)
+                        mainWindow.ChangeSelection(sprInst.Sprite, true);
+                });
+            });
         }
 
         private UndertaleObject copied;
@@ -1670,6 +1699,7 @@ namespace UndertaleModTool
             canvas.CurrentLayer = layer;
             ObjElemDict[layer] = canvas;
         }
+
         private void LayerCanvas_Unloaded(object sender, RoutedEventArgs e)
         {
             LayerCanvas canvas = sender as LayerCanvas;

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -2301,7 +2301,7 @@ namespace UndertaleModTool
             updater.Dispose();
         }
 
-        public void OpenCodeFile(string name, CodeEditorMode editorDecompile)
+        public void OpenCodeFile(string name, CodeEditorMode editorDecompile, bool inNewTab = false)
         {
             UndertaleCode code = Data.Code.ByName(name);
 
@@ -2336,7 +2336,7 @@ namespace UndertaleModTool
                     CodeEditorDecompile = editorDecompile;
 
                 HighlightObject(code);
-                ChangeSelection(code);
+                ChangeSelection(code, inNewTab);
             }
             else
             {

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -3515,9 +3515,9 @@ result in loss of work.");
             return false;
         }
 
-        public void ChangeSelection(object newsel)
+        public void ChangeSelection(object newsel, bool inNewTab = false)
         {
-            OpenInTab(newsel);
+            OpenInTab(newsel, inNewTab);
         }
 
         private void TabController_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/UndertaleModTool/Windows/ClickableTextOutput.xaml
+++ b/UndertaleModTool/Windows/ClickableTextOutput.xaml
@@ -7,6 +7,11 @@
         xmlns:local="clr-namespace:UndertaleModTool"
         mc:Ignorable="d"
         Title="ClickableTextOutput" Height="540" Width="536" MinHeight="160" MinWidth="210">
+    <Window.Resources>
+        <local:ContextMenuDark x:Key="linkContextMenu" Placement="MousePoint">
+            <local:MenuItemDark Header="Open in new tab" Click="OpenInNewTabItem_Click"/>
+        </local:ContextMenuDark>
+    </Window.Resources>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="25*"/>
@@ -16,15 +21,14 @@
         <Grid.Background>
             <DynamicResource ResourceKey="{x:Static SystemColors.ControlBrushKey}"/>
         </Grid.Background>
-        <Label x:Name="FillingLabel" Content="Displaying the results, please wait..." HorizontalAlignment="Center" VerticalAlignment="Top" Visibility="Hidden" FontSize="14" FontStyle="Normal" Margin="0,-3,0,0" Grid.RowSpan="2"/>
-        <RichTextBox x:Name="OutTextBox" Margin="10,25,10,0" FontSize="14" IsDocumentEnabled="True" IsReadOnly="True" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Grid.RowSpan="2">
+        <Label x:Name="FillingLabel" Content="Displaying the results, please wait..." HorizontalAlignment="Center" VerticalAlignment="Top" Visibility="Hidden" FontSize="14" FontStyle="Normal"
+               Margin="0,-3,0,0" Grid.RowSpan="2"/>
+        <RichTextBox x:Name="OutTextBox" Margin="10,25,10,0" FontSize="14" IsDocumentEnabled="True" IsReadOnly="True" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto"
+                     Grid.RowSpan="2" PreviewMouseDown="OutTextBox_PreviewMouseDown">
             <RichTextBox.Background>
                 <DynamicResource ResourceKey="{x:Static SystemColors.ControlLightLightBrushKey}"/>
             </RichTextBox.Background>
             <RichTextBox.Resources>
-                <Style TargetType="Hyperlink">
-                    <EventSetter Event="Click" Handler="Hyperlink_Click"/>
-                </Style>
                 <Style TargetType="Paragraph">
                     <Setter Property="Margin" Value="0"/>
                 </Style>


### PR DESCRIPTION
## Description
Addresses the second sub-issue of [this comment](https://github.com/krzys-h/UndertaleModTool/issues/827#issuecomment-1152974833).
Now you can open objects in a new tab from:
- Object reference fields (e.g. a background definition of room background).
- Code editor (object IDs, function references).
- Embedded texture editor (by middle mouse clicking on the image).
- Room editor object list.
- Code search results of "Search.csx" script.

Also, I've added a hint for embedded texture image clickability, and optimized the code search results text elements generation by moving out click event from every "hyperlink" to the text window.