### PR TITLE
An initial support for GM 2023.2 games (and one fix).

### DIFF
--- a/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
+++ b/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
@@ -169,7 +169,7 @@ public class UndertaleEmbeddedTexture : UndertaleNamedResource, IDisposable,
 
         if (writer.undertaleData.IsVersionAtLeast(2022, 3))
         {
-            _textureBlockSize = texStartPos - writer.Position;
+            _textureBlockSize = writer.Position - texStartPos;
             // Write the actual size of the texture block in
             // the place of _textureBlockSize
             var posBackup = writer.Position;

--- a/UndertaleModLib/Models/UndertaleFont.cs
+++ b/UndertaleModLib/Models/UndertaleFont.cs
@@ -75,9 +75,16 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
     public float ScaleY { get; set; }
 
     /// <summary>
-    /// TODO: currently unknown, needs investigation. GMS2022.2 specific?
+    /// TODO: currently unknown, needs investigation. GM 2022.2 specific?
     /// </summary>
     public uint Ascender { get; set; }
+
+    /// <summary>
+    /// A spread value that's used for SDF rendering.
+    /// Introduced in GM 2023.2.
+    /// </summary>
+    /// <value><c>0</c> if SDF is disabled for this font.</value>
+    public uint SDFSpread { get; set; }
 
     /// <summary>
     /// The glyphs that this font uses.
@@ -242,6 +249,8 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
             writer.Write(AscenderOffset);
         if (writer.undertaleData.IsVersionAtLeast(2022, 2))
             writer.Write(Ascender);
+        if (writer.undertaleData.IsVersionAtLeast(2023, 2))
+            writer.Write(SDFSpread);
         writer.WriteUndertaleObject(Glyphs);
     }
 
@@ -274,6 +283,8 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
             AscenderOffset = reader.ReadInt32();
         if (reader.undertaleData.IsVersionAtLeast(2022, 2))
             Ascender = reader.ReadUInt32();
+        if (reader.undertaleData.IsVersionAtLeast(2023, 2))
+            SDFSpread = reader.ReadUInt32();
         Glyphs = reader.ReadUndertaleObject<UndertalePointerList<Glyph>>();
     }
 
@@ -285,6 +296,8 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
             skipSize += 4; // AscenderOffset
         if (reader.undertaleData.IsVersionAtLeast(2022, 2))
             skipSize += 4; // Ascender
+        if (reader.undertaleData.IsVersionAtLeast(2023, 2))
+            skipSize += 4; // SDFSpread
 
         reader.Position += skipSize;
 

--- a/UndertaleModLib/Models/UndertaleGeneralInfo.cs
+++ b/UndertaleModLib/Models/UndertaleGeneralInfo.cs
@@ -315,7 +315,9 @@ public class UndertaleGeneralInfo : UndertaleObject, IDisposable
         (uint Major, uint Minor, uint Release, uint Build) detectedVer = readVersion;
 
         // Some GMS2+ version detection. The rest is spread around, mostly in UndertaleChunks.cs
-        if (reader.AllChunkNames.Contains("FEAT"))      // 2022.8
+        if (reader.AllChunkNames.Contains("PSEM"))      // 2023.2
+            detectedVer = (2023, 2, 0, 0);
+        else if (reader.AllChunkNames.Contains("FEAT")) // 2022.8
             detectedVer = (2022, 8, 0, 0);
         else if (reader.AllChunkNames.Contains("FEDS")) // 2.3.6
             detectedVer = (2, 3, 6, 0);

--- a/UndertaleModLib/Models/UndertaleSequence.cs
+++ b/UndertaleModLib/Models/UndertaleSequence.cs
@@ -319,8 +319,11 @@ public class UndertaleSequence : UndertaleNamedResource, IDisposable
                 case "GMColourTrack":
                     writer.WriteUndertaleObject(Keyframes as RealKeyframes);
                     break;
-                case "GMTextTrack": // Introduced in GM 2022.2
+                case "GMTextTrack":     // Introduced in GM 2022.2
                     writer.WriteUndertaleObject(Keyframes as TextKeyframes);
+                    break;
+                case "GMParticleTrack": // Introduced in GM 2023.2
+                    writer.WriteUndertaleObject(Keyframes as ParticleKeyframes);
                     break;
             }
         }
@@ -408,12 +411,13 @@ public class UndertaleSequence : UndertaleNamedResource, IDisposable
                 case "GMColourTrack":
                     Keyframes = reader.ReadUndertaleObject<RealKeyframes>();
                     break;
-                case "GMTextTrack": // Introduced in GM 2022.2
+                case "GMTextTrack":     // Introduced in GM 2022.2
                     Keyframes = reader.ReadUndertaleObject<TextKeyframes>();
                     break;
+                case "GMParticleTrack": // Introduced in GM 2023.2
+                    Keyframes = reader.ReadUndertaleObject<ParticleKeyframes>();
+                    break;
 
-                case "GMParticleTrack":
-                    throw new NotImplementedException("GMParticleTrack not implemented, report this");
                 case "GMGroupTrack":
                     throw new NotImplementedException("GMGroupTrack not implemented, report this");
                 case "GMClipMaskTrack":
@@ -492,12 +496,13 @@ public class UndertaleSequence : UndertaleNamedResource, IDisposable
                 case "GMColourTrack":
                     count += 1 + RealKeyframes.UnserializeChildObjectCount(reader);
                     break;
-                case "GMTextTrack": // Introduced in GM 2022.2
+                case "GMTextTrack":     // Introduced in GM 2022.2
                     count += 1 + TextKeyframes.UnserializeChildObjectCount(reader);
                     break;
+                case "GMParticleTrack": // Introduced in GM 2023.2
+                    count += 1 + ParticleKeyframes.UnserializeChildObjectCount(reader);
+                    break;
 
-                case "GMParticleTrack":
-                    throw new NotImplementedException("GMParticleTrack not implemented, report this");
                 case "GMGroupTrack":
                     throw new NotImplementedException("GMGroupTrack not implemented, report this");
                 case "GMClipMaskTrack":
@@ -915,6 +920,30 @@ public class UndertaleSequence : UndertaleNamedResource, IDisposable
                 Wrap = reader.ReadBoolean();
                 _alignment = reader.ReadInt32();
                 FontIndex = reader.ReadInt32();
+            }
+        }
+    }
+
+    public class ParticleKeyframes : TrackKeyframes<ParticleKeyframes.Data>
+    {
+        // A temporary implementation, its type should be "ResourceData<UndertaleResourceById<...>>"
+        public class Data : UndertaleObject, IStaticChildObjectsSize
+        {
+            /// <inheritdoc cref="IStaticChildObjectsSize.ChildObjectsSize" />
+            public static readonly uint ChildObjectsSize = 4;
+
+            public int ParticleSystemIndex { get; set; }
+
+            /// <inheritdoc />
+            public void Serialize(UndertaleWriter writer)
+            {
+                writer.Write(ParticleSystemIndex);
+            }
+
+            /// <inheritdoc />
+            public void Unserialize(UndertaleReader reader)
+            {
+                ParticleSystemIndex = reader.ReadInt32();
             }
         }
     }

--- a/UndertaleModLib/UndertaleChunkTypes.cs
+++ b/UndertaleModLib/UndertaleChunkTypes.cs
@@ -345,4 +345,20 @@ namespace UndertaleModLib
 
         internal override uint UnserializeObjectCount(UndertaleReader reader) => 0;
     }
+
+    public abstract class UndertaleUnsupportedChunk : UndertaleChunk
+    {
+        public byte[] RawData;
+        internal override void SerializeChunk(UndertaleWriter writer)
+        {
+            writer.Write(RawData);
+        }
+
+        internal override void UnserializeChunk(UndertaleReader reader)
+        {
+            RawData = reader.ReadBytes((int)Length);
+        }
+
+        internal override uint UnserializeObjectCount(UndertaleReader reader) => 0;
+    }
 }

--- a/UndertaleModLib/UndertaleChunks.cs
+++ b/UndertaleModLib/UndertaleChunks.cs
@@ -1586,14 +1586,14 @@ namespace UndertaleModLib
         }
     }
 
-    // GMS2022.8+ only
+    // GM2022.8+ only
     public class UndertaleChunkFEAT : UndertaleSingleChunk<UndertaleFeatureFlags>
     {
         public override string Name => "FEAT";
 
         internal override void SerializeChunk(UndertaleWriter writer)
         {
-            if (writer.undertaleData.GeneralInfo.Major < 2)
+            if (!writer.undertaleData.IsGameMaker2())
                 throw new InvalidOperationException();
 
             while (writer.Position % 4 != 0)
@@ -1604,7 +1604,7 @@ namespace UndertaleModLib
 
         internal override void UnserializeChunk(UndertaleReader reader)
         {
-            if (reader.undertaleData.GeneralInfo.Major < 2)
+            if (!reader.undertaleData.IsGameMaker2())
                 throw new InvalidOperationException();
 
             // Padding
@@ -1627,5 +1627,15 @@ namespace UndertaleModLib
 
             return base.UnserializeObjectCount(reader);
         }
+    }
+
+    // GM2023.2+ only
+    public class UndertaleChunkPSEM : UndertaleUnsupportedChunk
+    {
+        public override string Name => "PSEM";
+    }
+    public class UndertaleChunkPSYS : UndertaleUnsupportedChunk
+    {
+        public override string Name => "PSYS";
     }
 }

--- a/UndertaleModTool/Editors/UndertaleFontEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleFontEditor.xaml
@@ -28,6 +28,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <TextBlock Grid.Row="0" Grid.Column="0" Margin="3">Name</TextBlock>
@@ -83,7 +84,10 @@
             <TextBox Grid.Column="1" Margin="3" Text="{Binding ScaleY}"/>
         </Grid>
 
-        <Viewbox Grid.Row="10" Grid.Column="1" Stretch="Uniform" StretchDirection="DownOnly">
+        <TextBlock Grid.Row="10" Grid.Column="0" Margin="3">SDF spread value</TextBlock>
+        <TextBox Grid.Row="10" Grid.Column="1" Margin="3" Text="{Binding SDFSpread}"/>
+
+        <Viewbox Grid.Row="11" Grid.Column="1" Stretch="Uniform" StretchDirection="DownOnly">
             <Border>
                 <Border.Background>
                     <SolidColorBrush Color="Black"/>
@@ -92,8 +96,8 @@
             </Border>
         </Viewbox>
 
-        <TextBlock Grid.Row="11" Grid.Column="0" Margin="3,30,3,3">Glyphs:</TextBlock>
-        <local:DataGridDark Grid.Row="12" Grid.ColumnSpan="2" MaxHeight="370" Margin="3" x:Name="GlyphsGrid" ItemsSource="{Binding Glyphs, Mode=OneWay}"
+        <TextBlock Grid.Row="12" Grid.Column="0" Margin="3,30,3,3">Glyphs:</TextBlock>
+        <local:DataGridDark Grid.Row="13" Grid.ColumnSpan="2" MaxHeight="370" Margin="3" x:Name="GlyphsGrid" ItemsSource="{Binding Glyphs, Mode=OneWay}"
                             AutoGenerateColumns="False" CanUserAddRows="True" CanUserDeleteRows="True" HorizontalGridLinesBrush="LightGray" VerticalGridLinesBrush="LightGray" HeadersVisibility="Column" SelectionMode="Single" SelectionUnit="FullRow"
                             ScrollViewer.CanContentScroll="True"
                             VirtualizingPanel.IsVirtualizing="True"
@@ -166,10 +170,10 @@
             </DataGrid.Columns>
         </local:DataGridDark>
 
-        <TextBlock Grid.Row="13" Grid.Column="0" Grid.ColumnSpan="2" Margin="3" TextWrapping="Wrap" HorizontalAlignment="Center">
+        <TextBlock Grid.Row="14" Grid.Column="0" Grid.ColumnSpan="2" Margin="3" TextWrapping="Wrap" HorizontalAlignment="Center">
             Note that the glyphs need to be specified in ascending order.<LineBreak/>
             Press the button below to sort them appropriately.
         </TextBlock>
-        <local:ButtonDark Grid.Row="14" Grid.Column="0" Grid.ColumnSpan="2" Margin="3" Click="Button_Sort_Click">Sort glyphs</local:ButtonDark>
+        <local:ButtonDark Grid.Row="15" Grid.Column="0" Grid.ColumnSpan="2" Margin="3" Click="Button_Sort_Click">Sort glyphs</local:ButtonDark>
     </Grid>
 </local:DataUserControl>

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
@@ -109,6 +109,10 @@
                             </TextBlock.Text>
                         </TextBlock>
                     </DataTemplate>
+                    <DataTemplate DataType="{x:Type undertale:UndertaleRoom+ParticleSystemInstance}">
+                        <TextBlock Text="ParticleSystemInstance (unsupported)"
+                                   Foreground="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                    </DataTemplate>
                 </TreeView.Resources>
 
                 <TreeViewItem Header="{Binding Name.Content}" Name="RoomRootItem" IsExpanded="True">
@@ -236,6 +240,9 @@
                                                 </MultiBinding.Converter>
                                                 <Binding Path="AssetsData.LegacyTiles"/>
                                                 <Binding Path="AssetsData.Sprites"/>
+                                                <Binding Path="AssetsData.Sequences"/>
+                                                <Binding Path="AssetsData.NineSlices"/>
+                                                <Binding Path="AssetsData.ParticleSystems"/>
                                             </MultiBinding>
                                         </HierarchicalDataTemplate.ItemsSource>
                                         <TextBlock Text="{Binding LayerName.Content, Mode=OneWay}" Style="{StaticResource LayerItemStyle}">

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -984,6 +984,10 @@ namespace UndertaleModTool
                                 this.ShowWarning("This game is set to run with the GameMaker Studio debugger and the normal runtime will simply hang after loading if the debugger is not running. You can turn this off in General Info by checking the \"Disable Debugger\" box and saving.", "GMS Debugger");
                             }
                         }
+                        if (data.IsVersionAtLeast(2023, 2))
+                        {
+                            this.ShowWarning("The particle systems that were added in GM 2023.2 are not fully supported yet.");
+                        }
                         if (Path.GetDirectoryName(FilePath) != Path.GetDirectoryName(filename))
                             CloseChildFiles();
 


### PR DESCRIPTION
## Description
1) **GM 2023.2+ games can be loaded and saved**, but the particle systems are not supported yet.
2) Fixed #1237. 
3) Added `UndertaleUnsupportedChunk` type.

Closes #1209, closes #1231