### PR TITLE
Improved "Run game" file context menu option(s).

### DIFF
--- a/UndertaleModLib/UndertaleChunks.cs
+++ b/UndertaleModLib/UndertaleChunks.cs
@@ -98,6 +98,9 @@ namespace UndertaleModLib
 
                     Chunks.Add(chunk.Name, chunk);
                     ChunksTypeDict.Add(chunk.GetType(), chunk);
+
+                    if (reader.ReadOnlyGEN8 && chunk.Name == "GEN8")
+                        return;
                 }
             }
         }

--- a/UndertaleModLib/UndertaleIO.cs
+++ b/UndertaleModLib/UndertaleIO.cs
@@ -160,6 +160,8 @@ namespace UndertaleModLib
         private WarningHandlerDelegate WarningHandler;
         private MessageHandlerDelegate MessageHandler;
 
+        public bool ReadOnlyGEN8 { get; set; }
+
         /// <summary>
         /// The detected absolute path of the data file, if a FileStream is passed in, or null otherwise (by default).
         /// Can also be manually changed.
@@ -173,10 +175,12 @@ namespace UndertaleModLib
         public string Directory { get; set; } = null;
 
         public UndertaleReader(Stream input,
-                               WarningHandlerDelegate warningHandler = null, MessageHandlerDelegate messageHandler = null) : base(input)
+                               WarningHandlerDelegate warningHandler = null, MessageHandlerDelegate messageHandler = null,
+                               bool onlyGeneralInfo = false) : base(input)
         {
             WarningHandler = warningHandler;
             MessageHandler = messageHandler;
+            ReadOnlyGEN8 = onlyGeneralInfo;
             if (input is FileStream fs)
             {
                 FilePath = fs.Name;
@@ -241,7 +245,8 @@ namespace UndertaleModLib
             {
                 try
                 {
-                    poolSize = data.FORM.UnserializeObjectCount(this);
+                    if (!ReadOnlyGEN8)
+                        poolSize = data.FORM.UnserializeObjectCount(this);
                 }
                 catch (Exception e)
                 {
@@ -606,6 +611,9 @@ namespace UndertaleModLib
 
         public void ThrowIfUnreadObjects()
         {
+            if (ReadOnlyGEN8)
+                return;
+
             if (unreadObjects.Count > 0)
             {
                 throw new IOException("Found pointer targets that were never read:\n" + String.Join("\n", unreadObjects.Take(10).Select((x) => "0x" + x.ToString("X8") + " (" + objectPool[x].GetType().Name + ")")) + (unreadObjects.Count > 10 ? "\n(and more, " + unreadObjects.Count + " total)" : ""));
@@ -897,9 +905,10 @@ namespace UndertaleModLib
         public static bool IsDictionaryCleared { get; set; } = true;
 
         public static UndertaleData Read(Stream stream, UndertaleReader.WarningHandlerDelegate warningHandler = null,
-                                                        UndertaleReader.MessageHandlerDelegate messageHandler = null)
+                                                        UndertaleReader.MessageHandlerDelegate messageHandler = null,
+                                                        bool onlyGeneralInfo = false)
         {
-            UndertaleReader reader = new UndertaleReader(stream, warningHandler, messageHandler);
+            UndertaleReader reader = new UndertaleReader(stream, warningHandler, messageHandler, onlyGeneralInfo);
             var data = reader.ReadUndertaleData();
             reader.ThrowIfUnreadObjects();
             return data;


### PR DESCRIPTION
## Description
Closes #453 by loading only the `GEN8` (general info) chunk if UTMT was launched from the "data.win" file context menu options ("Run game normally" and "Run extended options").