### PR TITLE
"Find all references of this tile" option for a GMS 2 tileset image.

### DIFF
--- a/UndertaleModTool/Editors/UndertaleBackgroundEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleBackgroundEditor.xaml
@@ -126,7 +126,7 @@
 
         <Viewbox Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2" Stretch="Uniform" StretchDirection="DownOnly">
             <Canvas Name="BGTexture" Width="{Binding Texture.BoundingWidth, Mode=OneWay}" Height="{Binding Texture.BoundingHeight, Mode=OneWay}"
-                    MouseLeftButtonDown="BGTexture_MouseLeftButtonDown">
+                    MouseLeftButtonDown="BGTexture_MouseLeftButtonDown" PreviewMouseRightButtonDown="BGTexture_PreviewMouseRightButtonDown">
                 <Border>
                     <Border.Background>
                         <DrawingBrush Stretch="None" TileMode="Tile" Viewport="0,0,20,20" ViewportUnits="Absolute">

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -38,7 +39,7 @@ namespace UndertaleModTool.Windows
                 MainWindow.SetDarkTitleBarForWindow(this, true, false);
         }
 
-        public FindReferencesResults(UndertaleResource sourceObj, UndertaleData data, Dictionary<string, List<object>> results)
+        public FindReferencesResults(object sourceObj, UndertaleData data, Dictionary<string, List<object>> results)
         {
             InitializeComponent();
 
@@ -49,6 +50,8 @@ namespace UndertaleModTool.Windows
                 sourceObjName = namedObj.Name.Content;
             else if (sourceObj is UndertaleString str)
                 sourceObjName = str.Content;
+            else if (sourceObj is ValueTuple<UndertaleBackground, UndertaleBackground.TileID> tileTuple)
+                sourceObjName = $"Tile {tileTuple.Item2} of {tileTuple.Item1.Name.Content}";
             else
                 sourceObjName = sourceObj.GetType().Name;
             this.sourceObjName = sourceObjName;
@@ -200,6 +203,12 @@ namespace UndertaleModTool.Windows
             }
             sb.Remove(sb.Length - 2, 2);
 
+            if (sourceObjName is not null)
+            {
+                string invalidCharsRegex = '[' + String.Join("", Path.GetInvalidFileNameChars()) + ']';
+                sourceObjName = Regex.Replace(sourceObjName, invalidCharsRegex, "_");
+            }
+                    
             string folderPath = Path.GetDirectoryName(mainWindow.FilePath);
             string filePath = Path.Combine(folderPath, sourceObjName is null
                                                        ? "unreferenced_assets.txt" : $"references_of_asset_{sourceObjName}.txt");

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
@@ -324,6 +324,20 @@ namespace UndertaleModTool.Windows
                         }
                     }
                 }
+            },
+            {
+                typeof(ValueTuple<UndertaleBackground, UndertaleBackground.TileID>),
+                new[]
+                {
+                    new TypesForVersion()
+                    {
+                        Version = (2, 0, 0),
+                        Types = new[]
+                        {
+                            (typeof(UndertaleRoom.Layer), "Room tile layer")
+                        }
+                    }
+                }
             }
         };
 


### PR DESCRIPTION
## Description
1) Closes #1286.
2) The "Export results" feature of the references results window is more safe - the object name is sanitized.