### PR TITLE
Fix of the "Bleeding Edge" release updating/uploading.

### DIFF
--- a/.github/workflows/publish_gui_nightly.yml
+++ b/.github/workflows/publish_gui_nightly.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Download artifacts
       uses: actions/download-artifact@v2
     - name: Delete tag and release
-      uses: dev-drprasad/delete-tag-and-release@v0.2.0
+      uses: dev-drprasad/delete-tag-and-release@v0.2.1
       with:
         delete_release: true # default: false
         tag_name: bleeding-edge # tag name to delete


### PR DESCRIPTION
## Description
The author of "delete-tag-and-release" library removed version 0.2.0 (because of new 0.2.1 version), so the GH action was broken (see [this issue](https://github.com/dev-drprasad/delete-tag-and-release/issues/20)).

And this PR updates the required version to 0.2.1, which should fix that.