### PR TITLE
Fix of the "GameObjectCopy.csx" script.

### DIFF
--- a/UndertaleModCli/Program.UMTLibInherited.cs
+++ b/UndertaleModCli/Program.UMTLibInherited.cs
@@ -771,7 +771,6 @@ public partial class Program : IScriptInterface
             locals.Locals.Add(argsLocal);
 
             code.LocalsCount = 1;
-            code.GenerateLocalVarDefinitions(code.FindReferencedLocalVars(), locals); // Dunno if we actually need this line, but it seems to work?
             Data.CodeLocals.Add(locals);
         }
         if (doParse)

--- a/UndertaleModTool/ImportCodeSystem.cs
+++ b/UndertaleModTool/ImportCodeSystem.cs
@@ -219,7 +219,6 @@ namespace UndertaleModTool
                 locals.Locals.Add(argsLocal);
 
                 code.LocalsCount = 1;
-                code.GenerateLocalVarDefinitions(code.FindReferencedLocalVars(), locals); // Dunno if we actually need this line, but it seems to work?
                 Data.CodeLocals.Add(locals);
             }
             if (doParse)

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -2056,7 +2056,6 @@ namespace UndertaleModTool
                             argsLocal.Index = 0;
                             locals.Locals.Add(argsLocal);
                             code.LocalsCount = 1;
-                            code.GenerateLocalVarDefinitions(code.FindReferencedLocalVars(), locals);
                             Data.CodeLocals.Add(locals);
                         }
                         (obj as UndertaleScript).Code = code;
@@ -2070,7 +2069,6 @@ namespace UndertaleModTool
                         argsLocal.Index = 0;
                         locals.Locals.Add(argsLocal);
                         (obj as UndertaleCode).LocalsCount = 1;
-                        (obj as UndertaleCode).GenerateLocalVarDefinitions((obj as UndertaleCode).FindReferencedLocalVars(), locals);
                         Data.CodeLocals.Add(locals);
                     }
                 }
@@ -2562,7 +2560,7 @@ namespace UndertaleModTool
 
                 ScriptPath = path;
 
-                string compatScriptText = Regex.Replace(scriptText, @"\bDecompileContext\b", "GlobalDecompileContext", RegexOptions.None);
+                string compatScriptText = Regex.Replace(scriptText, @"\bDecompileContext(?!\.)\b", "GlobalDecompileContext", RegexOptions.None);
                 object result = await CSharpScript.EvaluateAsync(compatScriptText, scriptOptions, this, typeof(IScriptInterface));
 
                 if (FinishedMessageEnabled)

--- a/UndertaleModTool/Scripts/Helper Scripts/15_To_16.csx
+++ b/UndertaleModTool/Scripts/Helper Scripts/15_To_16.csx
@@ -62,7 +62,6 @@ if ((Data?.GeneralInfo.BytecodeVersion == 14) || (Data?.GeneralInfo.BytecodeVers
             locals.Locals.Add(argsLocal);
     
             code.LocalsCount = 1;
-            code.GenerateLocalVarDefinitions(code.FindReferencedLocalVars(), locals); // Dunno if we actually need this line, but it seems to work?
             Data.CodeLocals.Add(locals);
         }
     }

--- a/UndertaleModTool/Scripts/Resource Repackers/GameObjectCopy.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/GameObjectCopy.csx
@@ -28,11 +28,20 @@ string DonorDataPath = PromptLoadFile(null, null);
 if (DonorDataPath == null)
     throw new ScriptException("The donor data path was not set.");
 
+bool compContextState = CompileContext.GMS2_3;
+bool decompContextState = DecompileContext.GMS2_3;
+
 using (var stream = new FileStream(DonorDataPath, FileMode.Open, FileAccess.Read))
     DonorData = UndertaleIO.Read(stream, warning => ScriptMessage("A warning occured while trying to load " + DonorDataPath + ":\n" + warning));
 var DonorDataEmbeddedTexturesCount = DonorData.EmbeddedTextures.Count;
 DonorData.BuiltinList = new BuiltinList(DonorData);
 AssetTypeResolver.InitializeTypes(DonorData);
+
+
+CompileContext.GMS2_3 = compContextState;
+DecompileContext.GMS2_3 = decompContextState;
+
+bool donorIs2_3 = DonorData.IsVersionAtLeast(2, 3);
 
 int copiedGameObjectsCount = 0;
 List<string> splitStringsList = GetSplitStringsList("game object");
@@ -129,7 +138,13 @@ for (var j = 0; j < splitStringsList.Count; j++)
                                 string codeToCopy = "";
                                 try
                                 {
+                                    CompileContext.GMS2_3 = donorIs2_3;
+                                    DecompileContext.GMS2_3 = donorIs2_3;
+
                                     codeToCopy = (donorACT.CodeId != null ? Decompiler.Decompile(donorACT.CodeId, DECOMPILE_CONTEXT.Value) : "");
+
+                                    CompileContext.GMS2_3 = compContextState;
+                                    DecompileContext.GMS2_3 = decompContextState;
                                 }
                                 catch (Exception e)
                                 {
@@ -167,7 +182,6 @@ for (var j = 0; j < splitStringsList.Count; j++)
                                         nativelocals.Locals.Add(argsLocal);
                                     }
                                     nativeACT.CodeId.LocalsCount = (uint)nativelocals.Locals.Count;
-                                    nativeACT.CodeId.GenerateLocalVarDefinitions(nativeACT.CodeId.FindReferencedLocalVars(), nativelocals); // Dunno if we actually need this line, but it seems to work?
                                 }
                             }
                             nativeACT.ArgumentCount = donorACT.ArgumentCount;

--- a/UndertaleModTool/Scripts/Resource Repackers/GameObjectCopyInternal.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/GameObjectCopyInternal.csx
@@ -126,7 +126,6 @@ for (var j = 0; j < splitStringsList.Count; j++)
                                         nativelocals.Locals.Add(argsLocal);
                                     }
                                     nativeACT.CodeId.LocalsCount = (uint)nativelocals.Locals.Count;
-                                    nativeACT.CodeId.GenerateLocalVarDefinitions(nativeACT.CodeId.FindReferencedLocalVars(), nativelocals); // Dunno if we actually need this line, but it seems to work?
                                 }
                             }
                             nativeACT.ArgumentCount = donorACT.ArgumentCount;

--- a/UndertaleModTool/Scripts/Resource Repackers/ImportASM_2_3.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/ImportASM_2_3.csx
@@ -126,7 +126,6 @@ await Task.Run(() => {
             argsLocal.Index = 0;
             locals.Locals.Add(argsLocal);
             code.LocalsCount = 1;
-            code.GenerateLocalVarDefinitions(code.FindReferencedLocalVars(), locals); // Dunno if we actually need this line, but it seems to work?
             Data.CodeLocals.Add(locals);
         }
         if (doParse)

--- a/UndertaleModTool/Scripts/Resource Repackers/ImportGML_2_3.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/ImportGML_2_3.csx
@@ -130,7 +130,6 @@ await Task.Run(() => {
             locals.Locals.Add(argsLocal);
 
             code.LocalsCount = 1;
-            code.GenerateLocalVarDefinitions(code.FindReferencedLocalVars(), locals); // Dunno if we actually need this line, but it seems to work?
             Data.CodeLocals.Add(locals);
         }
         if (doParse)

--- a/UndertaleModTool/Scripts/Technical Scripts/14_To_16.csx
+++ b/UndertaleModTool/Scripts/Technical Scripts/14_To_16.csx
@@ -231,7 +231,6 @@ for (var i = 0; i < Data.Code.Count; i++)
     locals.Locals.Add(argsLocal);
 
     Data.Code[i].LocalsCount = 1;
-    Data.Code[i].GenerateLocalVarDefinitions(Data.Code[i].FindReferencedLocalVars(), locals); // Dunno if we actually need this line, but it seems to work?
     Data.Code[i].WeirdLocalFlag = false;
     Data.CodeLocals.Add(locals);
 }

--- a/UndertaleModTool/Scripts/Technical Scripts/15_to_17_To_16.csx
+++ b/UndertaleModTool/Scripts/Technical Scripts/15_to_17_To_16.csx
@@ -65,7 +65,6 @@ if ((Data?.GeneralInfo.BytecodeVersion == 14) || (Data?.GeneralInfo.BytecodeVers
             locals.Locals.Add(argsLocal);
 
             code.LocalsCount = 1;
-            code.GenerateLocalVarDefinitions(code.FindReferencedLocalVars(), locals); // Dunno if we actually need this line, but it seems to work?
             Data.CodeLocals.Add(locals);
         }
     }

--- a/UndertaleModTool/Scripts/Technical Scripts/ExportAndConvert_2_3_ASM.csx
+++ b/UndertaleModTool/Scripts/Technical Scripts/ExportAndConvert_2_3_ASM.csx
@@ -73,7 +73,6 @@ void DumpCode()
                     codeLocalsCount += 1;
                 }
                 code_orig.LocalsCount = codeLocalsCount;
-                code_orig.GenerateLocalVarDefinitions(code_orig.FindReferencedLocalVars(), locals); // Dunno if we actually need this line, but it seems to work?
                 code_orig.ParentEntry = null;
             }
             else
@@ -83,7 +82,6 @@ void DumpCode()
                 argsLocal.Index = 0;
                 locals.Locals.Add(argsLocal);
                 code_orig.LocalsCount = 1;
-                code_orig.GenerateLocalVarDefinitions(code_orig.FindReferencedLocalVars(), locals); // Dunno if we actually need this line, but it seems to work?
             }
             Data.CodeLocals.Add(locals);
         }

--- a/UndertaleModTool/Scripts/Technical Scripts/RestoreMissingCodeLocals.csx
+++ b/UndertaleModTool/Scripts/Technical Scripts/RestoreMissingCodeLocals.csx
@@ -15,7 +15,6 @@ foreach (UndertaleCode code in Data.Code)
         argsLocal.Index = 0;
         locals.Locals.Add(argsLocal);
         code.LocalsCount = 1;
-        code.GenerateLocalVarDefinitions(code.FindReferencedLocalVars(), locals); // Dunno if we actually need this line, but it seems to work?
         Data.CodeLocals.Add(locals);
         newCount += 1;
     }


### PR DESCRIPTION
## Description
1) Fixes #1248.
2) Removes all redundant `GenerateLocalVarDefinitions()` method calls - it doesn't modify anything, only returns a string.