### PR TITLE
The "Find all references" feature.

### DIFF
--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -1535,7 +1535,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
         /// <inheritdoc />
         public override string ToString()
         {
-            return "Layer " + LayerName?.Content;
+            return $"Layer \"{LayerName?.Content}\"";
         }
 
         /// <inheritdoc/>
@@ -2129,7 +2129,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
         /// <inheritdoc />
         public override string ToString()
         {
-            return "Sprite " + Name?.Content + " of " + (Sprite?.Name?.Content ?? "?");
+            return "Sprite \"" + Name?.Content + "\" of " + (Sprite?.Name?.Content ?? "?");
         }
 
         /// <inheritdoc/>

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -1129,7 +1129,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
 
         public override string ToString()
         {
-            return "Instance " + InstanceID + " of " + (ObjectDefinition?.Name?.Content ?? "?") + " (UndertaleRoom+GameObject)";
+            return "Instance " + InstanceID + " of " + (ObjectDefinition?.Name?.Content ?? "?");
         }
 
         /// <inheritdoc/>
@@ -1325,7 +1325,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
         /// <inheritdoc />
         public override string ToString()
         {
-            return "Tile " + InstanceID + " of " + (ObjectDefinition?.Name?.Content ?? "?") + " (UndertaleRoom+Tile)";
+            return "Tile " + InstanceID + " of " + (ObjectDefinition?.Name?.Content ?? "?");
         }
 
         /// <inheritdoc/>
@@ -1535,7 +1535,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
         /// <inheritdoc />
         public override string ToString()
         {
-            return GetType().FullName + " - \"" + LayerName?.Content + '\"';
+            return "Layer " + LayerName?.Content;
         }
 
         /// <inheritdoc/>
@@ -2129,7 +2129,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
         /// <inheritdoc />
         public override string ToString()
         {
-            return "Sprite " + Name?.Content + " of " + (Sprite?.Name?.Content ?? "?") + " (UndertaleRoom+SpriteInstance)";
+            return "Sprite " + Name?.Content + " of " + (Sprite?.Name?.Content ?? "?");
         }
 
         /// <inheritdoc/>
@@ -2201,7 +2201,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
         /// <inheritdoc />
         public override string ToString()
         {
-            return "Sequence " + Name?.Content + " of " + (Sequence?.Name?.Content ?? "?") + " (UndertaleRoom+SequenceInstance)";
+            return "Sequence " + Name?.Content + " of " + (Sequence?.Name?.Content ?? "?");
         }
 
         /// <inheritdoc/>

--- a/UndertaleModLib/Models/UndertaleSequence.cs
+++ b/UndertaleModLib/Models/UndertaleSequence.cs
@@ -412,6 +412,8 @@ public class UndertaleSequence : UndertaleNamedResource, IDisposable
                     Keyframes = reader.ReadUndertaleObject<RealKeyframes>();
                     break;
                 case "GMTextTrack":     // Introduced in GM 2022.2
+                    if (!reader.undertaleData.IsVersionAtLeast(2022, 2))
+                        reader.undertaleData.SetGMS2Version(2022, 2);
                     Keyframes = reader.ReadUndertaleObject<TextKeyframes>();
                     break;
                 case "GMParticleTrack": // Introduced in GM 2023.2

--- a/UndertaleModLib/Models/UndertaleTags.cs
+++ b/UndertaleModLib/Models/UndertaleTags.cs
@@ -31,7 +31,7 @@ public class UndertaleTags : UndertaleObject, IDisposable
             UndertaleAnimationCurve => ResourceType.AnimCurve,
             _ => throw new ArgumentException("Invalid resource type!")
         };
-        IList list = data[resource.GetType()] as IList;
+        IList list = data[resource.GetType()];
 
         int offset = resource is UndertaleScript ? 100000 : 0;
 

--- a/UndertaleModLib/UndertaleChunks.cs
+++ b/UndertaleModLib/UndertaleChunks.cs
@@ -47,11 +47,16 @@ namespace UndertaleModLib
         public UndertaleChunkSTRG STRG => Chunks.GetValueOrDefault("STRG") as UndertaleChunkSTRG;
         public UndertaleChunkTXTR TXTR => Chunks.GetValueOrDefault("TXTR") as UndertaleChunkTXTR;
         public UndertaleChunkAUDO AUDO => Chunks.GetValueOrDefault("AUDO") as UndertaleChunkAUDO;
-        // GMS2.3+ for the below chunks
+        // GMS 2.3+ for the below chunks
         public UndertaleChunkACRV ACRV => Chunks.GetValueOrDefault("ACRV") as UndertaleChunkACRV;
         public UndertaleChunkSEQN SEQN => Chunks.GetValueOrDefault("SEQN") as UndertaleChunkSEQN;
         public UndertaleChunkTAGS TAGS => Chunks.GetValueOrDefault("TAGS") as UndertaleChunkTAGS;
         public UndertaleChunkFEAT FEAT => Chunks.GetValueOrDefault("FEAT") as UndertaleChunkFEAT;
+        // GMS 2.3.6+
+        public UndertaleChunkFEDS FEDS => Chunks.GetValueOrDefault("FEDS") as UndertaleChunkFEDS;
+        // GM 2023.2+
+        public UndertaleChunkPSEM PSEM => Chunks.GetValueOrDefault("PSEM") as UndertaleChunkPSEM;
+        public UndertaleChunkPSYS PSYS => Chunks.GetValueOrDefault("PSYS") as UndertaleChunkPSYS;
 
         internal override void SerializeChunk(UndertaleWriter writer)
         {

--- a/UndertaleModLib/UndertaleData.cs
+++ b/UndertaleModLib/UndertaleData.cs
@@ -275,6 +275,12 @@ namespace UndertaleModLib
         public UndertaleFeatureFlags FeatureFlags => FORM.FEAT?.Object;
 
         /// <summary>
+        /// The filter effects stored in the data file.
+        /// </summary>
+        public IList<UndertaleFilterEffect> FilterEffects => FORM.FEDS?.List;
+
+
+        /// <summary>
         /// Whether this is an unsupported bytecode version.
         /// </summary>
         public bool UnsupportedBytecodeVersion = false;

--- a/UndertaleModLib/UndertaleData.cs
+++ b/UndertaleModLib/UndertaleData.cs
@@ -25,18 +25,26 @@ namespace UndertaleModLib
         /// </summary>
         /// <param name="resourceTypeName">The resource name to get.</param>
         /// <exception cref="MissingMemberException"> if the data file does not contain a property with that name.</exception>
-        public object this[string resourceTypeName]
+        public IList this[string resourceTypeName]
         {
             get
             {
+                // Prevent recursion
+                if (resourceTypeName == "Item")
+                    return null;
+
                 var property = GetType().GetProperty(resourceTypeName);
                 if (property is null)
                     throw new MissingMemberException($"\"UndertaleData\" doesn't contain a property named \"{resourceTypeName}\".");
 
-                return property.GetValue(this, null);
+                return property.GetValue(this, null) as IList;
             }
             set
             {
+                // Prevent recursion
+                if (resourceTypeName == "Item")
+                    return;
+                
                 var property = GetType().GetProperty(resourceTypeName);
                 if (property is null)
                     throw new MissingMemberException($"\"UndertaleData\" doesn't contain a property named \"{resourceTypeName}\".");
@@ -51,10 +59,14 @@ namespace UndertaleModLib
         /// <param name="resourceType">The resource type to get.</param>
         /// <exception cref="NotSupportedException"> if the type is not an <see cref="UndertaleNamedResource"/>.</exception>
         /// <exception cref="MissingMemberException"> if the data file does not contain a property of that type.</exception>
-        public object this[Type resourceType]
+        public IList this[Type resourceType]
         {
             get
             {
+                // Prevent recursion
+                if (resourceType == typeof(UndertaleResource))
+                    return null;
+
                 if (!typeof(UndertaleResource).IsAssignableFrom(resourceType))
                     throw new NotSupportedException($"\"{resourceType.FullName}\" is not an UndertaleResource.");
 
@@ -63,7 +75,7 @@ namespace UndertaleModLib
                 if (property is null)
                     throw new MissingMemberException($"\"UndertaleData\" doesn't contain a resource list of type \"{resourceType.FullName}\".");
 
-                return property.GetValue(this, null);
+                return property.GetValue(this, null) as IList;
             }
             set
             {
@@ -611,6 +623,10 @@ namespace UndertaleModLib
             // Clear all object lists (sprites, code, etc.)
             foreach (PropertyInfo dataListProperty in AllListProperties)
             {
+                // If it's an indexer property
+                if (dataListProperty.Name == "Item")
+                    continue;
+
                 // If list is null
                 if (dataListProperty.GetValue(this) is not IList list)
                     continue;

--- a/UndertaleModTool/Controls/UndertaleObjectReference.xaml
+++ b/UndertaleModTool/Controls/UndertaleObjectReference.xaml
@@ -8,8 +8,9 @@
              mc:Ignorable="d" 
              d:DesignHeight="20" d:DesignWidth="300">
     <UserControl.Resources>
-        <local:ContextMenuDark x:Key="contextMenu">
-            <local:MenuItemDark Header="Open in new tab" Click="OpenInNewTabItem_Click"/>
+        <local:ContextMenuDark x:Key="contextMenu" Opened="MenuItem_ContextMenuOpened">
+            <MenuItem Header="Open in new tab" Click="OpenInNewTabItem_Click"/>
+            <MenuItem Header="Find all references" Click="FindAllReferencesItem_Click"/>
         </local:ContextMenuDark>
     </UserControl.Resources>
     <Grid>

--- a/UndertaleModTool/Controls/UndertaleObjectReference.xaml.cs
+++ b/UndertaleModTool/Controls/UndertaleObjectReference.xaml.cs
@@ -17,6 +17,7 @@ using System.Windows.Shapes;
 using UndertaleModLib;
 using UndertaleModLib.Models;
 using UndertaleModLib.Scripting;
+using UndertaleModTool.Windows;
 
 namespace UndertaleModTool
 {
@@ -37,16 +38,20 @@ namespace UndertaleModTool
                         if (inst is null)
                             return;
 
-                        if (e.NewValue is null)
-                            inst.ObjectText.ContextMenu = null;
-                        else
+                        if (e.NewValue is not null)
                         {
                             try
                             {
-                                inst.ObjectText.ContextMenu = inst.Resources["contextMenu"] as ContextMenu;
+                                if (inst.Resources["contextMenu"] is not ContextMenu menu)
+                                    return;
+
+                                menu.DataContext = inst.ObjectReference;
+                                inst.ObjectText.ContextMenu = menu;
                             }
                             catch { }
                         }
+                        else
+                            inst.ObjectText.ContextMenu = null;
                     }));
 
         public static DependencyProperty ObjectTypeProperty =
@@ -152,6 +157,47 @@ namespace UndertaleModTool
         private void OpenInNewTabItem_Click(object sender, RoutedEventArgs e)
         {
             mainWindow.ChangeSelection(ObjectReference, true);
+        }
+        private void MenuItem_ContextMenuOpened(object sender, RoutedEventArgs e)
+        {
+            var menu = sender as ContextMenu;
+            foreach (var item in menu.Items)
+            {
+                var menuItem = item as MenuItem;
+                if ((menuItem.Header as string) == "Find all references")
+                {
+                    Type objType = menu.DataContext.GetType();
+                    menuItem.Visibility = UndertaleResourceReferenceMap.IsTypeReferenceable(objType)
+                                          ? Visibility.Visible : Visibility.Collapsed;
+
+                    break;
+                }
+            }
+        }
+        private void FindAllReferencesItem_Click(object sender, RoutedEventArgs e)
+        {
+            var obj = (sender as FrameworkElement)?.DataContext;
+            if (obj is not UndertaleResource res)
+            {
+                mainWindow.ShowError("The selected object is not an \"UndertaleResource\".");
+                return;
+            }
+
+            FindReferencesTypesDialog dialog = null;
+            try
+            {
+                dialog = new(res, mainWindow.Data);
+                dialog.ShowDialog();
+            }
+            catch (Exception ex)
+            {
+                mainWindow.ShowError("An error occured in the object references related window.\n" +
+                                     $"Please report this on GitHub.\n\n{ex}");
+            }
+            finally
+            {
+                dialog?.Close();
+            }
         }
 
         private void Remove_Click(object sender, RoutedEventArgs e)

--- a/UndertaleModTool/Controls/UndertaleStringReference.xaml
+++ b/UndertaleModTool/Controls/UndertaleStringReference.xaml
@@ -7,8 +7,9 @@
              mc:Ignorable="d" 
              d:DesignHeight="20" d:DesignWidth="300">
     <UserControl.Resources>
-        <local:ContextMenuDark x:Key="contextMenu">
-            <local:MenuItemDark Header="Open in new tab" Click="OpenInNewTabItem_Click"/>
+        <local:ContextMenuDark x:Key="contextMenu" Opened="MenuItem_ContextMenuOpened">
+            <MenuItem Header="Open in new tab" Click="OpenInNewTabItem_Click"/>
+            <MenuItem Header="Find all references" Click="FindAllReferencesItem_Click"/>
         </local:ContextMenuDark>
     </UserControl.Resources>
     <Grid>

--- a/UndertaleModTool/Converters/FilteredViewConverter.cs
+++ b/UndertaleModTool/Converters/FilteredViewConverter.cs
@@ -39,6 +39,9 @@ namespace UndertaleModTool
                     return (obj as ISearchable)?.SearchMatches(Filter) ?? false;
                 if (obj is UndertaleNamedResource)
                     return ((obj as UndertaleNamedResource)?.Name?.Content?.IndexOf(Filter, StringComparison.OrdinalIgnoreCase) ?? -1) >= 0;
+                if (obj is object[] links)
+                    return links.Select(x => x is UndertaleNamedResource res ? res.Name?.Content : x.ToString())
+                                .Any(x => (x?.IndexOf(Filter, StringComparison.OrdinalIgnoreCase) ?? -1) >= 0);
                 return true;
             };
             return filteredView;

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
@@ -83,7 +83,7 @@
                     <DataTemplate DataType="{x:Type undertale:UndertaleRoom+GameObject}">
                         <TextBlock>
                             <TextBlock.Text>
-                                <MultiBinding Mode="OneWay" StringFormat="{}Instance {0} of {1} (UndertaleRoom+GameObject)">
+                                <MultiBinding Mode="OneWay" StringFormat="{}Instance {0} of {1}">
                                     <Binding Path="InstanceID" Mode="OneWay"/>
                                     <Binding Path="ObjectDefinition.Name.Content" Mode="OneWay" TargetNullValue="?" FallbackValue="EmptyInstance"/>
                                 </MultiBinding>
@@ -93,7 +93,7 @@
                     <DataTemplate DataType="{x:Type undertale:UndertaleRoom+Tile}">
                         <TextBlock>
                             <TextBlock.Text>
-                                <MultiBinding Mode="OneWay" StringFormat="{}Tile {0} of {1} (UndertaleRoom+Tile)">
+                                <MultiBinding Mode="OneWay" StringFormat="{}Tile {0} of {1}">
                                     <Binding Path="InstanceID" Mode="OneWay"/>
                                     <Binding Path="ObjectDefinition.Name.Content" Mode="OneWay" TargetNullValue="?" FallbackValue="EmptyTile"/>
                                 </MultiBinding>
@@ -103,8 +103,9 @@
                     <DataTemplate DataType="{x:Type undertale:UndertaleRoom+SpriteInstance}">
                         <TextBlock>
                             <TextBlock.Text>
-                                <MultiBinding Mode="OneWay" StringFormat="{}{0} (UndertaleRoom+SpriteInstance)">
-                                    <Binding Path="Name.Content" Mode="OneWay" TargetNullValue="?" FallbackValue="EmptySprite"/>
+                                <MultiBinding Mode="OneWay" StringFormat="{}Sprite {0} of {1}">
+                                    <Binding Path="Name.Content" Mode="OneWay" TargetNullValue="?" FallbackValue="EmptyName"/>
+                                    <Binding Path="Sprite.Name.Content" Mode="OneWay" TargetNullValue="?" FallbackValue="EmptySprite"/>
                                 </MultiBinding>
                             </TextBlock.Text>
                         </TextBlock>

--- a/UndertaleModTool/MainWindow.xaml
+++ b/UndertaleModTool/MainWindow.xaml
@@ -126,10 +126,12 @@
                     <MenuItem Header="Find unreferenced _assets" Name="FindUnreferencedAssetsItem" Click="MenuItem_FindUnreferencedAssets_Click"/>
                     <Separator/>
                     <MenuItem Header="(script links)" FontStyle="Italic" IsEnabled="False"/>
-                    <MenuItem Header="Find _code (&quot;Search.csx&quot;)"
+                    <MenuItem Header="Search in _code (&quot;Search.csx&quot;)"
                               Click="MenuItem_RunBuiltinScript_Item_Click" CommandParameter="Scripts\Builtin Scripts\Search.csx"/>
-                    <MenuItem Header="Find code _assembly (&quot;SearchASM.csx&quot;)"
+                    <MenuItem Header="Search in _assembly (&quot;SearchASM.csx&quot;)"
                               Click="MenuItem_RunBuiltinScript_Item_Click" CommandParameter="Scripts\Builtin Scripts\SearchASM.csx"/>
+                    <MenuItem Header="Search in _specific code (&quot;SearchLimited.csx&quot;)"
+                              Click="MenuItem_RunBuiltinScript_Item_Click" CommandParameter="Scripts\Builtin Scripts\SearchLimited.csx"/>
                 </local:MenuItemDark>
                 <local:MenuItemDark Header="_Help">
                     <MenuItem Header="_GitHub" Click="MenuItem_GitHub_Click"/>

--- a/UndertaleModTool/MainWindow.xaml
+++ b/UndertaleModTool/MainWindow.xaml
@@ -113,17 +113,23 @@
                     <MenuItem Header="(...loading...)" IsEnabled="False"/>
                 </local:MenuItemDark>
                 <local:MenuItemDark Header="_Find">
-                    <MenuItem Header="Find unreferenced _assets" Name="FindUnreferencedAssetsItem" Click="MenuItem_FindUnreferencedAssets_Click">
-                        <MenuItem.Style>
-                            <Style TargetType="MenuItem">
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding Data, Mode=OneWay}" Value="{x:Null}">
-                                        <Setter Property="IsEnabled" Value="False"/>
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </MenuItem.Style>
-                    </MenuItem>
+                    <MenuItem.Resources>
+                        <Style TargetType="MenuItem">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Data, Mode=OneWay}" Value="{x:Null}">
+                                    <Setter Property="IsEnabled" Value="False"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </MenuItem.Resources>
+
+                    <MenuItem Header="Find unreferenced _assets" Name="FindUnreferencedAssetsItem" Click="MenuItem_FindUnreferencedAssets_Click"/>
+                    <Separator/>
+                    <MenuItem Header="(script links)" FontStyle="Italic" IsEnabled="False"/>
+                    <MenuItem Header="Find _code (&quot;Search.csx&quot;)"
+                              Click="MenuItem_RunBuiltinScript_Item_Click" CommandParameter="Scripts\Builtin Scripts\Search.csx"/>
+                    <MenuItem Header="Find code _assembly (&quot;SearchASM.csx&quot;)"
+                              Click="MenuItem_RunBuiltinScript_Item_Click" CommandParameter="Scripts\Builtin Scripts\SearchASM.csx"/>
                 </local:MenuItemDark>
                 <local:MenuItemDark Header="_Help">
                     <MenuItem Header="_GitHub" Click="MenuItem_GitHub_Click"/>

--- a/UndertaleModTool/MainWindow.xaml
+++ b/UndertaleModTool/MainWindow.xaml
@@ -231,8 +231,9 @@
                         <local:ContextMenuDark x:Key="AddMenu">
                             <MenuItem Header="Add" Click="MenuItem_Add_Click"/>
                         </local:ContextMenuDark>
-                        <local:ContextMenuDark x:Key="UndertaleResourceMenu">
+                        <local:ContextMenuDark x:Key="UndertaleResourceMenu" Opened="MenuItem_ContextMenuOpened">
                             <MenuItem Header="Open in new tab" Click="MenuItem_OpenInNewTab_Click"/>
+                            <MenuItem Header="Find all references" Click="MenuItem_FindAllReferences_Click"/>
                             <MenuItem Header="Copy name to clipboard" Click="MenuItem_CopyName_Click"/>
                             <MenuItem Header="Delete" Click="MenuItem_Delete_Click"/>
                         </local:ContextMenuDark>

--- a/UndertaleModTool/MainWindow.xaml
+++ b/UndertaleModTool/MainWindow.xaml
@@ -112,6 +112,19 @@
                 <local:MenuItemDark x:Name="RootScriptItem" Header="_Scripts" SubmenuOpened="RootMenuItem_SubmenuOpened">
                     <MenuItem Header="(...loading...)" IsEnabled="False"/>
                 </local:MenuItemDark>
+                <local:MenuItemDark Header="_Find">
+                    <MenuItem Header="Find unreferenced _assets" Name="FindUnreferencedAssetsItem" Click="MenuItem_FindUnreferencedAssets_Click">
+                        <MenuItem.Style>
+                            <Style TargetType="MenuItem">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Data, Mode=OneWay}" Value="{x:Null}">
+                                        <Setter Property="IsEnabled" Value="False"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </MenuItem.Style>
+                    </MenuItem>
+                </local:MenuItemDark>
                 <local:MenuItemDark Header="_Help">
                     <MenuItem Header="_GitHub" Click="MenuItem_GitHub_Click"/>
                     <MenuItem Header="_About" Click="MenuItem_About_Click"/>

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -2232,7 +2232,7 @@ namespace UndertaleModTool
                 {
                     foreach (string resType in resTypes)
                     {
-                        IEnumerable resListCollection = Data[resType] as IEnumerable;
+                        IEnumerable resListCollection = Data[resType];
                         if (resListCollection is not null)
                         {
                             BindingOperations.EnableCollectionSynchronization(resListCollection, bindingLock);
@@ -2247,7 +2247,7 @@ namespace UndertaleModTool
                     {
                         if (syncBindings.Contains(resType))
                         {
-                            BindingOperations.DisableCollectionSynchronization(Data[resType] as IEnumerable);
+                            BindingOperations.DisableCollectionSynchronization(Data[resType]);
 
                             syncBindings.Remove(resType);
                         }
@@ -2258,7 +2258,7 @@ namespace UndertaleModTool
             {
                 if (enable)
                 {
-                    IEnumerable resListCollection = Data[resourceType] as IEnumerable;
+                    IEnumerable resListCollection = Data[resourceType];
                     if (resListCollection is not null)
                     {
                         BindingOperations.EnableCollectionSynchronization(resListCollection, bindingLock);
@@ -2268,7 +2268,7 @@ namespace UndertaleModTool
                 }
                 else if (syncBindings.Contains(resourceType))
                 {
-                    BindingOperations.DisableCollectionSynchronization(Data[resourceType] as IEnumerable);
+                    BindingOperations.DisableCollectionSynchronization(Data[resourceType]);
 
                     syncBindings.Remove(resourceType);
                 }
@@ -2279,7 +2279,7 @@ namespace UndertaleModTool
             if (syncBindings.Count <= 0) return;
 
             foreach (string resType in syncBindings)
-                BindingOperations.DisableCollectionSynchronization(Data[resType] as IEnumerable);
+                BindingOperations.DisableCollectionSynchronization(Data[resType]);
 
             syncBindings.Clear();
         }
@@ -3257,7 +3257,7 @@ result in loss of work.");
             IList resList;
             try
             {
-                resList = Data[res.GetType()] as IList;
+                resList = Data[res.GetType()];
             }
             catch (Exception ex)
             {
@@ -3296,7 +3296,7 @@ result in loss of work.");
                 mainTreeViewer.UpdateLayout();
 
                 double firstElemOffset = mainTreeViewer.VerticalOffset + (resPanel.Children[0] as TreeViewItem).TransformToAncestor(mainTreeViewer).Transform(new Point(0, 0)).Y;
-                mainTreeViewer.ScrollToVerticalOffset(firstElemOffset + ((resList.IndexOf(obj) + 1) * 16) - (mainTreeViewer.ViewportHeight / 2));
+                mainTreeViewer.ScrollToVerticalOffset(firstElemOffset + ((resList.IndexOf(res) + 1) * 16) - (mainTreeViewer.ViewportHeight / 2));
             }
             mainTreeViewer.UpdateLayout();
 

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -2157,6 +2157,9 @@ namespace UndertaleModTool
         private async void MenuItem_RunBuiltinScript_Item_Click(object sender, RoutedEventArgs e)
         {
             string path = (string)(sender as MenuItem).CommandParameter;
+            if (!File.Exists(path))
+                path = Path.Combine(Program.GetExecutableDirectory(), path);
+
             if (File.Exists(path))
                 await RunScript(path);
             else

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -1891,9 +1891,36 @@ namespace UndertaleModTool
             }
         }
 
+        private void MenuItem_ContextMenuOpened(object sender, RoutedEventArgs e)
+        {
+            var menu = sender as ContextMenu;
+            foreach (var item in menu.Items)
+            {
+                var menuItem = item as MenuItem;
+                if ((menuItem.Header as string) == "Find all references")
+                {
+                    menuItem.Visibility = UndertaleResourceReferenceMap.IsTypeReferenceable(menu.DataContext?.GetType())
+                                          ? Visibility.Visible : Visibility.Collapsed;
+
+                    break;
+                }
+            }
+        }
         private void MenuItem_OpenInNewTab_Click(object sender, RoutedEventArgs e)
         {
             OpenInTab(Highlighted, true);
+        }
+        private void MenuItem_FindAllReferences_Click(object sender, RoutedEventArgs e)
+        {
+            var obj = (sender as FrameworkElement)?.DataContext as UndertaleResource;
+            if (obj is null)
+            {
+                this.ShowError("The selected object is not an \"UndertaleResource\".");
+                return;
+            }
+
+            FindReferencesTypesDialog dialog = new(obj, Data);
+            dialog.ShowDialog();
         }
         private void MenuItem_CopyName_Click(object sender, RoutedEventArgs e)
         {

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -1911,6 +1911,25 @@ namespace UndertaleModTool
             }
         }
 
+        private void MenuItem_FindUnreferencedAssets_Click(object sender, RoutedEventArgs e)
+        {
+            FindReferencesTypesDialog dialog = null;
+            try
+            {
+                dialog = new(Data);
+                dialog.ShowDialog();
+            }
+            catch (Exception ex)
+            {
+                this.ShowError("An error occured in the object references related window.\n" +
+                               $"Please report this on GitHub.\n\n{ex}");
+            }
+            finally
+            {
+                dialog?.Close();
+            }
+        }
+
         private void MenuItem_ContextMenuOpened(object sender, RoutedEventArgs e)
         {
             var menu = sender as ContextMenu;
@@ -2496,14 +2515,21 @@ namespace UndertaleModTool
             return excText;
         }
 
+        public void InitializeProgressDialog(string title, string msg)
+        {
+            scriptDialog ??= new LoaderDialog(title, msg)
+            {
+                Owner = this,
+                PreventClose = true
+            };
+        }
+
         public async Task RunScript(string path)
         {
             ScriptExecutionSuccess = true;
             ScriptErrorMessage = "";
             ScriptErrorType = "";
-            scriptDialog = new LoaderDialog("Script in progress...", "Please wait...");
-            scriptDialog.Owner = this;
-            scriptDialog.PreventClose = true;
+            InitializeScriptDialog();
             this.IsEnabled = false; // Prevent interaction while the script is running.
 
             await RunScriptNow(path); // Runs the script now.

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -3826,6 +3826,21 @@ result in loss of work.");
                 && e.Source == viewer)
                 e.Handled = true;
         }
+
+        public bool HasEditorForAsset(object asset)
+        {
+            if (asset is null)
+                return false;
+
+            Type objType = asset.GetType();
+            foreach (var key in DataEditor.Resources.Keys)
+            {
+                if (key is DataTemplateKey templateKey && (templateKey.DataType as Type) == objType)
+                    return true;
+            }
+
+            return false;
+        }
     }
 
     public class GeneralInfoEditor

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -1581,6 +1581,8 @@ namespace UndertaleModTool
                 // Gets the clicked visual element by the mouse position (relative to "MainTree").
                 // This is used instead of "VisualTreeHelper.HitTest()" because that ignores the visibility of elements,
                 // which led to "ghost" hits on empty space.
+
+                // Updated: why I simply didn't use "e.OriginalSource"?
                 DependencyObject obj = MainTree.InputHitTest(e.GetPosition(MainTree)) as DependencyObject;
                 if (obj is not TextBlock)
                     return;

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -1921,8 +1921,21 @@ namespace UndertaleModTool
                 return;
             }
 
-            FindReferencesTypesDialog dialog = new(obj, Data);
-            dialog.ShowDialog();
+            FindReferencesTypesDialog dialog = null;
+            try
+            {
+                dialog = new(obj, Data);
+                dialog.ShowDialog();
+            }
+            catch (Exception ex)
+            {
+                this.ShowError("An error occured in the object references related window.\n" +
+                               $"Please report this on GitHub.\n\n{ex}");
+            }
+            finally
+            {
+                dialog?.Close();
+            }
         }
         private void MenuItem_CopyName_Click(object sender, RoutedEventArgs e)
         {

--- a/UndertaleModTool/Scripts/Technical Scripts/FindUnusedStrings.csx
+++ b/UndertaleModTool/Scripts/Technical Scripts/FindUnusedStrings.csx
@@ -498,6 +498,17 @@ uint[] GetStringUsageCount()
             {
                 stringsUsageCountArray[Data.Strings.IndexOf(obj.Name)] += 1;
             }
+
+            if (obj.V2Sequence is not null && obj.V2Sequence.Tracks.Count != 0)
+            {
+                UndertaleString name = obj.V2Sequence.Tracks[0].Name;
+                if (name is not null)
+                    stringsUsageCountArray[Data.Strings.IndexOf(name)] += 1;
+
+                name = obj.V2Sequence.Tracks[0].ModelName;
+                if (name is not null)
+                    stringsUsageCountArray[Data.Strings.IndexOf(name)] += 1;
+            }
         }
     }
     UpdateProgress("Checking strings in Texture Group Info");

--- a/UndertaleModTool/Scripts/Technical Scripts/FindUnusedStrings.csx
+++ b/UndertaleModTool/Scripts/Technical Scripts/FindUnusedStrings.csx
@@ -269,9 +269,9 @@ uint[] GetStringUsageCount()
     UpdateProgress("Checking strings in GeneralInfo");
     if (Data.GeneralInfo != null)
     {
-        if (Data.GeneralInfo.Filename != null)
+        if (Data.GeneralInfo.FileName != null)
         {
-            stringsUsageCountArray[Data.Strings.IndexOf(Data.GeneralInfo.Filename)] += 1;
+            stringsUsageCountArray[Data.Strings.IndexOf(Data.GeneralInfo.FileName)] += 1;
         }
         if (Data.GeneralInfo.Config != null)
         {

--- a/UndertaleModTool/Tab.cs
+++ b/UndertaleModTool/Tab.cs
@@ -602,13 +602,19 @@ namespace UndertaleModTool
                     roomPreviewViewer.ScrollToHorizontalOffset(roomTabState.RoomPreviewScrollPosition.Left);
                     roomPreviewViewer.ScrollToVerticalOffset(roomTabState.RoomPreviewScrollPosition.Top);
 
+                    bool fromReferencesResults = false;
                     // (Sadly, arrays don't support destructuring like tuples)
-                    roomEditor.BGItems.IsExpanded = roomTabState.ObjectTreeItemsStates[0];
-                    roomEditor.ViewItems.IsExpanded = roomTabState.ObjectTreeItemsStates[1];
-                    roomEditor.GameObjItems.IsExpanded = roomTabState.ObjectTreeItemsStates[2];
-                    roomEditor.TileItems.IsExpanded = roomTabState.ObjectTreeItemsStates[3];
-                    roomEditor.LayerItems.IsExpanded = roomTabState.ObjectTreeItemsStates[4];
-                    roomEditor.RoomRootItem.UpdateLayout();
+                    if (roomTabState.ObjectTreeItemsStates is not null)
+                    {
+                        fromReferencesResults = true;
+
+                        roomEditor.BGItems.IsExpanded = roomTabState.ObjectTreeItemsStates[0];
+                        roomEditor.ViewItems.IsExpanded = roomTabState.ObjectTreeItemsStates[1];
+                        roomEditor.GameObjItems.IsExpanded = roomTabState.ObjectTreeItemsStates[2];
+                        roomEditor.TileItems.IsExpanded = roomTabState.ObjectTreeItemsStates[3];
+                        roomEditor.LayerItems.IsExpanded = roomTabState.ObjectTreeItemsStates[4];
+                        roomEditor.RoomRootItem.UpdateLayout();
+                    }
 
                     // Select the object
                     if (roomTabState.SelectedObject is not UndertaleRoom)
@@ -629,6 +635,12 @@ namespace UndertaleModTool
                                 var room = roomEditor.DataContext as UndertaleRoom;
                                 if (room.Flags.HasFlag(RoomEntryFlags.IsGMS2))
                                 {
+                                    if (fromReferencesResults)
+                                    {
+                                        roomEditor.LayerItems.IsExpanded = true;
+                                        roomEditor.RoomRootItem.UpdateLayout();
+                                    }
+
                                     layer = room.Layers
                                                 .FirstOrDefault(l => l.LayerType is LayerType.Instances
                                                     && (l.InstancesData.Instances?.Any(x => x.InstanceID == gameObj.InstanceID) ?? false));
@@ -642,6 +654,12 @@ namespace UndertaleModTool
                                 room = roomEditor.DataContext as UndertaleRoom;
                                 if (room.Flags.HasFlag(RoomEntryFlags.IsGMS2))
                                 {
+                                    if (fromReferencesResults)
+                                    {
+                                        roomEditor.LayerItems.IsExpanded = true;
+                                        roomEditor.RoomRootItem.UpdateLayout();
+                                    }
+
                                     layer = room.Layers
                                                 .FirstOrDefault(l => l.LayerType is LayerType.Assets
                                                     && (l.AssetsData.LegacyTiles?.Any(x => x.InstanceID == tile.InstanceID) ?? false));
@@ -656,6 +674,12 @@ namespace UndertaleModTool
                                 break;
 
                             case SpriteInstance spr:
+                                if (fromReferencesResults)
+                                {
+                                    roomEditor.LayerItems.IsExpanded = true;
+                                    roomEditor.RoomRootItem.UpdateLayout();
+                                }
+
                                 room = roomEditor.DataContext as UndertaleRoom;
                                 layer = room.Layers
                                             .FirstOrDefault(l => l.LayerType is LayerType.Assets

--- a/UndertaleModTool/Tab.cs
+++ b/UndertaleModTool/Tab.cs
@@ -595,19 +595,23 @@ namespace UndertaleModTool
                 case RoomTabState roomTabState:
                     var roomEditor = editor as UndertaleRoomEditor;
 
-                    roomEditor.RoomGraphics.LayoutTransform = roomTabState.RoomPreviewTransform;
-                    roomEditor.RoomGraphics.UpdateLayout();
+                    bool fromReferencesResults = true;
+                    if (roomTabState.ObjectTreeItemsStates is not null)
+                    {
+                        fromReferencesResults = false;
+
+                        roomEditor.RoomGraphics.LayoutTransform = roomTabState.RoomPreviewTransform;
+                        roomEditor.RoomGraphics.UpdateLayout();
+                    }  
 
                     ScrollViewer roomPreviewViewer = roomEditor.RoomGraphicsScroll;
                     roomPreviewViewer.ScrollToHorizontalOffset(roomTabState.RoomPreviewScrollPosition.Left);
                     roomPreviewViewer.ScrollToVerticalOffset(roomTabState.RoomPreviewScrollPosition.Top);
 
-                    bool fromReferencesResults = false;
+                    
                     // (Sadly, arrays don't support destructuring like tuples)
                     if (roomTabState.ObjectTreeItemsStates is not null)
                     {
-                        fromReferencesResults = true;
-
                         roomEditor.BGItems.IsExpanded = roomTabState.ObjectTreeItemsStates[0];
                         roomEditor.ViewItems.IsExpanded = roomTabState.ObjectTreeItemsStates[1];
                         roomEditor.GameObjItems.IsExpanded = roomTabState.ObjectTreeItemsStates[2];
@@ -699,14 +703,19 @@ namespace UndertaleModTool
                             return;
                         objItem.IsSelected = true;
                         objItem.Focus();
+                        if (fromReferencesResults)
+                            objItem.BringIntoView();
 
                         roomEditor.RoomRootItem.UpdateLayout();
                     }
 
-                    ScrollViewer treeObjViewer = MainWindow.FindVisualChild<ScrollViewer>(roomEditor.RoomObjectsTree);
-                    treeObjViewer.ScrollToHorizontalOffset(roomTabState.ObjectsTreeScrollPosition.Left);
-                    treeObjViewer.ScrollToVerticalOffset(roomTabState.ObjectsTreeScrollPosition.Top);
-                    treeObjViewer.UpdateLayout();
+                    if (!fromReferencesResults)
+                    {
+                        ScrollViewer treeObjViewer = MainWindow.FindVisualChild<ScrollViewer>(roomEditor.RoomObjectsTree);
+                        treeObjViewer.ScrollToHorizontalOffset(roomTabState.ObjectsTreeScrollPosition.Left);
+                        treeObjViewer.ScrollToVerticalOffset(roomTabState.ObjectsTreeScrollPosition.Top);
+                        treeObjViewer.UpdateLayout();
+                    }
                     break;
 
                 case FontTabState fontTabState:

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml
@@ -6,7 +6,7 @@
         xmlns:utmt="clr-namespace:UndertaleModTool"
         xmlns:local="clr-namespace:UndertaleModTool.Windows"
         mc:Ignorable="d"
-        Title="The references of game object &quot;&quot;" Height="588" Width="450" IsVisibleChanged="Window_IsVisibleChanged"
+        Title="The references of game object &quot;&quot;" Height="600" Width="450" IsVisibleChanged="Window_IsVisibleChanged"
         WindowStartupLocation="CenterOwner">
     <Window.Resources>
         <local:ChildInstanceNameConverter x:Key="ChildInstanceNameConverter"/>
@@ -27,6 +27,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*" MinHeight="60"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <Grid.Background>
@@ -87,7 +88,10 @@
             </TreeView.Resources>
         </TreeView>
 
-        <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,20,0,20">
+        <TextBlock Grid.Row="4" Text="Note: the results may be not 100% complete.&#x0a;Use one of the search scripts in the &quot;Find&quot; menu if necessary."
+                   Margin="10,0,20,0" FontStyle="Italic" Foreground="Gray"/>
+
+        <StackPanel Grid.Row="5" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,20,0,20">
             <utmt:ButtonDark Content="Export results" FontSize="18" Width="144" Height="40" Click="ExportButton_Click" Margin="0,0,10,0">
                 <Button.Style>
                     <Style TargetType="Button">

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml
@@ -16,14 +16,14 @@
         <Rectangle Margin="10,0,20,0" Height="2" Fill="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
 
         <TextBox Name="SearchBox" ToolTip="Search" TextChanged="SearchBox_TextChanged"
-                 Margin="10,15,20,0" FontSize="16">
+                 Margin="10,15,20,0" FontSize="14">
             <!-- Source - https://stackoverflow.com/a/7433840/12136394 -->
             <TextBox.Style>
                 <Style TargetType="TextBox">
                     <Style.Resources>
                         <VisualBrush x:Key="CueBannerBrush" AlignmentX="Left" AlignmentY="Center" Stretch="None">
                             <VisualBrush.Visual>
-                                <Label Content="Filter by name..." Foreground="Gray" FontSize="16"/>
+                                <Label Content="Filter by name..." Foreground="Gray" FontSize="14"/>
                             </VisualBrush.Visual>
                         </VisualBrush>
                     </Style.Resources>
@@ -41,12 +41,12 @@
                 </Style>
             </TextBox.Style>
         </TextBox>
-        <TreeView Name="ResultsTree" Height="350" Margin="10,5,20,0" FontSize="16">
+        <TreeView Name="ResultsTree" Height="350" Margin="10,5,20,0" FontSize="14">
             <TreeView.Background>
                 <DynamicResource ResourceKey="{x:Static SystemColors.ControlLightLightBrushKey}"/>
             </TreeView.Background>
         </TreeView>
 
-        <local:ButtonDark Content="Done" FontSize="18" Width="134" Height="40" Click="DoneButton_Click" Margin="0,25,0,0"/>
+        <local:ButtonDark Content="Done" FontSize="18" Width="134" Height="40" Click="DoneButton_Click" Margin="0,20,0,0"/>
     </StackPanel>
 </Window>

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml
@@ -59,8 +59,9 @@
                 <DynamicResource ResourceKey="{x:Static SystemColors.ControlLightLightBrushKey}"/>
             </TreeView.Background>
             <TreeView.Resources>
-                <utmt:ContextMenuDark x:Key="UndertaleResourceMenu">
+                <utmt:ContextMenuDark x:Key="UndertaleResourceMenu" Opened="MenuItem_ContextMenuOpened">
                     <MenuItem Header="Open in new tab" Click="MenuItem_OpenInNewTab_Click"/>
+                    <MenuItem Header="Find all references" Click="MenuItem_FindAllReferences_Click"/>
                 </utmt:ContextMenuDark>
                 <Style TargetType="TreeViewItem">
                     <Style.Triggers>

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml
@@ -82,6 +82,19 @@
             </TreeView.Resources>
         </TreeView>
 
-        <utmt:ButtonDark Grid.Row="4" Content="Done" FontSize="18" Width="134" Height="40" Click="DoneButton_Click" Margin="0,20,0,20"/>
+        <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,20,0,20">
+            <utmt:ButtonDark Content="Export results" FontSize="18" Width="144" Height="40" Click="ExportButton_Click" Margin="0,0,10,0">
+                <Button.Style>
+                    <Style TargetType="Button">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding Items.Count, ElementName=ResultsTree, Mode=OneWay}" Value="0">
+                                <Setter Property="IsEnabled" Value="False"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Button.Style>
+            </utmt:ButtonDark>
+            <utmt:ButtonDark Content="Done" FontSize="18" Width="134" Height="40" Click="DoneButton_Click"/>
+        </StackPanel>
     </Grid>
 </Window>

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml
@@ -5,7 +5,6 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:utmt="clr-namespace:UndertaleModTool"
         xmlns:local="clr-namespace:UndertaleModTool.Windows"
-        xmlns:scol="clr-namespace:System.Collections;assembly=mscorlib"
         mc:Ignorable="d"
         Title="The references of game object &quot;&quot;" Height="588" Width="497" IsVisibleChanged="Window_IsVisibleChanged"
         WindowStartupLocation="CenterOwner">
@@ -14,17 +13,26 @@
         <HierarchicalDataTemplate x:Key="ChildInstTemplate">
             <TextBlock Text="{Binding ., Mode=OneTime, Converter={StaticResource ChildInstanceNameConverter}}" />
         </HierarchicalDataTemplate>
-        <utmt:ImplementsInterfaceConverter x:Key="ImplementsInterfaceConverter"/>
+        <utmt:ContextMenuDark x:Key="StandaloneTabMenu">
+            <MenuItem Header="Open in new tab" Click="MenuItem_OpenInNewTab_Click"/>
+        </utmt:ContextMenuDark>
     </Window.Resources>
-    <StackPanel>
-        <StackPanel.Background>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*" MinHeight="60"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.Background>
             <DynamicResource ResourceKey="{x:Static SystemColors.ControlBrushKey}"/>
-        </StackPanel.Background>
-        <TextBlock Name="label" Text="The search results for the game object&#x0a;&quot;&quot;." HorizontalAlignment="Left" Padding="5" Margin="10,10,0,0"
+        </Grid.Background>
+        <TextBlock Grid.Row="0" Name="label" Text="The search results for the game object&#x0a;&quot;&quot;." HorizontalAlignment="Left" Padding="5" Margin="10,10,0,0"
                    FontSize="22" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" MaxHeight="70"/>
-        <Rectangle Margin="10,0,20,0" Height="2" Fill="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+        <Rectangle Grid.Row="1" Margin="10,0,20,0" Height="2" Fill="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
 
-        <TextBox Name="SearchBox" ToolTip="Search" TextChanged="SearchBox_TextChanged"
+        <TextBox Grid.Row="2" Name="SearchBox" ToolTip="Search" TextChanged="SearchBox_TextChanged"
                  Margin="10,15,20,0" FontSize="14">
             <!-- Source - https://stackoverflow.com/a/7433840/12136394 -->
             <TextBox.Style>
@@ -50,7 +58,7 @@
                 </Style>
             </TextBox.Style>
         </TextBox>
-        <TreeView Name="ResultsTree" Height="350" Margin="10,5,20,0" FontSize="14"
+        <TreeView Grid.Row="3" Name="ResultsTree" Margin="10,5,20,0" FontSize="14"
                   SelectedItemChanged="ResultsTree_SelectedItemChanged" MouseDown="ResultsTree_MouseDown"
                   MouseDoubleClick="ResultsTree_MouseDoubleClick" KeyUp="ResultsTree_KeyUp" PreviewMouseRightButtonDown="ResultsTree_PreviewMouseRightButtonDown"
                   VirtualizingStackPanel.IsVirtualizing="True"
@@ -65,8 +73,8 @@
                 </utmt:ContextMenuDark>
                 <Style TargetType="TreeViewItem">
                     <Style.Triggers>
-                        <DataTrigger Binding="{Binding ., Converter={StaticResource ImplementsInterfaceConverter}, ConverterParameter={x:Type scol:IEnumerable}}" Value="False">
-                            <!-- If the data context is not a enumerable -->
+                        <DataTrigger Binding="{Binding Items.Count, RelativeSource={RelativeSource Self}}" Value="0">
+                            <!-- If the data context is not a string -->
                             <Setter Property="ContextMenu" Value="{StaticResource UndertaleResourceMenu}"/>
                         </DataTrigger>
                     </Style.Triggers>
@@ -74,6 +82,6 @@
             </TreeView.Resources>
         </TreeView>
 
-        <utmt:ButtonDark Content="Done" FontSize="18" Width="134" Height="40" Click="DoneButton_Click" Margin="0,20,0,0"/>
-    </StackPanel>
+        <utmt:ButtonDark Grid.Row="4" Content="Done" FontSize="18" Width="134" Height="40" Click="DoneButton_Click" Margin="0,20,0,20"/>
+    </Grid>
 </Window>

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml
@@ -6,7 +6,7 @@
         xmlns:utmt="clr-namespace:UndertaleModTool"
         xmlns:local="clr-namespace:UndertaleModTool.Windows"
         mc:Ignorable="d"
-        Title="The references of game object &quot;&quot;" Height="588" Width="497" IsVisibleChanged="Window_IsVisibleChanged"
+        Title="The references of game object &quot;&quot;" Height="588" Width="450" IsVisibleChanged="Window_IsVisibleChanged"
         WindowStartupLocation="CenterOwner">
     <Window.Resources>
         <local:ChildInstanceNameConverter x:Key="ChildInstanceNameConverter"/>

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml
@@ -1,0 +1,52 @@
+﻿<Window x:Class="UndertaleModTool.Windows.FindReferencesResults"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:UndertaleModTool"
+        mc:Ignorable="d"
+        Title="The references of game object &quot;&quot;" Height="588" Width="497" IsVisibleChanged="Window_IsVisibleChanged"
+        WindowStartupLocation="CenterOwner">
+    <StackPanel>
+        <StackPanel.Background>
+            <DynamicResource ResourceKey="{x:Static SystemColors.ControlBrushKey}"/>
+        </StackPanel.Background>
+        <TextBlock Name="label" Text="The search results for the game object&#x0a;&quot;&quot;." HorizontalAlignment="Left" Padding="5" Margin="10,10,0,0"
+                   FontSize="22" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" MaxHeight="70"/>
+        <Rectangle Margin="10,0,20,0" Height="2" Fill="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+
+        <TextBox Name="SearchBox" ToolTip="Search" TextChanged="SearchBox_TextChanged"
+                 Margin="10,15,20,0" FontSize="16">
+            <!-- Source - https://stackoverflow.com/a/7433840/12136394 -->
+            <TextBox.Style>
+                <Style TargetType="TextBox">
+                    <Style.Resources>
+                        <VisualBrush x:Key="CueBannerBrush" AlignmentX="Left" AlignmentY="Center" Stretch="None">
+                            <VisualBrush.Visual>
+                                <Label Content="Filter by name..." Foreground="Gray" FontSize="16"/>
+                            </VisualBrush.Visual>
+                        </VisualBrush>
+                    </Style.Resources>
+                    <Style.Triggers>
+                        <Trigger Property="Text" Value="">
+                            <Setter Property="Background" Value="{StaticResource CueBannerBrush}" />
+                        </Trigger>
+                        <Trigger Property="Text" Value="{x:Null}">
+                            <Setter Property="Background" Value="{StaticResource CueBannerBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsKeyboardFocused" Value="True">
+                            <Setter Property="Background" Value="{x:Null}" />
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBox.Style>
+        </TextBox>
+        <TreeView Name="ResultsTree" Height="350" Margin="10,5,20,0" FontSize="16">
+            <TreeView.Background>
+                <DynamicResource ResourceKey="{x:Static SystemColors.ControlLightLightBrushKey}"/>
+            </TreeView.Background>
+        </TreeView>
+
+        <local:ButtonDark Content="Done" FontSize="18" Width="134" Height="40" Click="DoneButton_Click" Margin="0,25,0,0"/>
+    </StackPanel>
+</Window>

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml
@@ -10,8 +10,12 @@
         WindowStartupLocation="CenterOwner">
     <Window.Resources>
         <local:ChildInstanceNameConverter x:Key="ChildInstanceNameConverter"/>
+        <utmt:StringTitleConverter x:Key="StringTitleConverter"/>
         <HierarchicalDataTemplate x:Key="ChildInstTemplate">
             <TextBlock Text="{Binding ., Mode=OneTime, Converter={StaticResource ChildInstanceNameConverter}}" />
+        </HierarchicalDataTemplate>
+        <HierarchicalDataTemplate x:Key="StringTemplate">
+            <TextBlock Text="{Binding Content, Mode=OneWay, Converter={StaticResource StringTitleConverter}}" />
         </HierarchicalDataTemplate>
         <utmt:ContextMenuDark x:Key="StandaloneTabMenu">
             <MenuItem Header="Open in new tab" Click="MenuItem_OpenInNewTab_Click"/>
@@ -69,6 +73,7 @@
             <TreeView.Resources>
                 <utmt:ContextMenuDark x:Key="UndertaleResourceMenu" Opened="MenuItem_ContextMenuOpened">
                     <MenuItem Header="Open in new tab" Click="MenuItem_OpenInNewTab_Click"/>
+                    <MenuItem Header="Copy name to clipboard" Click="MenuItem_CopyName_Click"/>
                     <MenuItem Header="Find all references" Click="MenuItem_FindAllReferences_Click"/>
                 </utmt:ContextMenuDark>
                 <Style TargetType="TreeViewItem">

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml
@@ -3,10 +3,19 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="clr-namespace:UndertaleModTool"
+        xmlns:utmt="clr-namespace:UndertaleModTool"
+        xmlns:local="clr-namespace:UndertaleModTool.Windows"
+        xmlns:scol="clr-namespace:System.Collections;assembly=mscorlib"
         mc:Ignorable="d"
         Title="The references of game object &quot;&quot;" Height="588" Width="497" IsVisibleChanged="Window_IsVisibleChanged"
         WindowStartupLocation="CenterOwner">
+    <Window.Resources>
+        <local:ChildInstanceNameConverter x:Key="ChildInstanceNameConverter"/>
+        <HierarchicalDataTemplate x:Key="ChildInstTemplate">
+            <TextBlock Text="{Binding ., Mode=OneTime, Converter={StaticResource ChildInstanceNameConverter}}" />
+        </HierarchicalDataTemplate>
+        <utmt:ImplementsInterfaceConverter x:Key="ImplementsInterfaceConverter"/>
+    </Window.Resources>
     <StackPanel>
         <StackPanel.Background>
             <DynamicResource ResourceKey="{x:Static SystemColors.ControlBrushKey}"/>
@@ -41,12 +50,29 @@
                 </Style>
             </TextBox.Style>
         </TextBox>
-        <TreeView Name="ResultsTree" Height="350" Margin="10,5,20,0" FontSize="14">
+        <TreeView Name="ResultsTree" Height="350" Margin="10,5,20,0" FontSize="14"
+                  SelectedItemChanged="ResultsTree_SelectedItemChanged" MouseDown="ResultsTree_MouseDown"
+                  MouseDoubleClick="ResultsTree_MouseDoubleClick" KeyUp="ResultsTree_KeyUp" PreviewMouseRightButtonDown="ResultsTree_PreviewMouseRightButtonDown"
+                  VirtualizingStackPanel.IsVirtualizing="True"
+                  VirtualizingStackPanel.VirtualizationMode="Recycling">
             <TreeView.Background>
                 <DynamicResource ResourceKey="{x:Static SystemColors.ControlLightLightBrushKey}"/>
             </TreeView.Background>
+            <TreeView.Resources>
+                <utmt:ContextMenuDark x:Key="UndertaleResourceMenu">
+                    <MenuItem Header="Open in new tab" Click="MenuItem_OpenInNewTab_Click"/>
+                </utmt:ContextMenuDark>
+                <Style TargetType="TreeViewItem">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding ., Converter={StaticResource ImplementsInterfaceConverter}, ConverterParameter={x:Type scol:IEnumerable}}" Value="False">
+                            <!-- If the data context is not a enumerable -->
+                            <Setter Property="ContextMenu" Value="{StaticResource UndertaleResourceMenu}"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </TreeView.Resources>
         </TreeView>
 
-        <local:ButtonDark Content="Done" FontSize="18" Width="134" Height="40" Click="DoneButton_Click" Margin="0,20,0,0"/>
+        <utmt:ButtonDark Content="Done" FontSize="18" Width="134" Height="40" Click="DoneButton_Click" Margin="0,20,0,0"/>
     </StackPanel>
 </Window>

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+using UndertaleModLib;
+
+namespace UndertaleModTool.Windows
+{
+    /// <summary>
+    /// Interaction logic for FindReferencesResults.xaml
+    /// </summary>
+    public partial class FindReferencesResults : Window
+    {
+        private readonly UndertaleData data;
+
+        private void Window_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (!IsVisible || IsLoaded)
+                return;
+
+            if (Settings.Instance.EnableDarkMode)
+                MainWindow.SetDarkTitleBarForWindow(this, true, false);
+        }
+
+        public FindReferencesResults(UndertaleResource sourceObj, UndertaleResource[][] results, UndertaleData data)
+        {
+            InitializeComponent();
+
+            string sourceObjName;
+            if (sourceObj is UndertaleNamedResource namedObj)
+                sourceObjName = namedObj.Name.Content;
+            else
+                sourceObjName = sourceObj.GetType().Name;
+
+            Title = $"The references of game object \"{sourceObjName}\"";
+            label.Text = $"The search results for the game object\n\"{sourceObjName}\".";
+
+            this.data = data;
+        }
+
+        private void SearchBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            foreach (var child in ResultsTree.Items)
+                ((child as TreeViewItem).ItemsSource as ICollectionView)?.Refresh();
+        }
+
+        private void DoneButton_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+    }
+}

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml.cs
@@ -9,6 +9,7 @@ using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Documents;
 using System.Windows.Input;
+using System.Windows.Markup;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
@@ -21,8 +22,6 @@ namespace UndertaleModTool.Windows
     /// </summary>
     public partial class FindReferencesResults : Window
     {
-        private readonly UndertaleData data;
-
         private void Window_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
             if (!IsVisible || IsLoaded)
@@ -32,7 +31,7 @@ namespace UndertaleModTool.Windows
                 MainWindow.SetDarkTitleBarForWindow(this, true, false);
         }
 
-        public FindReferencesResults(UndertaleResource sourceObj, UndertaleResource[][] results, UndertaleData data)
+        public FindReferencesResults(UndertaleResource sourceObj, (string, object[])[] results)
         {
             InitializeComponent();
 
@@ -45,7 +44,7 @@ namespace UndertaleModTool.Windows
             Title = $"The references of game object \"{sourceObjName}\"";
             label.Text = $"The search results for the game object\n\"{sourceObjName}\".";
 
-            this.data = data;
+            ProcessResults(results);
         }
 
         private void SearchBox_TextChanged(object sender, TextChangedEventArgs e)
@@ -57,6 +56,45 @@ namespace UndertaleModTool.Windows
         private void DoneButton_Click(object sender, RoutedEventArgs e)
         {
             Close();
+        }
+
+        private void ProcessResults((string, object[])[] results)
+        {
+            var filterConv = new FilteredViewConverter();
+            BindingOperations.SetBinding(filterConv, FilteredViewConverter.FilterProperty, new Binding("Text")
+            {
+                Source = SearchBox,
+                UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged
+            });
+
+            var namedResTemplate = XamlReader.Parse(
+            @"
+                <HierarchicalDataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>
+                    <TextBlock Text='{Binding Name.Content}'/>
+                </HierarchicalDataTemplate>
+            ") as HierarchicalDataTemplate;
+
+            foreach (var result in results)
+            {
+                var item = new TreeViewItem()
+                {
+                    Header = result.Item1,
+                    DataContext = result.Item2
+                };
+                item.SetBinding(TreeView.ItemsSourceProperty, new Binding(".")
+                {
+                    Converter = filterConv,
+                    Mode = BindingMode.OneWay
+                });
+                if (result.Item2[0] is UndertaleNamedResource)
+                {
+                    item.ItemTemplate = namedResTemplate;
+                }
+
+                ResultsTree.Items.Add(item);
+
+                item.IsExpanded = true;
+            }
         }
     }
 }

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml.cs
@@ -132,6 +132,12 @@ namespace UndertaleModTool.Windows
 
         private void ExportResults()
         {
+            if (data.FORM is null)
+            {
+                this.ShowError($"The object references are stale - a different game data was loaded.");
+                return;
+            }
+
             string initContent = Title + ":\n";
             initContent += new string('-', initContent.Length - 1) + "\n\n";
             StringBuilder sb = new(initContent);
@@ -151,7 +157,7 @@ namespace UndertaleModTool.Windows
                         if (childItem is object[] inst)
                             itemName = ChildInstanceNameConverter.Instance.Convert(inst, null, null, null) as string;
                         else if (childItem is UndertaleNamedResource namedRes)
-                            itemName = namedRes.Name.Content;
+                            itemName = namedRes.Name?.Content;
                         else
                             itemName = childItem.ToString();
 

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml.cs
@@ -130,6 +130,8 @@ namespace UndertaleModTool.Windows
                 });
                 if (result.Value[0] is UndertaleNamedResource)
                     item.ItemTemplate = namedResTemplate;
+                else if (result.Value[0] is UndertaleString)
+                    item.ItemTemplate = TryFindResource("StringTemplate") as HierarchicalDataTemplate;
                 else if (result.Value[0] is GeneralInfoEditor or GlobalInitEditor or GameEndEditor)
                 {
                     ResultsTree.Items.Add(new TextBlock()
@@ -177,6 +179,8 @@ namespace UndertaleModTool.Windows
                             itemName = ChildInstanceNameConverter.Instance.Convert(inst, null, null, null) as string;
                         else if (childItem is UndertaleNamedResource namedRes)
                             itemName = namedRes.Name?.Content;
+                        else if (childItem is UndertaleString str)
+                            itemName = StringTitleConverter.Instance.Convert(str.Content, null, null, null) as string;
                         else
                             itemName = childItem.ToString();
 
@@ -271,6 +275,23 @@ namespace UndertaleModTool.Windows
         private void MenuItem_OpenInNewTab_Click(object sender, RoutedEventArgs e)
         {
             Open(highlighted, true);
+        }
+        private void MenuItem_CopyName_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem item && item.DataContext is not null)
+            {
+                string itemName;
+                if (item.DataContext is object[] inst)
+                    itemName = ChildInstanceNameConverter.Instance.Convert(inst, null, null, null) as string;
+                else if (item.DataContext is UndertaleNamedResource namedRes)
+                    itemName = namedRes.Name?.Content;
+                else if (item.DataContext is UndertaleString str)
+                    itemName = StringTitleConverter.Instance.Convert(str.Content, null, null, null) as string;
+                else
+                    itemName = item.DataContext.ToString();
+
+                Clipboard.SetText(itemName);
+            }
         }
         private void MenuItem_FindAllReferences_Click(object sender, RoutedEventArgs e)
         {

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml.cs
@@ -124,6 +124,12 @@ namespace UndertaleModTool.Windows
 
         private void Open(object obj, bool inNewTab = false)
         {
+            if (data.FORM is null)
+            {
+                this.ShowError($"The object reference is stale - a different game data was loaded.");
+                return;
+            }
+
             mainWindow.Focus();
 
             if (obj is object[] inst)
@@ -133,15 +139,13 @@ namespace UndertaleModTool.Windows
                     mainWindow.ChangeSelection(room, inNewTab);
                     mainWindow.CurrentTab.LastContentState = new RoomTabState()
                     {
-                        SelectedObject = inst[0],
-                        ObjectTreeItemsStates = new[] { false, false, false, false, true }
+                        SelectedObject = inst[0]
                     };
                     mainWindow.CurrentTab.RestoreTabContentState();
                 }
             }
             else
                 mainWindow.ChangeSelection(obj, inNewTab);
-
         }
 
         private void MenuItem_ContextMenuOpened(object sender, RoutedEventArgs e)

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml.cs
@@ -103,11 +103,11 @@ namespace UndertaleModTool.Windows
                 });
                 if (result.Item2[0] is UndertaleNamedResource)
                     item.ItemTemplate = namedResTemplate;
-                else if (result.Item2[0] is GeneralInfoEditor)
+                else if (result.Item2[0] is GeneralInfoEditor or GlobalInitEditor or GameEndEditor)
                 {
                     ResultsTree.Items.Add(new TextBlock()
                     {
-                        Text = "General Info",
+                        Text = result.Item1,
                         DataContext = result.Item2[0],
                         ContextMenu = TryFindResource("StandaloneTabMenu") as ContextMenu
                     });
@@ -130,12 +130,12 @@ namespace UndertaleModTool.Windows
                 return;
             }
 
-            mainWindow.Focus();
-
             if (obj is object[] inst)
             {
                 if (inst[^1] is UndertaleRoom room)
                 {
+                    mainWindow.Focus();
+
                     mainWindow.ChangeSelection(room, inNewTab);
                     mainWindow.CurrentTab.LastContentState = new RoomTabState()
                     {
@@ -143,9 +143,27 @@ namespace UndertaleModTool.Windows
                     };
                     mainWindow.CurrentTab.RestoreTabContentState();
                 }
+                else
+                {
+                    if (!mainWindow.HasEditorForAsset(inst[^1]))
+                    {
+                        this.ShowError("The type of this object reference doesn't have an editor/viewer.");
+                        return;
+                    }
+                }
             }
             else
+            {
+                if (!mainWindow.HasEditorForAsset(obj))
+                {
+                    this.ShowError("The type of this object reference doesn't have an editor/viewer.");
+                    return;
+                }
+
+                mainWindow.Focus();
+
                 mainWindow.ChangeSelection(obj, inNewTab);
+            } 
         }
 
         private void MenuItem_ContextMenuOpened(object sender, RoutedEventArgs e)

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml
@@ -14,7 +14,7 @@
         <Label Content="Where to search the references?" HorizontalAlignment="Left" Margin="10,10,0,0" FontSize="22"/>
         <Rectangle Margin="10,0,20,0" Height="2" Fill="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
 
-        <ItemsControl Name="TypesList" Margin="10,10,20,0" Height="350">
+        <ItemsControl Name="TypesList" Margin="10,15,20,0" Height="350">
             <ItemsControl.Background>
                 <DynamicResource ResourceKey="{x:Static SystemColors.ControlLightLightBrushKey}"/>
             </ItemsControl.Background>

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml
@@ -7,30 +7,40 @@
         mc:Ignorable="d"
         Title="The types of references" Height="555" Width="497" IsVisibleChanged="Window_IsVisibleChanged"
         WindowStartupLocation="CenterOwner">
-    <StackPanel>
-        <StackPanel.Background>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*" MinHeight="50"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.Background>
             <DynamicResource ResourceKey="{x:Static SystemColors.ControlBrushKey}"/>
-        </StackPanel.Background>
-        <Label Content="Where to search the references?" HorizontalAlignment="Left" Margin="10,10,0,0" FontSize="22"/>
-        <Rectangle Margin="10,0,20,0" Height="2" Fill="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+        </Grid.Background>
+        <Label Grid.Row="0" Content="Where to search the references?" HorizontalAlignment="Left" Margin="10,10,0,0" FontSize="22"/>
+        <Rectangle Grid.Row="1" Margin="10,0,20,0" Height="2" Fill="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
 
-        <ItemsControl Name="TypesList" Margin="10,15,20,0" Height="350">
-            <ItemsControl.Background>
-                <DynamicResource ResourceKey="{x:Static SystemColors.ControlLightLightBrushKey}"/>
-            </ItemsControl.Background>
-            <ItemsControl.Resources>
-                <Style TargetType="CheckBox">
-                    <Setter Property="FontSize" Value="16"/>
-                    <Setter Property="VerticalContentAlignment" Value="Center"/>
-                    <Setter Property="Margin" Value="5,2"/>
-                </Style>
-            </ItemsControl.Resources>
-        </ItemsControl>
-        <StackPanel Orientation="Horizontal" Margin="10,7,0,0">
+        <ScrollViewer Grid.Row="2" Margin="10,15,20,0" VerticalScrollBarVisibility="Auto">
+            <ItemsControl Name="TypesList">
+                <ItemsControl.Background>
+                    <DynamicResource ResourceKey="{x:Static SystemColors.ControlLightLightBrushKey}"/>
+                </ItemsControl.Background>
+                <ItemsControl.Resources>
+                    <Style TargetType="CheckBox">
+                        <Setter Property="FontSize" Value="16"/>
+                        <Setter Property="VerticalContentAlignment" Value="Center"/>
+                        <Setter Property="Margin" Value="5,2"/>
+                    </Style>
+                </ItemsControl.Resources>
+            </ItemsControl>
+        </ScrollViewer>
+        
+        <StackPanel Grid.Row="3" Orientation="Horizontal" Margin="10,7,0,0">
             <local:ButtonDark Content="Select all" Click="SelectAllButton_Click" Height="26" Width="63"/>
             <local:ButtonDark Content="Deselect all" Margin="5,0,0,0" Click="DeselectAllButton_Click" Height="26" Width="71"/>
         </StackPanel>
 
-        <local:ButtonDark Content="Search" FontSize="18" Width="134" Height="40" Click="SearchButton_Click" Margin="0,15,0,0"/>
-    </StackPanel>
+        <local:ButtonDark Grid.Row="4" Content="Search" FontSize="18" Width="134" Height="40" Click="SearchButton_Click" Margin="0,15,0,15"/>
+    </Grid>
 </Window>

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml
@@ -1,0 +1,36 @@
+﻿<Window x:Class="UndertaleModTool.Windows.FindReferencesTypesDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:UndertaleModTool"
+        mc:Ignorable="d"
+        Title="The types of references" Height="555" Width="497" IsVisibleChanged="Window_IsVisibleChanged"
+        WindowStartupLocation="CenterOwner">
+    <StackPanel>
+        <StackPanel.Background>
+            <DynamicResource ResourceKey="{x:Static SystemColors.ControlBrushKey}"/>
+        </StackPanel.Background>
+        <Label Content="Where to search the references?" HorizontalAlignment="Left" Margin="10,10,0,0" FontSize="22"/>
+        <Rectangle Margin="10,0,20,0" Height="2" Fill="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+
+        <ItemsControl Name="TypesList" Margin="10,10,20,0" Height="350">
+            <ItemsControl.Background>
+                <DynamicResource ResourceKey="{x:Static SystemColors.ControlLightLightBrushKey}"/>
+            </ItemsControl.Background>
+            <ItemsControl.Resources>
+                <Style TargetType="CheckBox">
+                    <Setter Property="FontSize" Value="16"/>
+                    <Setter Property="VerticalContentAlignment" Value="Center"/>
+                    <Setter Property="Margin" Value="5,2"/>
+                </Style>
+            </ItemsControl.Resources>
+        </ItemsControl>
+        <StackPanel Orientation="Horizontal" Margin="10,7,0,0">
+            <local:ButtonDark Content="Select all" Click="SelectAllButton_Click" Height="26" Width="63"/>
+            <local:ButtonDark Content="Deselect all" Margin="5,0,0,0" Click="DeselectAllButton_Click" Height="26" Width="71"/>
+        </StackPanel>
+
+        <local:ButtonDark Content="Search" FontSize="18" Width="134" Height="40" Click="SearchButton_Click" Margin="0,15,0,0"/>
+    </StackPanel>
+</Window>

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:UndertaleModTool"
         mc:Ignorable="d"
-        Title="The types of references" Height="555" Width="497" IsVisibleChanged="Window_IsVisibleChanged"
+        Title="The types of references" Height="555" Width="450" IsVisibleChanged="Window_IsVisibleChanged"
         WindowStartupLocation="CenterOwner">
     <Grid>
         <Grid.RowDefinitions>

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml.cs
@@ -56,7 +56,8 @@ namespace UndertaleModTool.Windows
                 TypesList.Items.Add(new CheckBox()
                 {
                     DataContext = typePair.Item1,
-                    Content = typePair.Item2
+                    Content = typePair.Item2,
+                    IsChecked = true
                 });
             }
 
@@ -83,13 +84,13 @@ namespace UndertaleModTool.Windows
 
         private void SearchButton_Click(object sender, RoutedEventArgs e)
         {
-            List<Type> typesList = new();
+            List<(Type, string)> typesList = new();
             foreach (var item in TypesList.Items)
             {
                 if (item is CheckBox checkBox && checkBox.IsChecked == true)
                 {
                     if (checkBox.DataContext is Type t)
-                        typesList.Add(t);
+                        typesList.Add((t, checkBox.Content as string));
                 }
             }
 
@@ -99,7 +100,8 @@ namespace UndertaleModTool.Windows
                 return;
             }
 
-            FindReferencesResults dialog = new(sourceObj, new UndertaleResource[0][], data);
+            var results = UndertaleResourceReferenceMethodsMap.GetReferencesOfObject(sourceObj, data);
+            FindReferencesResults dialog = new(sourceObj, results);
             dialog.Show();
 
             Close();

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml.cs
@@ -101,7 +101,7 @@ namespace UndertaleModTool.Windows
             }
 
             var results = UndertaleResourceReferenceMethodsMap.GetReferencesOfObject(sourceObj, data);
-            FindReferencesResults dialog = new(sourceObj, results);
+            FindReferencesResults dialog = new(sourceObj, data, results);
             dialog.Show();
 
             Close();

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml.cs
@@ -52,8 +52,7 @@ namespace UndertaleModTool.Windows
                 return;
             }
 
-            var ver = (data.GeneralInfo.Major, data.GeneralInfo.Minor, data.GeneralInfo.Release);
-            (Type, string)[] sourceTypes = UndertaleResourceReferenceMap.GetTypeMapForVersion(obj.GetType(), ver, data.GeneralInfo.BytecodeVersion);
+            (Type, string)[] sourceTypes = UndertaleResourceReferenceMap.GetTypeMapForVersion(obj.GetType(), data);
             if (sourceTypes is null)
             {
                 this.ShowError($"Cannot get the source types for object of type \"{obj.GetType()}\".");
@@ -90,6 +89,9 @@ namespace UndertaleModTool.Windows
 
             foreach (var typePair in sourceTypes)
             {
+                if (data.Code is null && typePair.Key == typeof(UndertaleCode))
+                    continue;
+
                 TypesList.Items.Add(new CheckBox()
                 {
                     DataContext = typePair.Key,
@@ -122,7 +124,7 @@ namespace UndertaleModTool.Windows
         {
             if (sourceObj is not null)
             {
-                HashSetOverride<Type> typesList = new();
+                HashSetTypesOverride typesList = new();
                 foreach (var item in TypesList.Items)
                 {
                     if (item is CheckBox checkBox && checkBox.IsChecked == true)

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml.cs
@@ -13,6 +13,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 using UndertaleModLib;
+using UndertaleModLib.Models;
 
 namespace UndertaleModTool.Windows
 {
@@ -157,6 +158,16 @@ namespace UndertaleModTool.Windows
                 {
                     this.ShowError("At least one type should be selected.");
                     return;
+                }
+
+                if (typesDict.Count > 1 && typesDict.ContainsKey(typeof(UndertaleString))
+                    && data.Strings.Count > 5000)
+                {
+                    var res = this.ShowQuestion("You have selected the \"Strings\" when there are a lot of strings.\n" +
+                                                "That could make the search process noticeably longer.\n" +
+                                                "Do you want to proceed?");
+                    if (res != MessageBoxResult.Yes)
+                        return;
                 }
 
                 Hide();

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+using UndertaleModLib;
+
+namespace UndertaleModTool.Windows
+{
+    /// <summary>
+    /// Interaction logic for FindReferencesTypesDialog.xaml
+    /// </summary>
+    public partial class FindReferencesTypesDialog : Window
+    {
+        private readonly UndertaleData data;
+
+        private void Window_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (!IsVisible || IsLoaded)
+                return;
+
+            if (Settings.Instance.EnableDarkMode)
+                MainWindow.SetDarkTitleBarForWindow(this, true, false);
+        }
+
+        public FindReferencesTypesDialog(UndertaleResource obj, UndertaleData data)
+        {
+            InitializeComponent();
+
+            if (data.GeneralInfo is null)
+            {
+                this.ShowError("Cannot determine GameMaker version - \"General Info\" is null.");
+                return;
+            }
+
+            var ver = (data.GeneralInfo.Major, data.GeneralInfo.Minor, data.GeneralInfo.Release);
+            (Type, string)[] sourceTypes = UndertaleResourceReferenceMap.GetTypeMapForVersion(obj.GetType(), ver);
+            if (sourceTypes is null)
+            {
+                this.ShowError($"Cannot get the source types for object of type \"{obj.GetType()}\".");
+                return;
+            }
+
+            foreach (var typePair in sourceTypes)
+            {
+                TypesList.Items.Add(new CheckBox()
+                {
+                    DataContext = typePair.Item1,
+                    Content = typePair.Item2
+                });
+            }
+
+            this.data = data;
+        }
+
+        private void SelectAllButton_Click(object sender, RoutedEventArgs e)
+        {
+            foreach (var item in TypesList.Items)
+            {
+                if (item is CheckBox checkBox)
+                    checkBox.IsChecked = true;
+            }
+        }
+        private void DeselectAllButton_Click(object sender, RoutedEventArgs e)
+        {
+            foreach (var item in TypesList.Items)
+            {
+                if (item is CheckBox checkBox)
+                    checkBox.IsChecked = false;
+            }
+        }
+
+        private void SearchButton_Click(object sender, RoutedEventArgs e)
+        {
+            List<Type> typesList = new();
+            foreach (var item in TypesList.Items)
+            {
+                if (item is CheckBox checkBox && checkBox.IsChecked == true)
+                {
+                    if (checkBox.DataContext is Type t)
+                        typesList.Add(t);
+                }
+            }
+
+            if (typesList.Count == 0)
+            {
+                this.ShowError("At least one type should be selected.");
+                return;
+            }
+
+
+
+            Close();
+        }
+    }
+}

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml.cs
@@ -21,6 +21,7 @@ namespace UndertaleModTool.Windows
     /// </summary>
     public partial class FindReferencesTypesDialog : Window
     {
+        private readonly UndertaleResource sourceObj;
         private readonly UndertaleData data;
 
         private void Window_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
@@ -59,6 +60,7 @@ namespace UndertaleModTool.Windows
                 });
             }
 
+            sourceObj = obj;
             this.data = data;
         }
 
@@ -97,7 +99,8 @@ namespace UndertaleModTool.Windows
                 return;
             }
 
-
+            FindReferencesResults dialog = new(sourceObj, new UndertaleResource[0][], data);
+            dialog.Show();
 
             Close();
         }

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml.cs
@@ -89,7 +89,7 @@ namespace UndertaleModTool.Windows
 
             foreach (var typePair in sourceTypes)
             {
-                if (data.Code is null && typePair.Key == typeof(UndertaleCode))
+                if (data.Code is null && UndertaleResourceReferenceMap.CodeTypes.Contains(typePair.Key))
                     continue;
 
                 TypesList.Items.Add(new CheckBox()

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml.cs
@@ -44,7 +44,7 @@ namespace UndertaleModTool.Windows
             }
 
             var ver = (data.GeneralInfo.Major, data.GeneralInfo.Minor, data.GeneralInfo.Release);
-            (Type, string)[] sourceTypes = UndertaleResourceReferenceMap.GetTypeMapForVersion(obj.GetType(), ver);
+            (Type, string)[] sourceTypes = UndertaleResourceReferenceMap.GetTypeMapForVersion(obj.GetType(), ver, data.GeneralInfo.BytecodeVersion);
             if (sourceTypes is null)
             {
                 this.ShowError($"Cannot get the source types for object of type \"{obj.GetType()}\".");
@@ -84,13 +84,13 @@ namespace UndertaleModTool.Windows
 
         private void SearchButton_Click(object sender, RoutedEventArgs e)
         {
-            List<(Type, string)> typesList = new();
+            HashSet<Type> typesList = new();
             foreach (var item in TypesList.Items)
             {
                 if (item is CheckBox checkBox && checkBox.IsChecked == true)
                 {
                     if (checkBox.DataContext is Type t)
-                        typesList.Add((t, checkBox.Content as string));
+                        typesList.Add(t);
                 }
             }
 
@@ -100,7 +100,7 @@ namespace UndertaleModTool.Windows
                 return;
             }
 
-            var results = UndertaleResourceReferenceMethodsMap.GetReferencesOfObject(sourceObj, data);
+            var results = UndertaleResourceReferenceMethodsMap.GetReferencesOfObject(sourceObj, data, typesList);
             FindReferencesResults dialog = new(sourceObj, data, results);
             dialog.Show();
 

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml.cs
@@ -23,11 +23,18 @@ namespace UndertaleModTool.Windows
     {
         private readonly UndertaleResource sourceObj;
         private readonly UndertaleData data;
+        private readonly bool dontShowWindow = false;
 
         private void Window_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
             if (!IsVisible || IsLoaded)
                 return;
+
+            if (dontShowWindow)
+            {
+                Close();
+                return;
+            }
 
             if (Settings.Instance.EnableDarkMode)
                 MainWindow.SetDarkTitleBarForWindow(this, true, false);
@@ -40,6 +47,7 @@ namespace UndertaleModTool.Windows
             if (data.GeneralInfo is null)
             {
                 this.ShowError("Cannot determine GameMaker version - \"General Info\" is null.");
+                dontShowWindow = true;
                 return;
             }
 
@@ -48,6 +56,7 @@ namespace UndertaleModTool.Windows
             if (sourceTypes is null)
             {
                 this.ShowError($"Cannot get the source types for object of type \"{obj.GetType()}\".");
+                dontShowWindow = true;
                 return;
             }
 

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
@@ -81,6 +81,28 @@ namespace UndertaleModTool.Windows
                         }
                     }
                 }
+            },
+            {
+                typeof(UndertaleEmbeddedTexture),
+                new[]
+                {
+                    new TypesForVersion
+                    {
+                        Version = (1, 0, 0),
+                        Types = new[]
+                        {
+                            (typeof(UndertaleTexturePageItem), "Texture page items")
+                        }
+                    },
+                    new TypesForVersion
+                    {
+                        Version = (2, 2, 1),
+                        Types = new[]
+                        {
+                            (typeof(UndertaleTextureGroupInfo), "Texture groups")
+                        }
+                    },
+                }
             }
         };
 

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
@@ -311,11 +311,23 @@ namespace UndertaleModTool.Windows
             { typeof(UndertaleEmbeddedAudio), "Embedded audio" },
             { typeof(UndertaleAudioGroup), "Audio groups" }
         };
+        
+        public static readonly HashSet<Type> CodeTypes = new()
+        {
+            typeof(UndertaleCode),
+            typeof(UndertaleScript),
+            typeof(UndertaleCodeLocals),
+            typeof(UndertaleVariable),
+            typeof(UndertaleFunction)
+        };
 
-        public static (Type, string)[] GetTypeMapForVersion(Type type, (uint, uint, uint) version, byte bytecodeVersion)
+        public static (Type, string)[] GetTypeMapForVersion(Type type, UndertaleData data)
         {
             if (!typeMap.TryGetValue(type, out TypesForVersion[] typesForVer))
                 return null;
+
+            var version = (data.GeneralInfo.Major, data.GeneralInfo.Minor, data.GeneralInfo.Release);
+            byte bytecodeVersion = data.GeneralInfo.BytecodeVersion;
 
             IEnumerable<(Type, string)> outTypes = Enumerable.Empty<(Type, string)>();
             foreach (var typeForVer in typesForVer)
@@ -333,7 +345,9 @@ namespace UndertaleModTool.Windows
             if (outTypes == Enumerable.Empty<(Type, string)>())
                 return null;
 
-            return outTypes.Where(x => x.Item2 is not null).ToArray();
+            return outTypes.Where(x => x.Item2 is not null
+                                       && !(data.Code is null && CodeTypes.Contains(x.Item1)))
+                           .ToArray();
         }
 
         public static Dictionary<Type, string> GetReferenceableTypes((uint, uint, uint) version)

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
@@ -17,7 +17,6 @@ namespace UndertaleModTool.Windows
     {
         private static readonly Dictionary<Type, TypesForVersion[]> typeMap = new()
         {
-            // typeof(Undertale),
             {
                 typeof(UndertaleSprite),
                 new[]
@@ -25,7 +24,7 @@ namespace UndertaleModTool.Windows
                     new TypesForVersion
                     {
                         Version = (1, 0, 0),
-                        Types = new (Type, string)[]
+                        Types = new[]
                         {
                             (typeof(UndertaleGameObject), "Game objects")
                         }
@@ -33,7 +32,7 @@ namespace UndertaleModTool.Windows
                     new TypesForVersion
                     {
                         Version = (2, 0, 0),
-                        Types = new (Type, string)[]
+                        Types = new[]
                         {
                             (typeof(UndertaleRoom.Tile), "Room tiles"),
                             (typeof(UndertaleRoom.SpriteInstance), "Room sprite instances"),
@@ -43,11 +42,44 @@ namespace UndertaleModTool.Windows
                     new TypesForVersion
                     {
                         Version = (2, 2, 1),
-                        Types = new (Type, string)[]
+                        Types = new[]
                         {
                             (typeof(UndertaleTextureGroupInfo), "Texture groups")
                         }
                     },
+                }
+            },
+            {
+                typeof(UndertaleBackground),
+                new[]
+                {
+                    new TypesForVersion
+                    {
+                        Version = (1, 0, 0),
+                        Types = new[]
+                        {
+                            (typeof(UndertaleRoom.Background), "Room backgrounds"),
+                            (typeof(UndertaleRoom.Tile), "Room tiles")
+                        }
+                    },
+                    new TypesForVersion
+                    {
+                        Version = (2, 0, 0),
+                        Types = new[]
+                        {
+                            (typeof(UndertaleRoom.Background), null),
+                            (typeof(UndertaleRoom.Tile), null),
+                            (typeof(UndertaleRoom.Layer), "Room tile layers")
+                        }
+                    },
+                    new TypesForVersion
+                    {
+                        Version = (2, 2, 1),
+                        Types = new[]
+                        {
+                            (typeof(UndertaleTextureGroupInfo), "Texture groups")
+                        }
+                    }
                 }
             }
         };
@@ -62,13 +94,13 @@ namespace UndertaleModTool.Windows
             foreach (var typeForVer in typesForVer)
             {
                 if (typeForVer.Version.CompareTo(version) <= 0)
-                    outTypes = outTypes.Concat(typeForVer.Types);
+                    outTypes = typeForVer.Types.UnionBy(outTypes, x => x.Item1);
             }
 
             if (outTypes == Enumerable.Empty<(Type, string)>())
                 return null;
 
-            return outTypes.ToArray();
+            return outTypes.Where(x => x.Item2 is not null).ToArray();
         }
 
         public static bool IsTypeReferenceable(Type type)

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
@@ -296,6 +296,34 @@ namespace UndertaleModTool.Windows
                         }
                     }
                 }
+            },
+            {
+                typeof(UndertaleFunction),
+                new[]
+                {
+                    new TypesForVersion()
+                    {
+                        Version = (1, 0, 0),
+                        Types = new[]
+                        {
+                            (typeof(UndertaleCode), "Code")
+                        }
+                    }
+                }
+            },
+            {
+                typeof(UndertaleVariable),
+                new[]
+                {
+                    new TypesForVersion()
+                    {
+                        Version = (1, 0, 0),
+                        Types = new[]
+                        {
+                            (typeof(UndertaleCode), "Code")
+                        }
+                    }
+                }
             }
         };
 
@@ -308,8 +336,10 @@ namespace UndertaleModTool.Windows
             { typeof(UndertaleString), "Strings" },
             { typeof(UndertaleGameObject), "Game objects" },
             { typeof(UndertaleCode), "Code entries" },
+            { typeof(UndertaleFunction), "Functions" },
+            { typeof(UndertaleVariable), "Variables" },
             { typeof(UndertaleEmbeddedAudio), "Embedded audio" },
-            { typeof(UndertaleAudioGroup), "Audio groups" }
+            { typeof(UndertaleAudioGroup), "Audio groups" },
         };
         
         public static readonly HashSet<Type> CodeTypes = new()

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
@@ -105,6 +105,31 @@ namespace UndertaleModTool.Windows
                 }
             },
             {
+                typeof(UndertaleTexturePageItem),
+                new[]
+                {
+                    new TypesForVersion()
+                    {
+                        Version = (1, 0, 0),
+                        Types = new[]
+                        {
+                            (typeof(UndertaleSprite), "Sprites"),
+                            (typeof(UndertaleBackground), "Backgrounds"),
+                            (typeof(UndertaleFont), "Fonts")
+                        }
+                    },
+                    new TypesForVersion()
+                    {
+                        Version = (2, 0, 0),
+                        Types = new[]
+                        {
+                            (typeof(UndertaleBackground), "Tile sets"),
+                            (typeof(UndertaleEmbeddedImage), "Embedded images")
+                        }
+                    }
+                }
+            },
+            {
                 typeof(UndertaleString),
                 new[]
                 {

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
@@ -139,7 +139,7 @@ namespace UndertaleModTool.Windows
                         Types = new[]
                         {
                             (typeof(UndertaleBackground), "Backgrounds"),
-                            (typeof(UndertaleCode), "Code entries"),
+                            (typeof(UndertaleCode), "Code entries (name and contents)"),
                             (typeof(UndertaleSound), "Sounds"),
                             (typeof(UndertaleAudioGroup), "Audio groups"),
                             (typeof(UndertaleSprite), "Sprites"),

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
@@ -27,9 +27,7 @@ namespace UndertaleModTool.Windows
                         Version = (1, 0, 0),
                         Types = new (Type, string)[]
                         {
-                            (typeof(UndertaleGameObject), "Game objects"),
-                            (typeof(UndertaleTextureGroupInfo), "Texture groups"),
-                            (typeof(UndertaleRoom.Tile), "Room tiles")
+                            (typeof(UndertaleGameObject), "Game objects")
                         }
                     },
                     new TypesForVersion
@@ -37,10 +35,19 @@ namespace UndertaleModTool.Windows
                         Version = (2, 0, 0),
                         Types = new (Type, string)[]
                         {
+                            (typeof(UndertaleRoom.Tile), "Room tiles"),
                             (typeof(UndertaleRoom.SpriteInstance), "Room sprite instances"),
                             (typeof(UndertaleRoom.Layer.LayerBackgroundData), "Room background layers")
                         }
-                    }
+                    },
+                    new TypesForVersion
+                    {
+                        Version = (2, 2, 1),
+                        Types = new (Type, string)[]
+                        {
+                            (typeof(UndertaleTextureGroupInfo), "Texture groups")
+                        }
+                    },
                 }
             }
         };

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
@@ -250,6 +250,22 @@ namespace UndertaleModTool.Windows
                         }
                     },
                 }
+            },
+            {
+                typeof(UndertaleCode),
+                new[]
+                {
+                    new TypesForVersion()
+                    {
+                        Version = (1, 0, 0),
+                        Types = new[]
+                        {
+                            (typeof(UndertaleGameObject), "Game objects"),
+                            (typeof(UndertaleRoom), "Rooms"),
+                            (typeof(UndertaleGlobalInit), "Global initialization and game end scripts")
+                        }
+                    }
+                }
             }
         };
 

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
@@ -140,6 +140,8 @@ namespace UndertaleModTool.Windows
                         {
                             (typeof(UndertaleBackground), "Backgrounds"),
                             (typeof(UndertaleCode), "Code entries (name and contents)"),
+                            (typeof(UndertaleVariable), "Variables"),
+                            (typeof(UndertaleFunction), "Functions"),
                             (typeof(UndertaleSound), "Sounds"),
                             (typeof(UndertaleAudioGroup), "Audio groups"),
                             (typeof(UndertaleSprite), "Sprites"),
@@ -148,7 +150,6 @@ namespace UndertaleModTool.Windows
                             (typeof(UndertaleExtensionOption), "Extension options"),
                             (typeof(UndertaleExtensionFunction), "Extension functions"),
                             (typeof(UndertaleFont), "Fonts"),
-                            (typeof(UndertaleFunction), "Functions"),
                             (typeof(UndertaleGameObject), "Game objects"),
                             (typeof(UndertaleGeneralInfo), "General info"),
                             (typeof(UndertaleOptions.Constant), "Game options constants"),

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
@@ -45,6 +45,7 @@ namespace UndertaleModTool.Windows
             }
         };
 
+
         public static (Type, string)[] GetTypeMapForVersion(Type type, (uint, uint, uint) version)
         {
             if (!typeMap.TryGetValue(type, out TypesForVersion[] typesForVer))

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
@@ -280,6 +280,20 @@ namespace UndertaleModTool.Windows
                         }
                     }
                 }
+            },
+            {
+                typeof(UndertaleAudioGroup),
+                new[]
+                {
+                    new TypesForVersion()
+                    {
+                        Version = (1, 0, 0),
+                        Types = new[]
+                        {
+                            (typeof(UndertaleSound), "Sounds")
+                        }
+                    }
+                }
             }
         };
 

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
@@ -103,11 +103,111 @@ namespace UndertaleModTool.Windows
                         }
                     },
                 }
+            },
+            {
+                typeof(UndertaleString),
+                new[]
+                {
+                    new TypesForVersion
+                    {
+                        Version = (1, 0, 0),
+                        Types = new[]
+                        {
+                            (typeof(UndertaleBackground), "Backgrounds"),
+                            (typeof(UndertaleCode), "Code entries"),
+                            (typeof(UndertaleSound), "Sounds"),
+                            (typeof(UndertaleAudioGroup), "Audio groups"),
+                            (typeof(UndertaleSprite), "Sprites"),
+                            (typeof(UndertaleExtension), "Extensions"),
+                            (typeof(UndertaleExtensionFile), "Extension files"),
+                            (typeof(UndertaleExtensionOption), "Extension options"),
+                            (typeof(UndertaleExtensionFunction), "Extension functions"),
+                            (typeof(UndertaleFont), "Fonts"),
+                            (typeof(UndertaleFunction), "Functions"),
+                            (typeof(UndertaleGameObject), "Game objects"),
+                            (typeof(UndertaleGeneralInfo), "General info"),
+                            (typeof(UndertaleOptions.Constant), "Game options constants"),
+                            (typeof(UndertaleLanguage), "Languages"),
+                            (typeof(UndertalePath), "Paths"),
+                            (typeof(UndertaleRoom), "Rooms"),
+                            (typeof(UndertaleScript), "Scripts"),
+                            (typeof(UndertaleShader), "Shaders"),
+                            (typeof(UndertaleTimeline), "Timelines")
+                        }
+                    },
+                    new TypesForVersion
+                    {
+                        // Bytecode version 15
+                        Version = (15, uint.MaxValue, uint.MaxValue),
+                        Types = new[]
+                        {
+                            (typeof(UndertaleCodeLocals), "Code locals")
+                        }
+                    },
+                    new TypesForVersion
+                    {
+                        Version = (2, 0, 0),
+                        Types = new[]
+                        {
+                            (typeof(UndertaleBackground), "Tile sets"),
+                            (typeof(UndertaleEmbeddedImage), "Embedded images"),
+                            (typeof(UndertaleRoom.Layer), "Room layers"),
+                            (typeof(UndertaleRoom.SpriteInstance), "Room sprite instances")
+                        }
+                    },
+                    new TypesForVersion
+                    {
+                        Version = (2, 2, 1),
+                        Types = new[]
+                        {
+                            (typeof(UndertaleTextureGroupInfo), "Texture groups")
+                        }
+                    },
+                    new TypesForVersion
+                    {
+                        Version = (2, 3, 0),
+                        Types = new[]
+                        {
+                            (typeof(UndertaleAnimationCurve), "Animation curves"),
+                            (typeof(UndertaleAnimationCurve.Channel), "Animation curve channels"),
+                            (typeof(UndertaleRoom.SequenceInstance), "Room sequence instances"),
+                            (typeof(UndertaleSequence), "Sequences"),
+                            (typeof(UndertaleSequence.Track), "Sequence tracks"),
+                            (typeof(UndertaleSequence.BroadcastMessage), "Sequence broadcast messages"),
+                            (typeof(UndertaleSequence.Moment), "Sequence moments"),
+                            (typeof(UndertaleSequence.StringKeyframes), "Sequence string keyframes")
+                        }
+                    },
+                    new TypesForVersion
+                    {
+                        Version = (2, 3, 6),
+                        Types = new[]
+                        {
+                            (typeof(UndertaleFilterEffect), "Filter effects")
+                        }
+                    },
+                    new TypesForVersion
+                    {
+                        Version = (2022, 1, 0),
+                        Types = new[]
+                        {
+                            (typeof(UndertaleRoom.EffectProperty), "Room effect properties")
+                        }
+                    },
+                    new TypesForVersion
+                    {
+                        Version = (2022, 2, 0),
+                        Types = new[]
+                        {
+                            (typeof(UndertaleSequence.TextKeyframes), "Sequence track text keyframes")
+                        }
+                    }
+                }
             }
         };
 
 
-        public static (Type, string)[] GetTypeMapForVersion(Type type, (uint, uint, uint) version)
+        public static (Type, string)[] GetTypeMapForVersion(Type type, (uint, uint, uint) version, byte bytecodeVersion)
         {
             if (!typeMap.TryGetValue(type, out TypesForVersion[] typesForVer))
                 return null;
@@ -115,7 +215,13 @@ namespace UndertaleModTool.Windows
             IEnumerable<(Type, string)> outTypes = Enumerable.Empty<(Type, string)>();
             foreach (var typeForVer in typesForVer)
             {
-                if (typeForVer.Version.CompareTo(version) <= 0)
+                bool isAtLeast = false;
+                if (typeForVer.Version.Minor == uint.MaxValue)
+                    isAtLeast = typeForVer.Version.Major <= bytecodeVersion;
+                else
+                    isAtLeast = typeForVer.Version.CompareTo(version) <= 0;
+
+                if (isAtLeast)
                     outTypes = typeForVer.Types.UnionBy(outTypes, x => x.Item1);
             }
 

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
@@ -262,7 +262,8 @@ namespace UndertaleModTool.Windows
                         {
                             (typeof(UndertaleGameObject), "Game objects"),
                             (typeof(UndertaleRoom), "Rooms"),
-                            (typeof(UndertaleGlobalInit), "Global initialization and game end scripts")
+                            (typeof(UndertaleGlobalInit), "Global initialization and game end scripts"),
+                            (typeof(UndertaleScript), "Scripts")
                         }
                     }
                 }
@@ -297,6 +298,18 @@ namespace UndertaleModTool.Windows
             }
         };
 
+        private static readonly Dictionary<Type, string> referenceableTypes = new()
+        {
+            { typeof(UndertaleSprite), "Sprites" },
+            { typeof(UndertaleBackground), "Backgrounds" },
+            { typeof(UndertaleEmbeddedTexture), "Embedded textures" },
+            { typeof(UndertaleTexturePageItem), "Texture page items" },
+            { typeof(UndertaleString), "Strings" },
+            { typeof(UndertaleGameObject), "Game objects" },
+            { typeof(UndertaleCode), "Code entries" },
+            { typeof(UndertaleEmbeddedAudio), "Embedded audio" },
+            { typeof(UndertaleAudioGroup), "Audio groups" }
+        };
 
         public static (Type, string)[] GetTypeMapForVersion(Type type, (uint, uint, uint) version, byte bytecodeVersion)
         {
@@ -320,6 +333,14 @@ namespace UndertaleModTool.Windows
                 return null;
 
             return outTypes.Where(x => x.Item2 is not null).ToArray();
+        }
+
+        public static Dictionary<Type, string> GetReferenceableTypes((uint, uint, uint) version)
+        {
+            referenceableTypes[typeof(UndertaleBackground)] = version.CompareTo((2, 0, 0)) >= 0
+                                                              ? "Tile sets" : "Backgrounds";
+
+            return referenceableTypes;
         }
 
         public static bool IsTypeReferenceable(Type type)

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
@@ -203,6 +203,28 @@ namespace UndertaleModTool.Windows
                         }
                     }
                 }
+            },
+            {
+                typeof(UndertaleGameObject),
+                new[]
+                {
+                    new TypesForVersion
+                    {
+                        Version = (1, 0, 0),
+                        Types = new[]
+                        {
+                            (typeof(UndertaleRoom.GameObject), "Room object instance")
+                        }
+                    },
+                    new TypesForVersion
+                    {
+                        Version = (2, 3, 0),
+                        Types = new[]
+                        {
+                            (typeof(UndertaleSequence.InstanceKeyframes), "Sequence instance keyframes")
+                        }
+                    },
+                }
             }
         };
 

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UndertaleModLib;
+using UndertaleModLib.Models;
+
+namespace UndertaleModTool.Windows
+{
+    public class TypesForVersion
+    {
+        public (uint Major, uint Minor, uint Release) Version { get; set; }
+        public (Type, string)[] Types { get; set; }
+    }
+
+    public static class UndertaleResourceReferenceMap
+    {
+        private static readonly Dictionary<Type, TypesForVersion[]> typeMap = new()
+        {
+            // typeof(Undertale),
+            {
+                typeof(UndertaleSprite),
+                new[]
+                {
+                    new TypesForVersion
+                    {
+                        Version = (1, 0, 0),
+                        Types = new (Type, string)[]
+                        {
+                            (typeof(UndertaleGameObject), "Game objects"),
+                            (typeof(UndertaleTextureGroupInfo), "Texture groups"),
+                            (typeof(UndertaleRoom.Tile), "Room tiles")
+                        }
+                    },
+                    new TypesForVersion
+                    {
+                        Version = (2, 0, 0),
+                        Types = new (Type, string)[]
+                        {
+                            (typeof(UndertaleRoom.SpriteInstance), "Room sprite instances"),
+                            (typeof(UndertaleRoom.Layer.LayerBackgroundData), "Room background layers")
+                        }
+                    }
+                }
+            }
+        };
+
+        public static (Type, string)[] GetTypeMapForVersion(Type type, (uint, uint, uint) version)
+        {
+            if (!typeMap.TryGetValue(type, out TypesForVersion[] typesForVer))
+                return null;
+
+            IEnumerable<(Type, string)> outTypes = Enumerable.Empty<(Type, string)>();
+            foreach (var typeForVer in typesForVer)
+            {
+                if (typeForVer.Version.CompareTo(version) <= 0)
+                    outTypes = outTypes.Concat(typeForVer.Types);
+            }
+
+            if (outTypes == Enumerable.Empty<(Type, string)>())
+                return null;
+
+            return outTypes.ToArray();
+        }
+
+        public static bool IsTypeReferenceable(Type type)
+        {
+            if (type is null)
+                return false;
+
+            return typeMap.ContainsKey(type);
+        }
+    }
+}

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
@@ -266,6 +266,20 @@ namespace UndertaleModTool.Windows
                         }
                     }
                 }
+            },
+            {
+                typeof(UndertaleEmbeddedAudio),
+                new[]
+                {
+                    new TypesForVersion()
+                    {
+                        Version = (1, 0, 0),
+                        Types = new[]
+                        {
+                            (typeof(UndertaleSound), "Sounds")
+                        }
+                    }
+                }
             }
         };
 

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -402,6 +402,18 @@ namespace UndertaleModTool.Windows
                                 if (codeEntries.Any())
                                     outDict["Code entries (name and contents)"] = checkOne ? codeEntries.ToEmptyArray() : codeEntries.ToArray();
                             }
+                            if (types.Contains(typeof(UndertaleFunction)))
+                            {
+                                var functions = data.Functions.Where(x => x.Name == obj);
+                                if (functions.Any())
+                                    outDict["Functions"] = checkOne ? functions.ToEmptyArray() : functions.ToArray();
+                            }
+                            if (types.Contains(typeof(UndertaleVariable)))
+                            {
+                                var variables = data.Variables.Where(x => x.Name == obj);
+                                if (variables.Any())
+                                    outDict["Variables"] = checkOne ? variables.ToEmptyArray() : variables.ToArray();
+                            }
 
                             if (types.Contains(typeof(UndertaleSound)))
                             {
@@ -497,13 +509,6 @@ namespace UndertaleModTool.Windows
                                 var fonts = data.Fonts.Where(x => x.Name == obj || x.DisplayName == obj);
                                 if (fonts.Any())
                                     outDict["Fonts"] = checkOne ? fonts.ToEmptyArray() : fonts.ToArray();
-                            }
-
-                            if (types.Contains(typeof(UndertaleFunction)))
-                            {
-                                var functions = data.Functions.Where(x => x.Name == obj);
-                                if (functions.Any())
-                                    outDict["Functions"] = checkOne ? functions.ToEmptyArray() : functions.ToArray();
                             }
 
                             if (types.Contains(typeof(UndertaleGameObject)))

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -43,9 +43,12 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (1, 0, 0),
-                        Predicate = (obj, types, checkOne) =>
+                        Predicate = (objSrc, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleGameObject)))
+                                return null;
+
+                            if (objSrc is not UndertaleSprite obj)
                                 return null;
 
                             var gameObjects = data.GameObjects.Where(x => x.Sprite == obj);
@@ -58,8 +61,11 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2, 0, 0),
-                        Predicate = (obj, types, checkOne) =>
+                        Predicate = (objSrc, types, checkOne) =>
                         {
+                            if (objSrc is not UndertaleSprite obj)
+                                return null;
+
                             Dictionary<string, object[]> outDict = new();
 
                             if (types.Contains(typeof(UndertaleRoom.Tile)))
@@ -134,9 +140,12 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2, 2, 1),
-                        Predicate = (obj, types, checkOne) =>
+                        Predicate = (objSrc, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleTextureGroupInfo)))
+                                return null;
+
+                            if (objSrc is not UndertaleSprite obj)
                                 return null;
 
                             var textGroups = data.TextureGroupInfo.Where(x => x.Sprites.Any(s => s.Resource == obj)
@@ -156,9 +165,12 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (1, 0, 0),
-                        Predicate = (obj, types, checkOne) =>
+                        Predicate = (objSrc, types, checkOne) =>
                         {
                             if (data.IsGameMaker2())
+                                return null;
+
+                            if (objSrc is not UndertaleBackground obj)
                                 return null;
 
                             Dictionary<string, object[]> outDict = new();
@@ -204,9 +216,12 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2, 0, 0),
-                        Predicate = (obj, types, checkOne) =>
+                        Predicate = (objSrc, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleRoom.Layer)))
+                                return null;
+
+                            if (objSrc is not UndertaleBackground obj)
                                 return null;
 
                             IEnumerable<object[]> GetTileLayers()
@@ -233,9 +248,12 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2, 2, 1),
-                        Predicate = (obj, types, checkOne) =>
+                        Predicate = (objSrc, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleTextureGroupInfo)))
+                                return null;
+
+                            if (objSrc is not UndertaleBackground obj)
                                 return null;
 
                             var textGroups = data.TextureGroupInfo.Where(x => x.Tilesets.Any(s => s.Resource == obj));
@@ -254,8 +272,11 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (1, 0, 0),
-                        Predicate = (obj, types, checkOne) =>
+                        Predicate = (objSrc, types, checkOne) =>
                         {
+                            if (objSrc is not UndertaleEmbeddedTexture obj)
+                                return null;
+
                             var pageItems = data.TexturePageItems.Where(x => x.TexturePage == obj);
                             if (pageItems.Any())
                                 return new() { { "Texture page items", checkOne ? pageItems.ToEmptyArray() : pageItems.ToArray() } };
@@ -266,9 +287,12 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2, 2, 1),
-                        Predicate = (obj, types, checkOne) =>
+                        Predicate = (objSrc, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleTextureGroupInfo)))
+                                return null;
+
+                            if (objSrc is not UndertaleEmbeddedTexture obj)
                                 return null;
 
                             var textGroups = data.TextureGroupInfo.Where(x => x.TexturePages.Any(s => s.Resource == obj));
@@ -287,9 +311,12 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (1, 0, 0),
-                        Predicate = (obj, types, checkOne) =>
+                        Predicate = (objSrc, types, checkOne) =>
                         {
                             Dictionary<string, object[]> outDict = new();
+
+                            if (objSrc is not UndertaleTexturePageItem obj)
+                                return null;
 
                             if (types.Contains(typeof(UndertaleSprite)))
                             {
@@ -320,9 +347,12 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2, 0, 0),
-                        Predicate = (obj, types, checkOne) =>
+                        Predicate = (objSrc, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleEmbeddedImage)))
+                                return null;
+
+                            if (objSrc is not UndertaleTexturePageItem obj)
                                 return null;
 
                             var embImages = data.EmbeddedImages.Where(x => x.TextureEntry == obj);
@@ -500,9 +530,9 @@ namespace UndertaleModTool.Windows
 
                             if (types.Contains(typeof(UndertaleLanguage)))
                             {
-                                bool langsMatches = data.Language.EntryIDs.Any(x => x == obj)
+                                bool langsMatches = data.Language.EntryIDs.Contains(obj)
                                                     || data.Language.Languages.Any(x => x.Name == obj || x.Region == obj
-                                                                                        || x.Entries.Any(e => e == obj));
+                                                                                        || x.Entries.Contains(obj));
                                 if (langsMatches)
                                     outDict["Languages"] = new object[] { new GeneralInfoEditor(data.GeneralInfo, data.Options, data.Language) };
                             }
@@ -554,9 +584,12 @@ namespace UndertaleModTool.Windows
                     {
                         // Bytecode version 15
                         Version = (15, uint.MaxValue, uint.MaxValue),
-                        Predicate = (obj, types, checkOne) =>
+                        Predicate = (objSrc, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleCodeLocals)))
+                                return null;
+
+                            if (objSrc is not UndertaleString obj)
                                 return null;
 
                             var codeLocals = data.CodeLocals.Where(x => x.Name == obj || x.Locals.Any(l => l.Name == obj));
@@ -569,8 +602,11 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2, 0, 0),
-                        Predicate = (obj, types, checkOne) =>
+                        Predicate = (objSrc, types, checkOne) =>
                         {
+                            if (objSrc is not UndertaleString obj)
+                                return null;
+
                             Dictionary<string, object[]> outDict = new();
 
                             if (types.Contains(typeof(UndertaleEmbeddedImage)))
@@ -625,9 +661,12 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2, 2, 1),
-                        Predicate = (obj, types, checkOne) =>
+                        Predicate = (objSrc, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleTextureGroupInfo)))
+                                return null;
+
+                            if (objSrc is not UndertaleString obj)
                                 return null;
 
                             var textGroups = data.TextureGroupInfo.Where(x => x.Name == obj);
@@ -696,7 +735,7 @@ namespace UndertaleModTool.Windows
                             if (types.Contains(typeof(UndertaleSequence)))
                             {
                                 var sequences = data.Sequences.Where(x => x.Name == obj
-                                                                          || x.FunctionIDs.Values.Any(i => i == obj));
+                                                                          || x.FunctionIDs.ContainsValue(obj));
                                 if (sequences.Any())
                                     outDict["Sequences"] = checkOne ? sequences.ToEmptyArray() : sequences.ToArray();
                             }
@@ -792,9 +831,12 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2, 3, 6),
-                        Predicate = (obj, types, checkOne) =>
+                        Predicate = (objSrc, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleFilterEffect)))
+                                return null;
+
+                            if (objSrc is not UndertaleString obj)
                                 return null;
 
                             var filterEffects = data.FilterEffects.Where(x => x.Name == obj || x.Value == obj);
@@ -807,9 +849,12 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2022, 1, 0),
-                        Predicate = (obj, types, checkOne) =>
+                        Predicate = (objSrc, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleRoom.EffectProperty)))
+                                return null;
+
+                            if (objSrc is not UndertaleString obj)
                                 return null;
 
                             IEnumerable<object[]> GetEffectProps()
@@ -835,9 +880,12 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2022, 2, 0),
-                        Predicate = (obj, types, checkOne) =>
+                        Predicate = (objSrc, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(TextKeyframes)))
+                                return null;
+
+                            if (objSrc is not UndertaleString obj)
                                 return null;
 
                             // TODO: make this "IEnumerable<object[]>"
@@ -884,9 +932,12 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (1, 0, 0),
-                        Predicate = (obj, types, checkOne) =>
+                        Predicate = (objSrc, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleRoom.GameObject)))
+                                return null;
+
+                            if (objSrc is not UndertaleGameObject obj)
                                 return null;
 
                             IEnumerable<object[]> GetObjInstances()
@@ -927,9 +978,12 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2, 3, 0),
-                        Predicate = (obj, types, checkOne) =>
+                        Predicate = (objSrc, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(InstanceKeyframes)))
+                                return null;
+
+                            if (objSrc is not UndertaleGameObject obj)
                                 return null;
 
                             // TODO: make this "IEnumerable<object[]>"
@@ -976,8 +1030,11 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (1, 0, 0),
-                        Predicate = (obj, types, checkOne) =>
+                        Predicate = (objSrc, types, checkOne) =>
                         {
+                            if (objSrc is not UndertaleCode obj)
+                                return null;
+
                             Dictionary<string, object[]> outDict = new();
 
                             if (types.Contains(typeof(UndertaleGameObject)))
@@ -1028,9 +1085,12 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (1, 0, 0),
-                        Predicate = (obj, types, checkOne) =>
+                        Predicate = (objSrc, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleSound)))
+                                return null;
+
+                            if (objSrc is not UndertaleEmbeddedAudio obj)
                                 return null;
 
                             var sounds = data.Sounds.Where(x => x.AudioFile == obj);
@@ -1049,9 +1109,12 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (1, 0, 0),
-                        Predicate = (obj, types, checkOne) =>
+                        Predicate = (objSrc, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleSound)))
+                                return null;
+
+                            if (objSrc is not UndertaleAudioGroup obj)
                                 return null;
 
                             var sounds = data.Sounds.Where(x => x.AudioGroup == obj);

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -169,8 +169,37 @@ namespace UndertaleModTool.Windows
                         Version = (2, 2, 1),
                         Predicate = (obj) =>
                         {
-                            var textGroups = data.TextureGroupInfo.Where(x => x.Sprites.Any(s => s.Resource == obj)
-                                                                              || x.SpineSprites.Any(s => s.Resource == obj));
+                            var textGroups = data.TextureGroupInfo.Where(x => x.Tilesets.Any(s => s.Resource == obj));
+                            if (textGroups.Any())
+                                return new (string, object[])[] { ("Texture groups", textGroups.ToArray()) };
+                            else
+                                return null;
+                        }
+                    }
+                }
+            },
+            {
+                typeof(UndertaleEmbeddedTexture),
+                new[]
+                {
+                    new PredicateForVersion()
+                    {
+                        Version = (1, 0, 0),
+                        Predicate = (obj) =>
+                        {
+                            var pageItems = data.TexturePageItems.Where(x => x.TexturePage == obj);
+                            if (pageItems.Any())
+                                return new (string, object[])[] { ("Texture page items", pageItems.ToArray()) };
+                            else
+                                return null;
+                        }
+                    },
+                    new PredicateForVersion()
+                    {
+                        Version = (2, 2, 1),
+                        Predicate = (obj) =>
+                        {
+                            var textGroups = data.TextureGroupInfo.Where(x => x.TexturePages.Any(s => s.Resource == obj));
                             if (textGroups.Any())
                                 return new (string, object[])[] { ("Texture groups", textGroups.ToArray()) };
                             else
@@ -180,6 +209,7 @@ namespace UndertaleModTool.Windows
                 }
             }
         };
+
 
         public static (string, object[])[] GetReferencesOfObject(UndertaleResource obj, UndertaleData data)
         {

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -5,7 +5,6 @@ using System.Text;
 using System.Threading.Tasks;
 using UndertaleModLib;
 using UndertaleModLib.Models;
-using static UndertaleModLib.Models.UndertaleRoom;
 using static UndertaleModLib.Models.UndertaleSequence;
 
 namespace UndertaleModTool.Windows
@@ -212,6 +211,60 @@ namespace UndertaleModTool.Windows
                             var textGroups = data.TextureGroupInfo.Where(x => x.TexturePages.Any(s => s.Resource == obj));
                             if (textGroups.Any())
                                 return new (string, object[])[] { ("Texture groups", textGroups.ToArray()) };
+                            else
+                                return null;
+                        }
+                    }
+                }
+            },
+            {
+                typeof(UndertaleTexturePageItem),
+                new[]
+                {
+                    new PredicateForVersion()
+                    {
+                        Version = (1, 0, 0),
+                        Predicate = (obj, types) =>
+                        {
+                            IEnumerable<(string, object[])> outList = Enumerable.Empty<(string, object[])>();
+
+                            if (types.Contains(typeof(UndertaleSprite)))
+                            {
+                                var sprites = data.Sprites.Where(x => x.Textures.Any(t => t.Texture == obj));
+                                if (sprites.Any())
+                                    outList = outList.Append(("Sprites", sprites.ToArray()));
+                            }
+
+                            if (types.Contains(typeof(UndertaleBackground)))
+                            {
+                                var backgrounds = data.Backgrounds.Where(x => x.Texture == obj);
+                                if (backgrounds.Any())
+                                    outList = outList.Append((data.IsGameMaker2() ? "Tile sets" : "Backgrounds", backgrounds.ToArray()));
+                            }
+
+                            if (types.Contains(typeof(UndertaleFont)))
+                            {
+                                var fonts = data.Fonts.Where(x => x.Texture == obj);
+                                if (fonts.Any())
+                                    outList = outList.Append(("Fonts", fonts.ToArray()));
+                            }
+
+                            if (outList == Enumerable.Empty<(string, object[])>())
+                                return null;
+                            return outList.ToArray();
+                        }
+                    },
+                    new PredicateForVersion()
+                    {
+                        Version = (2, 0, 0),
+                        Predicate = (obj, types) =>
+                        {
+                            if (!types.Contains(typeof(UndertaleEmbeddedImage)))
+                                return null;
+
+                            var embImages = data.EmbeddedImages.Where(x => x.TextureEntry == obj);
+                            if (embImages.Any())
+                                return new (string, object[])[] { ("Embedded images", embImages.ToArray()) };
                             else
                                 return null;
                         }

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -339,6 +339,15 @@ namespace UndertaleModTool.Windows
                             if (types.Contains(typeof(UndertaleSprite)))
                             {
                                 var sprites = data.Sprites.Where(x => x.Name == obj);
+
+                                if (data.IsVersionAtLeast(2, 3, 0))
+                                {
+                                    sprites = sprites.Concat(data.Sprites.Where(x => x.V2Sequence is not null
+                                                                                     && x.V2Sequence.Tracks.Count != 0
+                                                                                     && (x.V2Sequence.Tracks[0].Name == obj
+                                                                                         || x.V2Sequence.Tracks[0].ModelName == obj)));
+                                }
+
                                 if (sprites.Any())
                                     outDict["Sprites"] = sprites.ToArray();
                             }
@@ -596,7 +605,7 @@ namespace UndertaleModTool.Windows
                                         if (layer.AssetsData is not null)
                                         {
                                             foreach (var seqInst in layer.AssetsData.Sequences)
-                                                if (seqInst.Sequence == obj)
+                                                if (seqInst.Sequence.Name == obj)
                                                     seqInstances.Add(new object[] { seqInst, layer, room });
                                         }
                                     }

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -25,7 +25,7 @@ namespace UndertaleModTool.Windows
     public class PredicateForVersion
     {
         public (uint Major, uint Minor, uint Release) Version { get; set; }
-        public Func<UndertaleResource, HashSetOverride<Type>, Dictionary<string, object[]>> Predicate { get; set; }
+        public Func<UndertaleResource, HashSetOverride<Type>, bool, Dictionary<string, object[]>> Predicate { get; set; }
     }
 
     public static class UndertaleResourceReferenceMethodsMap
@@ -43,14 +43,14 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (1, 0, 0),
-                        Predicate = (obj, types) =>
+                        Predicate = (obj, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleGameObject)))
                                 return null;
 
                             var gameObjects = data.GameObjects.Where(x => x.Sprite == obj);
                             if (gameObjects.Any())
-                                return new() { { "Game objects", gameObjects.ToArray() } };
+                                return new() { { "Game objects", checkOne ? gameObjects.ToEmptyArray() : gameObjects.ToArray() } };
                             else
                                 return null;
                         }
@@ -58,7 +58,7 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2, 0, 0),
-                        Predicate = (obj, types) =>
+                        Predicate = (obj, types, checkOne) =>
                         {
                             Dictionary<string, object[]> outDict = new();
 
@@ -95,11 +95,11 @@ namespace UndertaleModTool.Windows
                                 }
                             }
                             if (tiles.Count > 0)
-                                outDict["Room tiles"] = tiles.ToArray();
+                                outDict["Room tiles"] = checkOne ? tiles.ToEmptyArray() : tiles.ToArray();
                             if (sprInstances.Count > 0)
-                                outDict["Room sprite instances"] = sprInstances.ToArray();
+                                outDict["Room sprite instances"] = checkOne ? sprInstances.ToEmptyArray() : sprInstances.ToArray();
                             if (bgLayers.Count > 0)
-                                outDict["Room background layers"] = bgLayers.ToArray();
+                                outDict["Room background layers"] = checkOne ? bgLayers.ToEmptyArray() : bgLayers.ToArray();
 
                             if (outDict.Count == 0)
                                 return null;
@@ -109,7 +109,7 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2, 2, 1),
-                        Predicate = (obj, types) =>
+                        Predicate = (obj, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleTextureGroupInfo)))
                                 return null;
@@ -117,7 +117,7 @@ namespace UndertaleModTool.Windows
                             var textGroups = data.TextureGroupInfo.Where(x => x.Sprites.Any(s => s.Resource == obj)
                                                                               || (x.SpineSprites?.Any(s => s.Resource == obj) == true));
                             if (textGroups.Any())
-                                return new() { { "Texture groups", textGroups.ToArray() } };
+                                return new() { { "Texture groups", checkOne ? textGroups.ToEmptyArray() : textGroups.ToArray() } };
                             else
                                 return null;
                         }
@@ -131,7 +131,7 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (1, 0, 0),
-                        Predicate = (obj, types) =>
+                        Predicate = (obj, types, checkOne) =>
                         {
                             if (data.IsGameMaker2())
                                 return null;
@@ -151,9 +151,9 @@ namespace UndertaleModTool.Windows
                                         tiles.Add(new object[] { tile, room });
                             }
                             if (backgrounds.Count > 0)
-                                outDict["Room tiles"] = tiles.ToArray();
+                                outDict["Room tiles"] = checkOne ? tiles.ToEmptyArray() : tiles.ToArray();
                             if (tiles.Count > 0)
-                                outDict["Room sprite instances"] = tiles.ToArray();
+                                outDict["Room sprite instances"] = checkOne ? tiles.ToEmptyArray() : tiles.ToArray();
 
                             if (outDict.Count == 0)
                                 return null;
@@ -163,7 +163,7 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2, 0, 0),
-                        Predicate = (obj, types) =>
+                        Predicate = (obj, types, checkOne) =>
                         {
                             List<object[]> tileLayers = new();
                             foreach (var room in data.Rooms)
@@ -177,7 +177,7 @@ namespace UndertaleModTool.Windows
                                 }
                             }
                             if (tileLayers.Count > 0)
-                                return new() { { "Room tile layers", tileLayers.ToArray() } };
+                                return new() { { "Room tile layers", checkOne ? tileLayers.ToEmptyArray() : tileLayers.ToArray() } };
                             else
                                 return null;
                         }
@@ -185,14 +185,14 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2, 2, 1),
-                        Predicate = (obj, types) =>
+                        Predicate = (obj, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleTextureGroupInfo)))
                                 return null;
 
                             var textGroups = data.TextureGroupInfo.Where(x => x.Tilesets.Any(s => s.Resource == obj));
                             if (textGroups.Any())
-                                return new() { { "Texture groups", textGroups.ToArray() } };
+                                return new() { { "Texture groups", checkOne ? textGroups.ToEmptyArray() : textGroups.ToArray() } };
                             else
                                 return null;
                         }
@@ -206,11 +206,11 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (1, 0, 0),
-                        Predicate = (obj, types) =>
+                        Predicate = (obj, types, checkOne) =>
                         {
                             var pageItems = data.TexturePageItems.Where(x => x.TexturePage == obj);
                             if (pageItems.Any())
-                                return new() { { "Texture page items", pageItems.ToArray() } };
+                                return new() { { "Texture page items", checkOne ? pageItems.ToEmptyArray() : pageItems.ToArray() } };
                             else
                                 return null;
                         }
@@ -218,14 +218,14 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2, 2, 1),
-                        Predicate = (obj, types) =>
+                        Predicate = (obj, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleTextureGroupInfo)))
                                 return null;
 
                             var textGroups = data.TextureGroupInfo.Where(x => x.TexturePages.Any(s => s.Resource == obj));
                             if (textGroups.Any())
-                                return new() { { "Texture groups", textGroups.ToArray() } };
+                                return new() { { "Texture groups", checkOne ? textGroups.ToEmptyArray() : textGroups.ToArray() } };
                             else
                                 return null;
                         }
@@ -239,7 +239,7 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (1, 0, 0),
-                        Predicate = (obj, types) =>
+                        Predicate = (obj, types, checkOne) =>
                         {
                             Dictionary<string, object[]> outDict = new();
 
@@ -247,21 +247,21 @@ namespace UndertaleModTool.Windows
                             {
                                 var sprites = data.Sprites.Where(x => x.Textures.Any(t => t.Texture == obj));
                                 if (sprites.Any())
-                                    outDict["Sprites"] = sprites.ToArray();
+                                    outDict["Sprites"] = checkOne ? sprites.ToEmptyArray() : sprites.ToArray();
                             }
 
                             if (types.Contains(typeof(UndertaleBackground)))
                             {
                                 var backgrounds = data.Backgrounds.Where(x => x.Texture == obj);
                                 if (backgrounds.Any())
-                                    outDict[data.IsGameMaker2() ? "Tile sets" : "Backgrounds"] = backgrounds.ToArray();
+                                    outDict[data.IsGameMaker2() ? "Tile sets" : "Backgrounds"] = checkOne ? backgrounds.ToEmptyArray() : backgrounds.ToArray();
                             }
 
                             if (types.Contains(typeof(UndertaleFont)))
                             {
                                 var fonts = data.Fonts.Where(x => x.Texture == obj);
                                 if (fonts.Any())
-                                    outDict["Fonts"] = fonts.ToArray();
+                                    outDict["Fonts"] = checkOne ? fonts.ToEmptyArray() : fonts.ToArray();
                             }
 
                             if (outDict.Count == 0)
@@ -272,14 +272,14 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2, 0, 0),
-                        Predicate = (obj, types) =>
+                        Predicate = (obj, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleEmbeddedImage)))
                                 return null;
 
                             var embImages = data.EmbeddedImages.Where(x => x.TextureEntry == obj);
                             if (embImages.Any())
-                                return new() { { "Embedded images", embImages.ToArray() } };
+                                return new() { { "Embedded images", checkOne ? embImages.ToEmptyArray() : embImages.ToArray() } };
                             else
                                 return null;
                         }
@@ -293,7 +293,7 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (1, 0, 0),
-                        Predicate = (obj, types) =>
+                        Predicate = (obj, types, checkOne) =>
                         {
                             Dictionary<string, object[]> outDict = new();
 
@@ -301,7 +301,7 @@ namespace UndertaleModTool.Windows
                             {
                                 var backgrounds = data.Backgrounds.Where(x => x.Name == obj);
                                 if (backgrounds.Any())
-                                    outDict[data.IsGameMaker2() ? "Tile sets" : "Backgrounds"] = backgrounds.ToArray();
+                                    outDict[data.IsGameMaker2() ? "Tile sets" : "Backgrounds"] = checkOne ? backgrounds.ToEmptyArray() : backgrounds.ToArray();
                             }
 
                             if (types.Contains(typeof(UndertaleCode)))
@@ -319,21 +319,21 @@ namespace UndertaleModTool.Windows
                                 codeEntries = codeEntries.Concat(stringRefs);
 
                                 if (codeEntries.Any())
-                                    outDict["Code entries (name and contents)"] = codeEntries.ToArray();
+                                    outDict["Code entries (name and contents)"] = checkOne ? codeEntries.ToEmptyArray() : codeEntries.ToArray();
                             }
 
                             if (types.Contains(typeof(UndertaleSound)))
                             {
                                 var sounds = data.Sounds.Where(x => x.Name == obj || x.Type == obj || x.File == obj);
                                 if (sounds.Any())
-                                    outDict["Sounds"] = sounds.ToArray();
+                                    outDict["Sounds"] = checkOne ? sounds.ToEmptyArray() : sounds.ToArray();
                             }
 
                             if (types.Contains(typeof(UndertaleAudioGroup)))
                             {
                                 var audioGroups = data.AudioGroups.Where(x => x.Name == obj);
                                 if (audioGroups.Any())
-                                    outDict["Audio groups"] = audioGroups.ToArray();
+                                    outDict["Audio groups"] = checkOne ? audioGroups.ToEmptyArray() : audioGroups.ToArray();
                             }
 
                             if (types.Contains(typeof(UndertaleSprite)))
@@ -349,7 +349,7 @@ namespace UndertaleModTool.Windows
                                 }
 
                                 if (sprites.Any())
-                                    outDict["Sprites"] = sprites.ToArray();
+                                    outDict["Sprites"] = checkOne ? sprites.ToEmptyArray() : sprites.ToArray();
                             }
 
 
@@ -357,7 +357,7 @@ namespace UndertaleModTool.Windows
                             {
                                 var extensions = data.Extensions.Where(x => x.Name == obj || x.ClassName == obj || x.FolderName == obj);
                                 if (extensions.Any())
-                                    outDict["Extensions"] = extensions.ToArray();
+                                    outDict["Extensions"] = checkOne ? extensions.ToEmptyArray() : extensions.ToArray();
                             }
 
                             if (types.Contains(typeof(UndertaleExtensionOption)))
@@ -370,7 +370,7 @@ namespace UndertaleModTool.Windows
                                             extnOptions.Add(new object[] { option, extn });
                                 }
                                 if (extnOptions.Count > 0)
-                                    outDict["Extension options"] = extnOptions.ToArray();
+                                    outDict["Extension options"] = checkOne ? extnOptions.ToEmptyArray() : extnOptions.ToArray();
                             }
 
                             List<object[]> extnFunctions = new();
@@ -394,29 +394,29 @@ namespace UndertaleModTool.Windows
                                 }
                             }
                             if (extnFunctions.Count > 0)
-                                outDict["Extension functions"] = extnFunctions.ToArray();
+                                outDict["Extension functions"] = checkOne ? extnFunctions.ToEmptyArray() : extnFunctions.ToArray();
                             if (extnFiles.Count > 0)
-                                outDict["Extension files"] = extnFiles.ToArray();
+                                outDict["Extension files"] = checkOne ? extnFiles.ToEmptyArray() : extnFiles.ToArray();
 
                             if (types.Contains(typeof(UndertaleFont)))
                             {
                                 var fonts = data.Fonts.Where(x => x.Name == obj || x.DisplayName == obj);
                                 if (fonts.Any())
-                                    outDict["Fonts"] = fonts.ToArray();
+                                    outDict["Fonts"] = checkOne ? fonts.ToEmptyArray() : fonts.ToArray();
                             }
 
                             if (types.Contains(typeof(UndertaleFunction)))
                             {
                                 var functions = data.Functions.Where(x => x.Name == obj);
                                 if (functions.Any())
-                                    outDict["Functions"] = functions.ToArray();
+                                    outDict["Functions"] = checkOne ? functions.ToEmptyArray() : functions.ToArray();
                             }
 
                             if (types.Contains(typeof(UndertaleGameObject)))
                             {
                                 var gameObjects = data.GameObjects.Where(x => x.Name == obj);
                                 if (gameObjects.Any())
-                                    outDict["Game objects"] = gameObjects.ToArray();
+                                    outDict["Game objects"] = checkOne ? gameObjects.ToEmptyArray() : gameObjects.ToArray();
                             }
 
                             if (types.Contains(typeof(UndertaleGeneralInfo)))
@@ -447,21 +447,21 @@ namespace UndertaleModTool.Windows
                             {
                                 var paths = data.Paths.Where(x => x.Name == obj);
                                 if (paths.Any())
-                                    outDict["Paths"] = paths.ToArray();
+                                    outDict["Paths"] = checkOne ? paths.ToEmptyArray() : paths.ToArray();
                             }
 
                             if (types.Contains(typeof(UndertaleRoom)))
                             {
                                 var rooms = data.Rooms.Where(x => x.Name == obj || x.Caption == obj);
                                 if (rooms.Any())
-                                    outDict["Rooms"] = rooms.ToArray();
+                                    outDict["Rooms"] = checkOne ? rooms.ToEmptyArray() : rooms.ToArray();
                             }
 
                             if (types.Contains(typeof(UndertaleScript)))
                             {
                                 var scripts = data.Scripts.Where(x => x.Name == obj);
                                 if (scripts.Any())
-                                    outDict["Scripts"] = scripts.ToArray();
+                                    outDict["Scripts"] = checkOne ? scripts.ToEmptyArray() : scripts.ToArray();
                             }
 
                             if (types.Contains(typeof(UndertaleShader)))
@@ -471,14 +471,14 @@ namespace UndertaleModTool.Windows
                                                                       || x.GLSL_ES_Fragment == obj || x.GLSL_Fragment == obj || x.HLSL9_Fragment == obj
                                                                       || x.VertexShaderAttributes.Any(a => a.Name == obj));
                                 if (shaders.Any())
-                                    outDict["Shaders"] = shaders.ToArray();
+                                    outDict["Shaders"] = checkOne ? shaders.ToEmptyArray() : shaders.ToArray();
                             }
 
                             if (types.Contains(typeof(UndertaleTimeline)))
                             {
                                 var timelines = data.Timelines.Where(x => x.Name == obj);
                                 if (timelines.Any())
-                                    outDict["Timelines"] = timelines.ToArray();
+                                    outDict["Timelines"] = checkOne ? timelines.ToEmptyArray() : timelines.ToArray();
                             }
 
                             if (outDict.Count == 0)
@@ -490,14 +490,14 @@ namespace UndertaleModTool.Windows
                     {
                         // Bytecode version 15
                         Version = (15, uint.MaxValue, uint.MaxValue),
-                        Predicate = (obj, types) =>
+                        Predicate = (obj, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleCodeLocals)))
                                 return null;
 
                             var codeLocals = data.CodeLocals.Where(x => x.Name == obj || x.Locals.Any(l => l.Name == obj));
                             if (codeLocals.Any())
-                                return new() { { "Code locals", codeLocals.ToArray() } };
+                                return new() { { "Code locals", checkOne ? codeLocals.ToEmptyArray() : codeLocals.ToArray() } };
                             else
                                 return null;
                         }
@@ -505,7 +505,7 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2, 0, 0),
-                        Predicate = (obj, types) =>
+                        Predicate = (obj, types, checkOne) =>
                         {
                             Dictionary<string, object[]> outDict = new();
 
@@ -513,7 +513,7 @@ namespace UndertaleModTool.Windows
                             {
                                 var embImages = data.EmbeddedImages.Where(x => x.Name == obj);
                                 if (embImages.Any())
-                                    outDict["Embedded images"] = embImages.ToArray();
+                                    outDict["Embedded images"] = checkOne ? embImages.ToEmptyArray() : embImages.ToArray();
                             }
 
                             List<object[]> layers = new();
@@ -544,9 +544,9 @@ namespace UndertaleModTool.Windows
                                         sprInstances.Add(new object[] { tile, room });
                             }
                             if (layers.Count > 0)
-                                outDict["Room layers"] = layers.ToArray();
+                                outDict["Room layers"] = checkOne ? layers.ToEmptyArray() : layers.ToArray();
                             if (sprInstances.Count > 0)
-                                outDict["Room sprite instances"] = sprInstances.ToArray();
+                                outDict["Room sprite instances"] = checkOne ? sprInstances.ToEmptyArray() : sprInstances.ToArray();
 
                             if (outDict.Count == 0)
                                 return null;
@@ -556,14 +556,14 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2, 2, 1),
-                        Predicate = (obj, types) =>
+                        Predicate = (obj, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleTextureGroupInfo)))
                                 return null;
 
                             var textGroups = data.TextureGroupInfo.Where(x => x.Name == obj);
                             if (textGroups.Any())
-                                return new() { { "Texture groups", textGroups.ToArray() } };
+                                return new() { { "Texture groups", checkOne ? textGroups.ToEmptyArray() : textGroups.ToArray() } };
                             else
                                 return null;
                         }
@@ -571,7 +571,7 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2, 3, 0),
-                        Predicate = (obj, types) =>
+                        Predicate = (obj, types, checkOne) =>
                         {
                             Dictionary<string, object[]> outDict = new();
 
@@ -579,7 +579,7 @@ namespace UndertaleModTool.Windows
                             {
                                 var animCurves = data.AnimationCurves.Where(x => x.Name == obj);
                                 if (animCurves.Any())
-                                    outDict["Animation curves"] = animCurves.ToArray();
+                                    outDict["Animation curves"] = checkOne ? animCurves.ToEmptyArray() : animCurves.ToArray();
                             }
                             if (types.Contains(typeof(UndertaleAnimationCurve.Channel)))
                             {
@@ -592,7 +592,7 @@ namespace UndertaleModTool.Windows
                                 }
 
                                 if (animCurveChannels.Count > 0)
-                                    outDict["Animation curve channels"] = animCurveChannels.ToArray();
+                                    outDict["Animation curve channels"] = checkOne ? animCurveChannels.ToEmptyArray() : animCurveChannels.ToArray();
                             }
 
                             if (types.Contains(typeof(UndertaleRoom.SequenceInstance)))
@@ -611,7 +611,7 @@ namespace UndertaleModTool.Windows
                                     }
                                 }
                                 if (seqInstances.Count > 0)
-                                    outDict["Room sequence instances"] = seqInstances.ToArray();
+                                    outDict["Room sequence instances"] = checkOne ? seqInstances.ToEmptyArray() : seqInstances.ToArray();
                             }
 
                             if (types.Contains(typeof(UndertaleSequence)))
@@ -619,7 +619,7 @@ namespace UndertaleModTool.Windows
                                 var sequences = data.Sequences.Where(x => x.Name == obj
                                                                           || x.FunctionIDs.Values.Any(i => i == obj));
                                 if (sequences.Any())
-                                    outDict["Sequences"] = sequences.ToArray();
+                                    outDict["Sequences"] = checkOne ? sequences.ToEmptyArray() : sequences.ToArray();
                             }
 
 
@@ -686,13 +686,13 @@ namespace UndertaleModTool.Windows
                                 }
                             }
                             if (sequenceTracks.Count > 0)
-                                outDict["Sequence tracks"] = sequenceTracks.ToArray();
+                                outDict["Sequence tracks"] = checkOne ? sequenceTracks.ToEmptyArray() : sequenceTracks.ToArray();
                             if (seqBroadMessages.Count > 0)
-                                outDict["Sequence broadcast messages"] = seqBroadMessages.ToArray();
+                                outDict["Sequence broadcast messages"] = checkOne ? seqBroadMessages.ToEmptyArray() : seqBroadMessages.ToArray();
                             if (sequenceMoments.Count > 0)
-                                outDict["Sequence moments"] = sequenceMoments.ToArray();
+                                outDict["Sequence moments"] = checkOne ? sequenceMoments.ToEmptyArray() : sequenceMoments.ToArray();
                             if (seqStringKeyframes.Count > 0)
-                                outDict["Sequence string keyframes"] = seqStringKeyframes.ToArray();
+                                outDict["Sequence string keyframes"] = checkOne ? seqStringKeyframes.ToEmptyArray() : seqStringKeyframes.ToArray();
 
                             if (outDict.Count == 0)
                                 return null;
@@ -702,14 +702,14 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2, 3, 6),
-                        Predicate = (obj, types) =>
+                        Predicate = (obj, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleFilterEffect)))
                                 return null;
 
                             var filterEffects = data.FilterEffects.Where(x => x.Name == obj || x.Value == obj);
                             if (filterEffects.Any())
-                                return new() { { "Filter effects", filterEffects.ToArray() } };
+                                return new() { { "Filter effects", checkOne ? filterEffects.ToEmptyArray() : filterEffects.ToArray() } };
                             else
                                 return null;
                         }
@@ -717,7 +717,7 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2022, 1, 0),
-                        Predicate = (obj, types) =>
+                        Predicate = (obj, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleRoom.EffectProperty)))
                                 return null;
@@ -733,7 +733,7 @@ namespace UndertaleModTool.Windows
                                 }
                             }
                             if (effectProps.Count > 0)
-                                return new() { { "Room effect properties", effectProps.ToArray() } };
+                                return new() { { "Room effect properties", checkOne ? effectProps.ToEmptyArray() : effectProps.ToArray() } };
                             else
                                 return null;
                         }
@@ -741,7 +741,7 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2022, 2, 0),
-                        Predicate = (obj, types) =>
+                        Predicate = (obj, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(TextKeyframes)))
                                 return null;
@@ -776,7 +776,7 @@ namespace UndertaleModTool.Windows
                                 }
                             }
                             if (textKeyframesList.Count > 0)
-                                return new() { { "Sequence text keyframes", textKeyframesList.ToArray() } };
+                                return new() { { "Sequence text keyframes", checkOne ? textKeyframesList.ToEmptyArray() : textKeyframesList.ToArray() } };
                             else
                                 return null;
                         }
@@ -790,7 +790,7 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (1, 0, 0),
-                        Predicate = (obj, types) =>
+                        Predicate = (obj, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleRoom.GameObject)))
                                 return null;
@@ -822,7 +822,7 @@ namespace UndertaleModTool.Windows
                             }
 
                             if (objInstances.Count > 0)
-                                return new() { { "Room object instance", objInstances.ToArray() } };
+                                return new() { { "Room object instance", checkOne ? objInstances.ToEmptyArray() : objInstances.ToArray() } };
                             else
                                 return null;
                         }
@@ -830,7 +830,7 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2, 3, 0),
-                        Predicate = (obj, types) =>
+                        Predicate = (obj, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(InstanceKeyframes)))
                                 return null;
@@ -865,7 +865,7 @@ namespace UndertaleModTool.Windows
                                 }
                             }
                             if (instKeyframesList.Count > 0)
-                                return new() { { "Sequence object instance keyframes", instKeyframesList.ToArray() } };
+                                return new() { { "Sequence object instance keyframes", checkOne ? instKeyframesList.ToEmptyArray() : instKeyframesList.ToArray() } };
                             else
                                 return null;
                         }
@@ -879,7 +879,7 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (1, 0, 0),
-                        Predicate = (obj, types) =>
+                        Predicate = (obj, types, checkOne) =>
                         {
                             Dictionary<string, object[]> outDict = new();
 
@@ -889,14 +889,14 @@ namespace UndertaleModTool.Windows
                                                                             e => e.Any(se => se.Actions.Any(
                                                                                 a => a.CodeId == obj))));
                                 if (gameObjects.Any())
-                                    outDict["Game objects"] = gameObjects.ToArray();
+                                    outDict["Game objects"] = checkOne ? gameObjects.ToEmptyArray() : gameObjects.ToArray();
                             }
 
                             if (types.Contains(typeof(UndertaleRoom)))
                             {
                                 var rooms = data.Rooms.Where(x => x.CreationCodeId == obj);
                                 if (rooms.Any())
-                                    outDict["Rooms"] = rooms.ToArray();
+                                    outDict["Rooms"] = checkOne ? rooms.ToEmptyArray() : rooms.ToArray();
                             }
 
                             if (types.Contains(typeof(UndertaleGlobalInit)))
@@ -914,7 +914,7 @@ namespace UndertaleModTool.Windows
                             {
                                 var scripts = data.Scripts.Where(x => x.Code == obj);
                                 if (scripts.Any())
-                                    outDict["Scripts"] = scripts.ToArray();
+                                    outDict["Scripts"] = checkOne ? scripts.ToEmptyArray() : scripts.ToArray();
                             }
 
                             if (outDict.Count == 0)
@@ -931,14 +931,14 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (1, 0, 0),
-                        Predicate = (obj, types) =>
+                        Predicate = (obj, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleSound)))
                                 return null;
 
                             var sounds = data.Sounds.Where(x => x.AudioFile == obj);
                             if (sounds.Any())
-                                return new() { { "Sounds", sounds.ToArray() } };
+                                return new() { { "Sounds", checkOne ? sounds.ToEmptyArray() : sounds.ToArray() } };
                             else
                                 return null;
                         }
@@ -952,14 +952,14 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (1, 0, 0),
-                        Predicate = (obj, types) =>
+                        Predicate = (obj, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleSound)))
                                 return null;
 
                             var sounds = data.Sounds.Where(x => x.AudioGroup == obj);
                             if (sounds.Any())
-                                return new() { { "Sounds", sounds.ToArray() } };
+                                return new() { { "Sounds", checkOne ? sounds.ToEmptyArray() : sounds.ToArray() } };
                             else
                                 return null;
                         }
@@ -970,7 +970,7 @@ namespace UndertaleModTool.Windows
 
 
 
-        public static Dictionary<string, List<object>> GetReferencesOfObject(UndertaleResource obj, UndertaleData data, HashSetOverride<Type> types)
+        public static Dictionary<string, List<object>> GetReferencesOfObject(UndertaleResource obj, UndertaleData data, HashSetOverride<Type> types, bool checkOne = false)
         {
             if (obj is null)
                 return null;
@@ -992,7 +992,7 @@ namespace UndertaleModTool.Windows
 
                 if (isAtLeast)
                 {
-                    var result = predicateForVer.Predicate(obj, types);
+                    var result = predicateForVer.Predicate(obj, types, checkOne);
                     if (result is null)
                         continue;
 
@@ -1062,7 +1062,7 @@ namespace UndertaleModTool.Windows
                         for (int i = range.Item1; i < range.Item2; i++)
                         {
                             var asset = assets[i];
-                            var assetReferences = GetReferencesOfObject(asset.Item1, data, new HashSetOverride<Type>(true));
+                            var assetReferences = GetReferencesOfObject(asset.Item1, data, new HashSetOverride<Type>(true), true);
                             if (assetReferences is null)
                             {
                                 if (resultDict.TryGetValue(asset.Item2, out var list))
@@ -1128,5 +1128,7 @@ namespace UndertaleModTool.Windows
                 return null;
             return outDict;
         }
+
+        private static T[] ToEmptyArray<T>(this IEnumerable<T> _) => Array.Empty<T>();
     }
 }

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -316,7 +316,7 @@ namespace UndertaleModTool.Windows
                                 if (sprites.Any())
                                     outList = outList.Append(("Sprites", sprites.ToArray()));
                             }
-                            
+
 
                             if (types.Contains(typeof(UndertaleExtension)))
                             {
@@ -599,7 +599,7 @@ namespace UndertaleModTool.Windows
                                 trackChain.Insert(0, track);
                                 if (types.Contains(typeof(Track)))
                                 {
-                                    if (track.Name == obj || track.ModelName == obj || track.GMAnimCurveString == obj) 
+                                    if (track.Name == obj || track.ModelName == obj || track.GMAnimCurveString == obj)
                                         sequenceTracks.Add(trackChain.Append(seq).ToArray());
                                 }
 
@@ -621,7 +621,7 @@ namespace UndertaleModTool.Windows
                                 foreach (var subTrack in track.Tracks)
                                     ProcessTrack(seq, subTrack, trackChain);
                             };
-                            
+
                             foreach (var seq in data.Sequences)
                             {
                                 foreach (var track in seq.Tracks)
@@ -785,7 +785,7 @@ namespace UndertaleModTool.Windows
                                             objInstances.Add(new object[] { inst, room });
                                 }
                             }
-                            
+
                             if (objInstances.Count > 0)
                                 return new (string, object[])[] { ("Room object instance", objInstances.ToArray()) };
                             else
@@ -880,6 +880,27 @@ namespace UndertaleModTool.Windows
                             if (outList == Enumerable.Empty<(string, object[])>())
                                 return null;
                             return outList.ToArray();
+                        }
+                    }
+                }
+            },
+            {
+                typeof(UndertaleEmbeddedAudio),
+                new[]
+                {
+                    new PredicateForVersion()
+                    {
+                        Version = (1, 0, 0),
+                        Predicate = (obj, types) =>
+                        {
+                            if (!types.Contains(typeof(UndertaleSound)))
+                                return null;
+
+                            var sounds = data.Sounds.Where(x => x.AudioFile == obj);
+                            if (sounds.Any())
+                                return new (string, object[])[] { ("Sounds", sounds.ToArray()) };
+                            else
+                                return null;
                         }
                     }
                 }

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UndertaleModLib;
+using UndertaleModLib.Models;
+
+namespace UndertaleModTool.Windows
+{
+    public class PredicateForVersion
+    {
+        public (uint Major, uint Minor, uint Release) Version { get; set; }
+        public Func<UndertaleResource, (string, object[])[]> Predicate { get; set; }
+    }
+
+    public static class UndertaleResourceReferenceMethodsMap
+    {
+        private static UndertaleData data;
+
+        private static readonly Dictionary<Type, PredicateForVersion[]> typeMap = new()
+        {
+            {
+                typeof(UndertaleSprite),
+                new[]
+                {
+                    new PredicateForVersion()
+                    {
+                        Version = (1, 0, 0),
+                        Predicate = (obj) =>
+                        {
+                            var gameObjects = data.GameObjects.Where(x => x.Sprite == obj);
+                            if (gameObjects.Any())
+                                return new(string, object[])[] {("Game objects", gameObjects.ToArray()) };
+                            else
+                                return null;
+                        }
+                    },
+                    new PredicateForVersion()
+                    {
+                        Version = (2, 0, 0),
+                        Predicate = (obj) =>
+                        {
+                            IEnumerable<(string, object[])> outList = Enumerable.Empty<(string, object[])>();
+
+                            List<(UndertaleRoom, UndertaleRoom.Tile)> tiles = new();
+                            List<(UndertaleRoom, UndertaleRoom.SpriteInstance)> sprInstances = new();
+                            List<UndertaleRoom.Layer> bgLayers = new();
+                            foreach (var room in data.Rooms)
+                            {
+                                foreach (var layer in room.Layers)
+                                {
+                                    if (layer.AssetsData is not null)
+                                    {
+                                        foreach (var tile in layer.AssetsData.LegacyTiles)
+                                            if (tile.SpriteDefinition == obj)
+                                                tiles.Add((room, tile));
+
+                                        foreach (var sprInst in layer.AssetsData.Sprites)
+                                            if (sprInst.Sprite == obj)
+                                                sprInstances.Add((room, sprInst));
+                                    }
+
+                                    if (layer.BackgroundData is not null
+                                        && layer.BackgroundData.Sprite == obj)
+                                        bgLayers.Add(layer);
+
+                                }
+                            }
+                            if (tiles.Count > 0)
+                                outList = outList.Append(("Room tiles", tiles.Cast<object>().ToArray()));
+                            if (sprInstances.Count > 0)
+                                outList = outList.Append(("Room sprite instances", sprInstances.Cast<object>().ToArray()));
+                            if (bgLayers.Count > 0)
+                                outList = outList.Append(("Room background layers", bgLayers.ToArray()));
+
+                            if (outList == Enumerable.Empty<(string, object[])>())
+                                return null;
+                            return outList.ToArray();
+                        }
+                    },
+                    new PredicateForVersion()
+                    {
+                        Version = (2, 2, 1),
+                        Predicate = (obj) =>
+                        {
+                            var textGroups = data.TextureGroupInfo.Where(x => x.Sprites.Any(s => s.Resource == obj)
+                                                                              || x.SpineSprites.Any(s => s.Resource == obj));
+                            if (textGroups.Any())
+                                return new (string, object[])[] { ("Texture groups", textGroups.ToArray()) };
+                            else
+                                return null;
+                        }
+                    }
+                }
+            }
+        };
+
+        public static (string, object[])[] GetReferencesOfObject(UndertaleResource obj, UndertaleData data)
+        {
+            if (obj is null)
+                return null;
+
+            if (!typeMap.TryGetValue(obj.GetType(), out PredicateForVersion[] predicatesForVer))
+                return null;
+
+            UndertaleResourceReferenceMethodsMap.data = data;
+
+            var ver = (data.GeneralInfo.Major, data.GeneralInfo.Minor, data.GeneralInfo.Release);
+            IEnumerable<(string, object[])> outList = Enumerable.Empty<(string, object[])>();
+            foreach (var predicateForVer in predicatesForVer)
+            {
+                if (predicateForVer.Version.CompareTo(ver) <= 0)
+                {
+                    var result = predicateForVer.Predicate(obj);
+                    if (result is not null)
+                        outList = outList.Concat(result);
+                }  
+            }
+
+            if (outList == Enumerable.Empty<(string, object[])>())
+                return null;
+
+            return outList.ToArray();
+        }
+    }
+}

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -5,25 +5,14 @@ using System.Text;
 using System.Threading.Tasks;
 using UndertaleModLib;
 using UndertaleModLib.Models;
+using static UndertaleModLib.Models.UndertaleSequence;
 
 namespace UndertaleModTool.Windows
 {
     public class PredicateForVersion
     {
         public (uint Major, uint Minor, uint Release) Version { get; set; }
-        public Func<UndertaleResource, (string, object[])[]> Predicate { get; set; }
-    }
-
-    public class ChildInstance
-    {
-        public UndertaleResource Parent { get; set; }
-        public object Child { get; set; }
-
-        public ChildInstance(UndertaleResource parent, object child)
-        {
-            Parent = parent;
-            Child = child;
-        }
+        public Func<UndertaleResource, HashSet<Type>, (string, object[])[]> Predicate { get; set; }
     }
 
     public static class UndertaleResourceReferenceMethodsMap
@@ -39,8 +28,11 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (1, 0, 0),
-                        Predicate = (obj) =>
+                        Predicate = (obj, types) =>
                         {
+                            if (!types.Contains(typeof(UndertaleGameObject)))
+                                return null;
+
                             var gameObjects = data.GameObjects.Where(x => x.Sprite == obj);
                             if (gameObjects.Any())
                                 return new(string, object[])[] {("Game objects", gameObjects.ToArray()) };
@@ -51,38 +43,46 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2, 0, 0),
-                        Predicate = (obj) =>
+                        Predicate = (obj, types) =>
                         {
                             IEnumerable<(string, object[])> outList = Enumerable.Empty<(string, object[])>();
 
-                            List<ChildInstance> tiles = new();
-                            List<ChildInstance> sprInstances = new();
-                            List<ChildInstance> bgLayers = new();
+                            List<object[]> tiles = new();
+                            List<object[]> sprInstances = new();
+                            List<object[]> bgLayers = new();
                             foreach (var room in data.Rooms)
                             {
                                 foreach (var layer in room.Layers)
                                 {
                                     if (layer.AssetsData is not null)
                                     {
-                                        foreach (var tile in layer.AssetsData.LegacyTiles)
-                                            if (tile.SpriteDefinition == obj)
-                                                tiles.Add(new(room, tile));
+                                        if (types.Contains(typeof(UndertaleRoom.Tile)))
+                                        {
+                                            foreach (var tile in layer.AssetsData.LegacyTiles)
+                                                if (tile.SpriteDefinition == obj)
+                                                    tiles.Add(new object[] { tile, layer, room });
+                                        }
 
-                                        foreach (var sprInst in layer.AssetsData.Sprites)
-                                            if (sprInst.Sprite == obj)
-                                                sprInstances.Add(new(room, sprInst));
+                                        if (types.Contains(typeof(UndertaleRoom.SpriteInstance)))
+                                        {
+                                            foreach (var sprInst in layer.AssetsData.Sprites)
+                                                if (sprInst.Sprite == obj)
+                                                    sprInstances.Add(new object[] { sprInst, layer, room });
+                                        }
                                     }
 
-                                    if (layer.BackgroundData is not null
-                                        && layer.BackgroundData.Sprite == obj)
-                                        bgLayers.Add(new(room, layer));
-
+                                    if (types.Contains(typeof(UndertaleRoom.Layer)))
+                                    {
+                                        if (layer.BackgroundData is not null
+                                            && layer.BackgroundData.Sprite == obj)
+                                            bgLayers.Add(new object[] { layer, room });
+                                    }
                                 }
                             }
                             if (tiles.Count > 0)
-                                outList = outList.Append(("Room tiles", tiles.Cast<object>().ToArray()));
+                                outList = outList.Append(("Room tiles", tiles.ToArray()));
                             if (sprInstances.Count > 0)
-                                outList = outList.Append(("Room sprite instances", sprInstances.Cast<object>().ToArray()));
+                                outList = outList.Append(("Room sprite instances", sprInstances.ToArray()));
                             if (bgLayers.Count > 0)
                                 outList = outList.Append(("Room background layers", bgLayers.ToArray()));
 
@@ -94,10 +94,13 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2, 2, 1),
-                        Predicate = (obj) =>
+                        Predicate = (obj, types) =>
                         {
+                            if (!types.Contains(typeof(UndertaleTextureGroupInfo)))
+                                return null;
+
                             var textGroups = data.TextureGroupInfo.Where(x => x.Sprites.Any(s => s.Resource == obj)
-                                                                              || x.SpineSprites.Any(s => s.Resource == obj));
+                                                                              || (x.SpineSprites?.Any(s => s.Resource == obj) == true));
                             if (textGroups.Any())
                                 return new (string, object[])[] { ("Texture groups", textGroups.ToArray()) };
                             else
@@ -113,24 +116,24 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (1, 0, 0),
-                        Predicate = (obj) =>
+                        Predicate = (obj, types) =>
                         {
                             if (data.IsGameMaker2())
                                 return null;
 
                             IEnumerable<(string, object[])> outList = Enumerable.Empty<(string, object[])>();
 
-                            List<ChildInstance> backgrounds = new();
-                            List<ChildInstance> tiles = new();
+                            List<object[]> backgrounds = new();
+                            List<object[]> tiles = new();
                             foreach (var room in data.Rooms)
                             {
                                 foreach (var bg in room.Backgrounds)
                                     if (bg.BackgroundDefinition == obj)
-                                        backgrounds.Add(new(room, bg));
+                                        backgrounds.Add(new object[] { bg, room });
 
                                 foreach (var tile in room.Tiles)
                                     if (tile.BackgroundDefinition == obj)
-                                        tiles.Add(new(room, tile));
+                                        tiles.Add(new object[] { tile, room });
                             }
                             if (backgrounds.Count > 0)
                                 outList = outList.Append(("Room tiles", tiles.ToArray()));
@@ -145,16 +148,16 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2, 0, 0),
-                        Predicate = (obj) =>
+                        Predicate = (obj, types) =>
                         {
-                            List<ChildInstance> tileLayers = new();
+                            List<object[]> tileLayers = new();
                             foreach (var room in data.Rooms)
                             {
                                 foreach (var layer in room.Layers)
                                 {
                                     if (layer.TilesData is not null
                                         && layer.TilesData.Background == obj)
-                                        tileLayers.Add(new(room, layer));
+                                        tileLayers.Add(new object[] { layer, room });
 
                                 }
                             }
@@ -167,8 +170,11 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2, 2, 1),
-                        Predicate = (obj) =>
+                        Predicate = (obj, types) =>
                         {
+                            if (!types.Contains(typeof(UndertaleTextureGroupInfo)))
+                                return null;
+
                             var textGroups = data.TextureGroupInfo.Where(x => x.Tilesets.Any(s => s.Resource == obj));
                             if (textGroups.Any())
                                 return new (string, object[])[] { ("Texture groups", textGroups.ToArray()) };
@@ -185,7 +191,7 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (1, 0, 0),
-                        Predicate = (obj) =>
+                        Predicate = (obj, types) =>
                         {
                             var pageItems = data.TexturePageItems.Where(x => x.TexturePage == obj);
                             if (pageItems.Any())
@@ -197,11 +203,482 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         Version = (2, 2, 1),
-                        Predicate = (obj) =>
+                        Predicate = (obj, types) =>
                         {
+                            if (!types.Contains(typeof(UndertaleTextureGroupInfo)))
+                                return null;
+
                             var textGroups = data.TextureGroupInfo.Where(x => x.TexturePages.Any(s => s.Resource == obj));
                             if (textGroups.Any())
                                 return new (string, object[])[] { ("Texture groups", textGroups.ToArray()) };
+                            else
+                                return null;
+                        }
+                    }
+                }
+            },
+            {
+                typeof(UndertaleString),
+                new[]
+                {
+                    new PredicateForVersion()
+                    {
+                        Version = (1, 0, 0),
+                        Predicate = (obj, types) =>
+                        {
+                            IEnumerable<(string, object[])> outList = Enumerable.Empty<(string, object[])>();
+
+                            if (types.Contains(typeof(UndertaleBackground)))
+                            {
+                                var backgrounds = data.Backgrounds.Where(x => x.Name == obj);
+                                if (backgrounds.Any())
+                                    outList = outList.Append((data.IsGameMaker2() ? "Tile sets" : "Backgrounds", backgrounds.ToArray()));
+                            }
+
+                            if (types.Contains(typeof(UndertaleCode)))
+                            {
+                                var codeEntries = data.Code.Where(x => x.Name == obj);
+                                if (codeEntries.Any())
+                                    outList = outList.Append(("Code entries", codeEntries.ToArray()));
+                            }
+
+                            if (types.Contains(typeof(UndertaleSound)))
+                            {
+                                var sounds = data.Sounds.Where(x => x.Name == obj || x.Type == obj || x.File == obj);
+                                if (sounds.Any())
+                                    outList = outList.Append(("Sounds", sounds.ToArray()));
+                            }
+
+                            if (types.Contains(typeof(UndertaleAudioGroup)))
+                            {
+                                var audioGroups = data.AudioGroups.Where(x => x.Name == obj);
+                                if (audioGroups.Any())
+                                    outList = outList.Append(("Audio groups", audioGroups.ToArray()));
+                            }
+
+                            if (types.Contains(typeof(UndertaleSprite)))
+                            {
+                                var sprites = data.Sprites.Where(x => x.Name == obj);
+                                if (sprites.Any())
+                                    outList = outList.Append(("Sprites", sprites.ToArray()));
+                            }
+                            
+
+                            if (types.Contains(typeof(UndertaleExtension)))
+                            {
+                                var extensions = data.Extensions.Where(x => x.Name == obj || x.ClassName == obj || x.FolderName == obj);
+                                if (extensions.Any())
+                                    outList = outList.Append(("Extensions", extensions.ToArray()));
+                            }
+
+                            if (types.Contains(typeof(UndertaleExtensionOption)))
+                            {
+                                List<object[]> extnOptions = new();
+                                foreach (var extn in data.Extensions)
+                                {
+                                    foreach (var option in extn.Options)
+                                        if (option.Name == obj || option.Value == obj)
+                                            extnOptions.Add(new object[] { option, extn });
+                                }
+                                if (extnOptions.Count > 0)
+                                    outList = outList.Append(("Extension options", extnOptions.ToArray()));
+                            }
+
+                            List<object[]> extnFunctions = new();
+                            List<object[]> extnFiles = new();
+                            foreach (var extn in data.Extensions)
+                            {
+                                foreach (var file in extn.Files)
+                                {
+                                    if (types.Contains(typeof(UndertaleExtensionFile)))
+                                    {
+                                        if (file.Filename == obj || file.InitScript == obj || file.CleanupScript == obj)
+                                            extnFiles.Add(new object[] { file, extn });
+                                    }
+
+                                    if (types.Contains(typeof(UndertaleExtensionFunction)))
+                                    {
+                                        foreach (var func in file.Functions)
+                                            if (func.Name == obj || func.ExtName == obj)
+                                                extnFunctions.Add(new object[] { func, file, extn });
+                                    }
+                                }
+                            }
+                            if (extnFunctions.Count > 0)
+                                outList = outList.Append(("Extension functions", extnFunctions.ToArray()));
+                            if (extnFiles.Count > 0)
+                                outList = outList.Append(("Extension files", extnFiles.ToArray()));
+
+                            if (types.Contains(typeof(UndertaleFont)))
+                            {
+                                var fonts = data.Fonts.Where(x => x.Name == obj || x.DisplayName == obj);
+                                if (fonts.Any())
+                                    outList = outList.Append(("Fonts", fonts.ToArray()));
+                            }
+
+                            if (types.Contains(typeof(UndertaleFunction)))
+                            {
+                                var functions = data.Functions.Where(x => x.Name == obj);
+                                if (functions.Any())
+                                    outList = outList.Append(("Functions", functions.ToArray()));
+                            }
+
+                            if (types.Contains(typeof(UndertaleGameObject)))
+                            {
+                                var gameObjects = data.GameObjects.Where(x => x.Name == obj);
+                                if (gameObjects.Any())
+                                    outList = outList.Append(("Game objects", gameObjects.ToArray()));
+                            }
+
+                            if (types.Contains(typeof(UndertaleGeneralInfo)))
+                            {
+                                bool genInfoMatches = data.GeneralInfo.Name == obj || data.GeneralInfo.FileName == obj
+                                                      || data.GeneralInfo.Config == obj || data.GeneralInfo.DisplayName == obj;
+                                if (genInfoMatches)
+                                    outList = outList.Append(("General Info", new object[] { new GeneralInfoEditor(data.GeneralInfo, data.Options, data.Language) }));
+                            }
+
+                            if (types.Contains(typeof(UndertaleOptions.Constant)))
+                            {
+                                bool constantsMatches = data.Options.Constants.Any(x => x.Name == obj || x.Value == obj);
+                                if (constantsMatches)
+                                    outList = outList.Append(("Game options constants", new object[] { new GeneralInfoEditor(data.GeneralInfo, data.Options, data.Language) }));
+                            }
+
+                            if (types.Contains(typeof(UndertaleLanguage)))
+                            {
+                                bool langsMatches = data.Language.EntryIDs.Any(x => x == obj)
+                                                    || data.Language.Languages.Any(x => x.Name == obj || x.Region == obj
+                                                                                        || x.Entries.Any(e => e == obj));
+                                if (langsMatches)
+                                    outList = outList.Append(("Languages", new object[] { new GeneralInfoEditor(data.GeneralInfo, data.Options, data.Language) }));
+                            }
+
+                            if (types.Contains(typeof(UndertalePath)))
+                            {
+                                var paths = data.Paths.Where(x => x.Name == obj);
+                                if (paths.Any())
+                                    outList = outList.Append(("Paths", paths.ToArray()));
+                            }
+
+                            if (types.Contains(typeof(UndertaleRoom)))
+                            {
+                                var rooms = data.Rooms.Where(x => x.Name == obj || x.Caption == obj);
+                                if (rooms.Any())
+                                    outList = outList.Append(("Rooms", rooms.ToArray()));
+                            }
+
+                            if (types.Contains(typeof(UndertaleScript)))
+                            {
+                                var scripts = data.Scripts.Where(x => x.Name == obj);
+                                if (scripts.Any())
+                                    outList = outList.Append(("Scripts", scripts.ToArray()));
+                            }
+
+                            if (types.Contains(typeof(UndertaleShader)))
+                            {
+                                var shaders = data.Shaders.Where(x => x.Name == obj
+                                                                      || x.GLSL_ES_Vertex == obj || x.GLSL_Vertex == obj || x.HLSL9_Vertex == obj
+                                                                      || x.GLSL_ES_Fragment == obj || x.GLSL_Fragment == obj || x.HLSL9_Fragment == obj
+                                                                      || x.VertexShaderAttributes.Any(a => a.Name == obj));
+                                if (shaders.Any())
+                                    outList = outList.Append(("Shaders", shaders.ToArray()));
+                            }
+
+                            if (types.Contains(typeof(UndertaleTimeline)))
+                            {
+                                var timelines = data.Timelines.Where(x => x.Name == obj);
+                                if (timelines.Any())
+                                    outList = outList.Append(("Timelines", timelines.ToArray()));
+                            }
+
+                            if (outList == Enumerable.Empty<(string, object[])>())
+                                return null;
+                            return outList.ToArray();
+                        }
+                    },
+                    new PredicateForVersion()
+                    {
+                        // Bytecode version 15
+                        Version = (15, uint.MaxValue, uint.MaxValue),
+                        Predicate = (obj, types) =>
+                        {
+                            if (!types.Contains(typeof(UndertaleCodeLocals)))
+                                return null;
+
+                            var codeLocals = data.CodeLocals.Where(x => x.Name == obj || x.Locals.Any(l => l.Name == obj));
+                            if (codeLocals.Any())
+                                return new (string, object[])[] { ("Code locals", codeLocals.ToArray()) };
+                            else
+                                return null;
+                        }
+                    },
+                    /*new PredicateForVersion()
+                    {
+                        Version = (2, 0, 0),
+                        Predicate = (obj, types) =>
+                        {
+                            IEnumerable<(string, object[])> outList = Enumerable.Empty<(string, object[])>();
+
+                            if (types.Contains(typeof(Undertale)))
+                            {
+                                var  = data..Where(x => x.Name == obj);
+                                if (.Any())
+                                    outList = outList.Append(("", .ToArray()));
+                            }
+
+                            if (outList == Enumerable.Empty<(string, object[])>())
+                                return null;
+                            return outList.ToArray();
+                        }
+                    },*/
+                    new PredicateForVersion()
+                    {
+                        Version = (2, 0, 0),
+                        Predicate = (obj, types) =>
+                        {
+                            IEnumerable<(string, object[])> outList = Enumerable.Empty<(string, object[])>();
+
+                            if (types.Contains(typeof(UndertaleEmbeddedImage)))
+                            {
+                                var embImages = data.EmbeddedImages.Where(x => x.Name == obj);
+                                if (embImages.Any())
+                                    outList = outList.Append(("Embedded images", embImages.ToArray()));
+                            }
+
+                            List<object[]> layers = new();
+                            List<object[]> sprInstances = new();
+                            foreach (var room in data.Rooms)
+                            {
+                                foreach (var layer in room.Layers)
+                                {
+                                    if (types.Contains(typeof(UndertaleRoom.Layer)))
+                                    {
+                                        if (layer.LayerName == obj || layer.EffectType == obj)
+                                            layers.Add(new object[] { layer, room });
+                                    }
+
+                                    if (layer.AssetsData is not null)
+                                    {
+                                        if (types.Contains(typeof(UndertaleRoom.SpriteInstance)))
+                                        {
+                                            foreach (var sprInst in layer.AssetsData.Sprites)
+                                                if (sprInst.Name == obj)
+                                                    sprInstances.Add(new object[] { sprInst, layer, room });
+                                        }
+                                    }
+                                }
+
+                                foreach (var tile in room.Tiles)
+                                    if (tile.BackgroundDefinition == obj)
+                                        sprInstances.Add(new object[] { tile, room });
+                            }
+                            if (layers.Count > 0)
+                                outList = outList.Append(("Room layers", layers.ToArray()));
+                            if (sprInstances.Count > 0)
+                                outList = outList.Append(("Room sprite instances", sprInstances.ToArray()));
+
+                            if (outList == Enumerable.Empty<(string, object[])>())
+                                return null;
+                            return outList.ToArray();
+                        }
+                    },
+                    new PredicateForVersion()
+                    {
+                        Version = (2, 2, 1),
+                        Predicate = (obj, types) =>
+                        {
+                            if (!types.Contains(typeof(UndertaleTextureGroupInfo)))
+                                return null;
+
+                            var textGroups = data.TextureGroupInfo.Where(x => x.Name == obj);
+                            if (textGroups.Any())
+                                return new (string, object[])[] { ("Texture groups", textGroups.ToArray()) };
+                            else
+                                return null;
+                        }
+                    },
+                    new PredicateForVersion()
+                    {
+                        Version = (2, 3, 0),
+                        Predicate = (obj, types) =>
+                        {
+                            IEnumerable<(string, object[])> outList = Enumerable.Empty<(string, object[])>();
+
+                            if (types.Contains(typeof(UndertaleAnimationCurve)))
+                            {
+                                var animCurves = data.AnimationCurves.Where(x => x.Name == obj);
+                                if (animCurves.Any())
+                                    outList = outList.Append(("Animation curves", animCurves.ToArray()));
+                            }
+                            if (types.Contains(typeof(UndertaleAnimationCurve.Channel)))
+                            {
+                                List<object[]> animCurveChannels = new();
+                                foreach (var curve in data.AnimationCurves)
+                                {
+                                    foreach (var ch in curve.Channels)
+                                        if (ch.Name == obj)
+                                            animCurveChannels.Add(new object[] { ch, curve });
+                                }
+
+                                if (animCurveChannels.Count > 0)
+                                    outList = outList.Append(("Animation curve channels", animCurveChannels.ToArray()));
+                            }
+
+                            if (types.Contains(typeof(UndertaleRoom.SequenceInstance)))
+                            {
+                                List<object[]> seqInstances = new();
+                                foreach (var room in data.Rooms)
+                                {
+                                    foreach (var layer in room.Layers)
+                                    {
+                                        if (layer.AssetsData is not null)
+                                        {
+                                            foreach (var seqInst in layer.AssetsData.Sequences)
+                                                if (seqInst.Sequence == obj)
+                                                    seqInstances.Add(new object[] { seqInst, layer, room });
+                                        }
+                                    }
+                                }
+                                if (seqInstances.Count > 0)
+                                    outList = outList.Append(("Room sequence instances", seqInstances.ToArray()));
+                            }
+
+                            if (types.Contains(typeof(UndertaleSequence)))
+                            {
+                                var sequences = data.Sequences.Where(x => x.Name == obj
+                                                                          || x.FunctionIDs.Values.Any(i => i == obj));
+                                if (sequences.Any())
+                                    outList = outList.Append(("Sequences", sequences.ToArray()));
+                            }
+
+                            List<object[]> sequenceTracks = new();
+                            List<object[]> seqBroadMessages = new();
+                            List<object[]> sequenceMoments = new();
+                            List<object[]> seqStringKeyframes = new();
+                            foreach (var seq in data.Sequences)
+                            {
+                                foreach (var track in seq.Tracks)
+                                {
+                                    if (types.Contains(typeof(Track)))
+                                    {
+                                        if (track.Name == obj || track.ModelName == obj || track.GMAnimCurveString == obj)
+                                            sequenceTracks.Add(new object[] { track, seq });
+                                    }
+
+                                    if (types.Contains(typeof(StringKeyframes)))
+                                    {
+                                        if (track.Keyframes is StringKeyframes strKeyframes)
+                                        {
+                                            foreach (var data in strKeyframes.List)
+                                            {
+                                                foreach (var strPair in data.Channels)
+                                                    if (strPair.Value.Value == obj)
+                                                        seqStringKeyframes.Add(new object[] { strPair.Key, data, seq });
+                                            }
+                                        }
+                                    }
+                                }
+
+                                if (types.Contains(typeof(BroadcastMessage)))
+                                {
+                                    foreach (var keyframe in seq.BroadcastMessages)
+                                    {
+                                        foreach (var msgPair in keyframe.Channels)
+                                            if (msgPair.Value.Messages.Any(x => x == obj))
+                                                seqBroadMessages.Add(new object[] { msgPair.Key, keyframe, seq });
+                                    }
+                                }
+
+                                if (types.Contains(typeof(Moment)))
+                                {
+                                    foreach (var keyframe in seq.Moments)
+                                    {
+                                        foreach (var momentPair in keyframe.Channels)
+                                            if (momentPair.Value.Event == obj)
+                                                sequenceMoments.Add(new object[] { momentPair.Key, keyframe, seq });
+                                    }
+                                }
+                            }
+                            if (sequenceTracks.Count > 0)
+                                outList = outList.Append(("Sequence tracks", sequenceTracks.ToArray()));
+                            if (seqBroadMessages.Count > 0)
+                                outList = outList.Append(("Sequence broadcast messages", seqBroadMessages.ToArray()));
+                            if (sequenceMoments.Count > 0)
+                                outList = outList.Append(("Sequence moments", sequenceMoments.ToArray()));
+                            if (seqStringKeyframes.Count > 0)
+                                outList = outList.Append(("Sequence string keyframes", seqStringKeyframes.ToArray()));
+
+                            if (outList == Enumerable.Empty<(string, object[])>())
+                                return null;
+                            return outList.ToArray();
+                        }
+                    },
+                    new PredicateForVersion()
+                    {
+                        Version = (2, 3, 6),
+                        Predicate = (obj, types) =>
+                        {
+                            if (!types.Contains(typeof(UndertaleFilterEffect)))
+                                return null;
+
+                            var filterEffects = data.FilterEffects.Where(x => x.Name == obj || x.Value == obj);
+                            if (filterEffects.Any())
+                                return new (string, object[])[] { ("Filter effects", filterEffects.ToArray()) };
+                            else
+                                return null;
+                        }
+                    },
+                    new PredicateForVersion()
+                    {
+                        Version = (2022, 1, 0),
+                        Predicate = (obj, types) =>
+                        {
+                            if (!types.Contains(typeof(UndertaleRoom.EffectProperty)))
+                                return null;
+
+                            List<object[]> effectProps = new();
+                            foreach (var room in data.Rooms)
+                            {
+                                foreach (var layer in room.Layers)
+                                {
+                                    foreach (var prop in layer.EffectProperties)
+                                        if (prop.Name == obj)
+                                            effectProps.Add(new object[] { prop, layer, room });
+                                }
+                            }
+                            if (effectProps.Count > 0)
+                                return new (string, object[])[] { ("Room effect properties", effectProps.ToArray()) };
+                            else
+                                return null;
+                        }
+                    },
+                    new PredicateForVersion()
+                    {
+                        Version = (2022, 2, 0),
+                        Predicate = (obj, types) =>
+                        {
+                            if (!types.Contains(typeof(TextKeyframes)))
+                                return null;
+
+                            List<object[]> textKeyframesList = new();
+                            foreach (var seq in data.Sequences)
+                            {
+                                foreach (var track in seq.Tracks)
+                                {
+                                    if (track.Keyframes is TextKeyframes textKeyframes)
+                                    {
+                                        foreach (var data in textKeyframes.List)
+                                        {
+                                            foreach (var textPair in data.Channels)
+                                                if (textPair.Value.Text == obj)
+                                                    textKeyframesList.Add(new object[] { textPair.Key, data, seq });
+                                        }
+                                    }
+                                }
+                            }
+                            if (textKeyframesList.Count > 0)
+                                return new (string, object[])[] { ("Sequence text keyframes", textKeyframesList.ToArray()) };
                             else
                                 return null;
                         }
@@ -211,7 +688,7 @@ namespace UndertaleModTool.Windows
         };
 
 
-        public static (string, object[])[] GetReferencesOfObject(UndertaleResource obj, UndertaleData data)
+        public static (string, object[])[] GetReferencesOfObject(UndertaleResource obj, UndertaleData data, HashSet<Type> types)
         {
             if (obj is null)
                 return null;
@@ -225,9 +702,15 @@ namespace UndertaleModTool.Windows
             IEnumerable<(string, object[])> outList = Enumerable.Empty<(string, object[])>();
             foreach (var predicateForVer in predicatesForVer)
             {
-                if (predicateForVer.Version.CompareTo(ver) <= 0)
+                bool isAtLeast = false;
+                if (predicateForVer.Version.Minor == uint.MaxValue)
+                    isAtLeast = predicateForVer.Version.Major <= data.GeneralInfo.BytecodeVersion;
+                else
+                    isAtLeast = predicateForVer.Version.CompareTo(ver) <= 0;
+
+                if (isAtLeast)
                 {
-                    var result = predicateForVer.Predicate(obj);
+                    var result = predicateForVer.Predicate(obj, types);
                     if (result is not null)
                         outList = outList.Concat(result);
                 }  

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -14,6 +14,18 @@ namespace UndertaleModTool.Windows
         public Func<UndertaleResource, (string, object[])[]> Predicate { get; set; }
     }
 
+    public class ChildInstance
+    {
+        public UndertaleResource Parent { get; set; }
+        public object Child { get; set; }
+
+        public ChildInstance(UndertaleResource parent, object child)
+        {
+            Parent = parent;
+            Child = child;
+        }
+    }
+
     public static class UndertaleResourceReferenceMethodsMap
     {
         private static UndertaleData data;
@@ -43,9 +55,9 @@ namespace UndertaleModTool.Windows
                         {
                             IEnumerable<(string, object[])> outList = Enumerable.Empty<(string, object[])>();
 
-                            List<(UndertaleRoom, UndertaleRoom.Tile)> tiles = new();
-                            List<(UndertaleRoom, UndertaleRoom.SpriteInstance)> sprInstances = new();
-                            List<UndertaleRoom.Layer> bgLayers = new();
+                            List<ChildInstance> tiles = new();
+                            List<ChildInstance> sprInstances = new();
+                            List<ChildInstance> bgLayers = new();
                             foreach (var room in data.Rooms)
                             {
                                 foreach (var layer in room.Layers)
@@ -54,16 +66,16 @@ namespace UndertaleModTool.Windows
                                     {
                                         foreach (var tile in layer.AssetsData.LegacyTiles)
                                             if (tile.SpriteDefinition == obj)
-                                                tiles.Add((room, tile));
+                                                tiles.Add(new(room, tile));
 
                                         foreach (var sprInst in layer.AssetsData.Sprites)
                                             if (sprInst.Sprite == obj)
-                                                sprInstances.Add((room, sprInst));
+                                                sprInstances.Add(new(room, sprInst));
                                     }
 
                                     if (layer.BackgroundData is not null
                                         && layer.BackgroundData.Sprite == obj)
-                                        bgLayers.Add(layer);
+                                        bgLayers.Add(new(room, layer));
 
                                 }
                             }

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -105,6 +105,79 @@ namespace UndertaleModTool.Windows
                         }
                     }
                 }
+            },
+            {
+                typeof(UndertaleBackground),
+                new[]
+                {
+                    new PredicateForVersion()
+                    {
+                        Version = (1, 0, 0),
+                        Predicate = (obj) =>
+                        {
+                            if (data.IsGameMaker2())
+                                return null;
+
+                            IEnumerable<(string, object[])> outList = Enumerable.Empty<(string, object[])>();
+
+                            List<ChildInstance> backgrounds = new();
+                            List<ChildInstance> tiles = new();
+                            foreach (var room in data.Rooms)
+                            {
+                                foreach (var bg in room.Backgrounds)
+                                    if (bg.BackgroundDefinition == obj)
+                                        backgrounds.Add(new(room, bg));
+
+                                foreach (var tile in room.Tiles)
+                                    if (tile.BackgroundDefinition == obj)
+                                        tiles.Add(new(room, tile));
+                            }
+                            if (backgrounds.Count > 0)
+                                outList = outList.Append(("Room tiles", tiles.ToArray()));
+                            if (tiles.Count > 0)
+                                outList = outList.Append(("Room sprite instances", tiles.ToArray()));
+
+                            if (outList == Enumerable.Empty<(string, object[])>())
+                                return null;
+                            return outList.ToArray();
+                        }
+                    },
+                    new PredicateForVersion()
+                    {
+                        Version = (2, 0, 0),
+                        Predicate = (obj) =>
+                        {
+                            List<ChildInstance> tileLayers = new();
+                            foreach (var room in data.Rooms)
+                            {
+                                foreach (var layer in room.Layers)
+                                {
+                                    if (layer.TilesData is not null
+                                        && layer.TilesData.Background == obj)
+                                        tileLayers.Add(new(room, layer));
+
+                                }
+                            }
+                            if (tileLayers.Count > 0)
+                                return new (string, object[])[] { ("Room tile layers", tileLayers.ToArray()) };
+                            else
+                                return null;
+                        }
+                    },
+                    new PredicateForVersion()
+                    {
+                        Version = (2, 2, 1),
+                        Predicate = (obj) =>
+                        {
+                            var textGroups = data.TextureGroupInfo.Where(x => x.Sprites.Any(s => s.Resource == obj)
+                                                                              || x.SpineSprites.Any(s => s.Resource == obj));
+                            if (textGroups.Any())
+                                return new (string, object[])[] { ("Texture groups", textGroups.ToArray()) };
+                            else
+                                return null;
+                        }
+                    }
+                }
             }
         };
 

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -904,6 +904,27 @@ namespace UndertaleModTool.Windows
                         }
                     }
                 }
+            },
+            {
+                typeof(UndertaleAudioGroup),
+                new[]
+                {
+                    new PredicateForVersion()
+                    {
+                        Version = (1, 0, 0),
+                        Predicate = (obj, types) =>
+                        {
+                            if (!types.Contains(typeof(UndertaleSound)))
+                                return null;
+
+                            var sounds = data.Sounds.Where(x => x.AudioGroup == obj);
+                            if (sounds.Any())
+                                return new (string, object[])[] { ("Sounds", sounds.ToArray()) };
+                            else
+                                return null;
+                        }
+                    }
+                }
             }
         };
 


### PR DESCRIPTION
## Description
1) **Added a possibility to search for asset references - from the asset tree or from any object definition UI field (by right-clicking on it).**
Also, it's possible to do that from the references results window by right-clicking on the assets.

The asset types that support the reference searching:
- Sprites
- Backgrounds/tile sets
- Texture pages
- Strings **(at least 683 added lines of code)**
- Game objects
- Texture page items
- Code entries
- Embedded audio
- Audio groups
- Functions
- Variables

2) Added a new top menu entry "Find" - for now, it only contains **the "Find unreferences assets" option** and the code search scripts links.
3) Improved GM 2022.2 version detection.
4) Added missing chunk instances to `UndertaleChunkFORM`; made the filter effects list accessible.
5) Various improvements of room object names (includes a **removal of redundant type names, e.g. "(UndertaleRoom+Tile)"**).
6) Fixed the "FindUnusedStrings.csx" script (closes #1269).

Closes #493, closes #1033.