### PR TITLE
The find references feature improvements, and more.

### DIFF
--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml
@@ -87,7 +87,7 @@
                     <Grid Cursor="Hand" MouseDown="Grid_MouseDown" MouseMove="Grid_MouseMove" MouseLeave="Grid_MouseLeave">
                         <Image Source="{Binding TextureData.TextureBlob, Mode=OneWay}"/>
                         <Canvas>
-                            <Border Name="PageItemBorder" Background="LightBlue" BorderThickness="2" BorderBrush="LightSkyBlue" Opacity="0.8"/>
+                            <Border Name="PageItemBorder" Background="LightBlue" BorderThickness="2" BorderBrush="Blue" Opacity="0.65"/>
                         </Canvas>
                     </Grid>
                 </Border>

--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml
@@ -67,8 +67,7 @@
             </Grid.RowDefinitions>
 
             <TextBlock Grid.Row="0" Grid.ColumnSpan="3" Margin="3" HorizontalAlignment="Center" Foreground="DarkGray" FontStyle="Italic" TextWrapping="Wrap" TextAlignment="Center">
-                Hint: You can open a texture page item by clicking on its region below.<LineBreak/>
-                The middle (wheel) mouse button will open it in a new tab.
+                Hint: This image is mouse interactable (3 mouse buttons and mouse wheel).
             </TextBlock>
             <ScrollViewer Name="TextureScroll" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3" MaxHeight="450"
                           HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Visible" ScrollChanged="TextureScroll_ScrollChanged">

--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml
@@ -7,7 +7,7 @@
                        xmlns:undertale="clr-namespace:UndertaleModLib.Models;assembly=UndertaleModLib"
                        mc:Ignorable="d" 
                        d:DesignHeight="450" d:DesignWidth="800" d:DataContext="{d:DesignInstance undertale:UndertaleEmbeddedTexture}"
-                       DataContextChanged="DataUserControl_DataContextChanged">
+                       DataContextChanged="DataUserControl_DataContextChanged" Loaded="DataUserControl_Loaded">
     <UserControl.Resources>
         <local:BooleanToVisibilityConverter x:Key="BoolFalseToVisConverter" local:trueValue="Collapsed" local:falseValue="Visible"/>
         <local:TextureLoadedWrapper x:Key="TextureLoadedWrapper"/>
@@ -70,28 +70,35 @@
                 Hint: You can open a texture page item by clicking on its region below.<LineBreak/>
                 The middle (wheel) mouse button will open it in a new tab.
             </TextBlock>
-            <Viewbox Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3" Stretch="Uniform" StretchDirection="DownOnly"
-                     SnapsToDevicePixels="True" RenderOptions.BitmapScalingMode="NearestNeighbor">
-                <Border>
-                    <Border.Background>
-                        <DrawingBrush Stretch="None" TileMode="Tile" Viewport="0,0,20,20" ViewportUnits="Absolute">
-                            <DrawingBrush.Drawing>
-                                <DrawingGroup>
-                                    <GeometryDrawing Geometry="M0,0 L20,0 20,20, 0,20Z" Brush="White"/>
-                                    <GeometryDrawing Geometry="M0,10 L20,10 20,20, 10,20 10,0 0,0Z" Brush="LightGray"/>
-                                </DrawingGroup>
-                            </DrawingBrush.Drawing>
-                        </DrawingBrush>
-                    </Border.Background>
+            <ScrollViewer Name="TextureScroll" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3" MaxHeight="450"
+                          HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Visible" ScrollChanged="TextureScroll_ScrollChanged">
+                <ScrollViewer.Background>
+                    <DynamicResource ResourceKey="{x:Static SystemColors.MenuBrushKey}"/>
+                </ScrollViewer.Background>
+                <Viewbox Name="TextureViewbox" Stretch="Uniform" StretchDirection="DownOnly"
+                         SnapsToDevicePixels="True" RenderOptions.BitmapScalingMode="NearestNeighbor" MouseWheel="TextureViewbox_MouseWheel">
+                    <Border>
+                        <Border.Background>
+                            <DrawingBrush Stretch="None" TileMode="Tile" Viewport="0,0,20,20" ViewportUnits="Absolute">
+                                <DrawingBrush.Drawing>
+                                    <DrawingGroup>
+                                        <GeometryDrawing Geometry="M0,0 L20,0 20,20, 0,20Z" Brush="White"/>
+                                        <GeometryDrawing Geometry="M0,10 L20,10 20,20, 10,20 10,0 0,0Z" Brush="LightGray"/>
+                                    </DrawingGroup>
+                                </DrawingBrush.Drawing>
+                            </DrawingBrush>
+                        </Border.Background>
 
-                    <Grid Cursor="Hand" MouseDown="Grid_MouseDown" MouseMove="Grid_MouseMove" MouseLeave="Grid_MouseLeave">
-                        <Image Source="{Binding TextureData.TextureBlob, Mode=OneWay}"/>
-                        <Canvas>
-                            <Border Name="PageItemBorder" Background="LightBlue" BorderThickness="2" BorderBrush="Blue" Opacity="0.65"/>
-                        </Canvas>
-                    </Grid>
-                </Border>
-            </Viewbox>
+                        <Grid Cursor="Hand" MouseDown="Grid_MouseDown" MouseMove="Grid_MouseMove" MouseLeave="Grid_MouseLeave">
+                            <Image Source="{Binding TextureData.TextureBlob, Mode=OneWay}"/>
+                            <Canvas>
+                                <Border Name="PageItemBorder" Background="LightBlue" BorderThickness="2" BorderBrush="Blue" Opacity="0.65"
+                                        Width="0" Height="0"/>
+                            </Canvas>
+                        </Grid>
+                    </Border>
+                </Viewbox>
+            </ScrollViewer>
 
             <local:ButtonDark Grid.Row="2" Grid.Column="0" Margin="0,2" Content="Import" Click="Import_Click"/>
             <local:ButtonDark Grid.Row="2" Grid.Column="3" Margin="0,2" Content="Export" Click="Export_Click"/>

--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml
@@ -1,12 +1,13 @@
 ﻿<local:DataUserControl x:Class="UndertaleModTool.UndertaleEmbeddedTextureEditor"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:UndertaleModTool"
-             xmlns:undertale="clr-namespace:UndertaleModLib.Models;assembly=UndertaleModLib"
-             mc:Ignorable="d" 
-             d:DesignHeight="450" d:DesignWidth="800" d:DataContext="{d:DesignInstance undertale:UndertaleEmbeddedTexture}">
+                       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+                       xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+                       xmlns:local="clr-namespace:UndertaleModTool"
+                       xmlns:undertale="clr-namespace:UndertaleModLib.Models;assembly=UndertaleModLib"
+                       mc:Ignorable="d" 
+                       d:DesignHeight="450" d:DesignWidth="800" d:DataContext="{d:DesignInstance undertale:UndertaleEmbeddedTexture}"
+                       DataContextChanged="DataUserControl_DataContextChanged">
     <UserControl.Resources>
         <local:BooleanToVisibilityConverter x:Key="BoolFalseToVisConverter" local:trueValue="Collapsed" local:falseValue="Visible"/>
         <local:TextureLoadedWrapper x:Key="TextureLoadedWrapper"/>
@@ -83,7 +84,12 @@
                         </DrawingBrush>
                     </Border.Background>
 
-                    <Image Source="{Binding TextureData.TextureBlob, Mode=OneWay}" MouseDown="Image_MouseDown" Cursor="Hand"/>
+                    <Grid Cursor="Hand" MouseDown="Grid_MouseDown" MouseMove="Grid_MouseMove" MouseLeave="Grid_MouseLeave">
+                        <Image Source="{Binding TextureData.TextureBlob, Mode=OneWay}"/>
+                        <Canvas>
+                            <Border Name="PageItemBorder" Background="LightBlue" BorderThickness="2" BorderBrush="LightSkyBlue" Opacity="0.8"/>
+                        </Canvas>
+                    </Grid>
                 </Border>
             </Viewbox>
 

--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml
@@ -7,7 +7,7 @@
                        xmlns:undertale="clr-namespace:UndertaleModLib.Models;assembly=UndertaleModLib"
                        mc:Ignorable="d" 
                        d:DesignHeight="450" d:DesignWidth="800" d:DataContext="{d:DesignInstance undertale:UndertaleEmbeddedTexture}"
-                       DataContextChanged="DataUserControl_DataContextChanged" Loaded="DataUserControl_Loaded">
+                       DataContextChanged="DataUserControl_DataContextChanged" Loaded="DataUserControl_Loaded" Unloaded="DataUserControl_Unloaded">
     <UserControl.Resources>
         <local:BooleanToVisibilityConverter x:Key="BoolFalseToVisConverter" local:trueValue="Collapsed" local:falseValue="Visible"/>
         <local:TextureLoadedWrapper x:Key="TextureLoadedWrapper"/>

--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
@@ -48,7 +48,7 @@ namespace UndertaleModTool
             newTabItem.Click += OpenInNewTabItem_Click;
             var referencesItem = new MenuItem()
             {
-                Header = "Find all references of this page item"
+                Header = "Find all references to this page item"
             };
             referencesItem.Click += FindAllItemReferencesItem_Click;
             pageContextMenu.Items.Add(newTabItem);

--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
@@ -35,6 +35,8 @@ namespace UndertaleModTool
         private UndertaleTexturePageItem[] items;
         private UndertaleTexturePageItem hoveredItem;
 
+        public static (Transform Transform, double Left, double Top) OverriddenPreviewState { get; set; }
+
         public UndertaleEmbeddedTextureEditor()
         {
             InitializeComponent();
@@ -100,10 +102,25 @@ namespace UndertaleModTool
                     initScale = scrollPres.ActualWidth / textureWidth;
             }
 
-            TextureViewbox.LayoutTransform = new MatrixTransform(initScale, 0, 0, initScale, 0, 0);
+            Transform t;
+            double top, left;
+            if (OverriddenPreviewState == default)
+            {
+                t = new MatrixTransform(initScale, 0, 0, initScale, 0, 0);
+                top = 0;
+                left = 0;
+            }
+            else
+            {
+                t = OverriddenPreviewState.Transform;
+                top = OverriddenPreviewState.Top;
+                left = OverriddenPreviewState.Left;
+            }
+
+            TextureViewbox.LayoutTransform = t;
             TextureViewbox.UpdateLayout();
-            TextureScroll.ScrollToTop();
-            TextureScroll.ScrollToLeftEnd();
+            TextureScroll.ScrollToVerticalOffset(top);
+            TextureScroll.ScrollToHorizontalOffset(left);
         }
         private void DataUserControl_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
@@ -118,6 +135,10 @@ namespace UndertaleModTool
         private void DataUserControl_Loaded(object sender, RoutedEventArgs e)
         {
             ScaleTextureToFit();
+        }
+        private void DataUserControl_Unloaded(object sender, RoutedEventArgs e)
+        {
+            OverriddenPreviewState = default;
         }
 
         private void Import_Click(object sender, RoutedEventArgs e)

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -146,12 +146,18 @@ namespace UndertaleModTool
                 RoomRootItem.IsSelected = true;
 
                 ScrollViewer viewer = MainWindow.FindVisualChild<ScrollViewer>(RoomObjectsTree);
-                viewer.ScrollToVerticalOffset(0);
-                viewer.ScrollToHorizontalOffset(0);
+                if (viewer is not null)
+                {
+                    viewer.ScrollToTop();
+                    viewer.ScrollToLeftEnd();
+                }
 
                 RoomGraphics.ClearValue(LayoutTransformProperty);
-                RoomGraphicsScroll.ScrollToVerticalOffset(0);
-                RoomGraphicsScroll.ScrollToHorizontalOffset(0);
+                _ = Dispatcher.InvokeAsync(() =>
+                {
+                    RoomGraphicsScroll.ScrollToTop();
+                    RoomGraphicsScroll.ScrollToLeftEnd();
+                }, DispatcherPriority.ContextIdle);
             }
 
             UndertaleCachedImageLoader.Reset();
@@ -711,9 +717,8 @@ namespace UndertaleModTool
         private void Canvas_MouseWheel(object sender, MouseWheelEventArgs e)
         {
             e.Handled = true;
-            var element = sender as ItemsControl;
             var mousePos = e.GetPosition(RoomGraphics);
-            var transform = element.LayoutTransform as MatrixTransform;
+            var transform = RoomGraphics.LayoutTransform as MatrixTransform;
             var matrix = transform.Matrix;
             var scale = e.Delta >= 0 ? 1.1 : (1.0 / 1.1); // choose appropriate scaling factor
 
@@ -721,7 +726,7 @@ namespace UndertaleModTool
             {
                 matrix.ScaleAtPrepend(scale, scale, mousePos.X, mousePos.Y);
             }
-            element.LayoutTransform = new MatrixTransform(matrix);
+            RoomGraphics.LayoutTransform = new MatrixTransform(matrix);
         }
 
         private void ScrollViewer_ScrollChanged(object sender, ScrollChangedEventArgs e)

--- a/UndertaleModTool/Editors/UndertaleTexturePageItemEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleTexturePageItemEditor.xaml
@@ -65,7 +65,7 @@
         <local:UndertaleObjectReference Grid.Row="3" Grid.Column="1" Margin="3" ObjectReference="{Binding TexturePage}" ObjectType="{x:Type undertale:UndertaleEmbeddedTexture}"/>
 
         <local:ButtonDark Grid.Row="4" Grid.ColumnSpan="3" Width="230" Margin="3"
-                          Click="FindReferencesButton_Click">Find all references of this page item</local:ButtonDark>
+                          Click="FindReferencesButton_Click">Find all references to this page item</local:ButtonDark>
 
         <Viewbox Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" Stretch="Uniform" StretchDirection="DownOnly" Margin="3">
             <Border>

--- a/UndertaleModTool/Editors/UndertaleTexturePageItemEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleTexturePageItemEditor.xaml
@@ -20,6 +20,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <TextBlock Grid.Row="0" Grid.Column="0" Margin="3">Source position/size</TextBlock>
@@ -63,7 +64,10 @@
         <TextBlock Grid.Row="3" Grid.Column="0" Margin="3">Texture</TextBlock>
         <local:UndertaleObjectReference Grid.Row="3" Grid.Column="1" Margin="3" ObjectReference="{Binding TexturePage}" ObjectType="{x:Type undertale:UndertaleEmbeddedTexture}"/>
 
-        <Viewbox Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Stretch="Uniform" StretchDirection="DownOnly" Margin="0,0,0,20">
+        <local:ButtonDark Grid.Row="4" Grid.ColumnSpan="3" Width="230" Margin="3"
+                          Click="FindReferencesButton_Click">Find all references of this page item</local:ButtonDark>
+
+        <Viewbox Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" Stretch="Uniform" StretchDirection="DownOnly" Margin="3">
             <Border>
                 <Border.Background>
                     <DrawingBrush Stretch="None" TileMode="Tile" Viewport="0,0,20,20" ViewportUnits="Absolute">
@@ -80,7 +84,7 @@
             </Border>
         </Viewbox>
 
-        <Grid Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" Margin="3">
+        <Grid Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2" Margin="3,3,3,25">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
@@ -91,7 +95,7 @@
             <local:ButtonDark Grid.Column="3" Content="Export" Click="Export_Click"/>
         </Grid>
 
-        <Viewbox Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2" Stretch="Uniform" StretchDirection="DownOnly"
+        <Viewbox Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2" Stretch="Uniform" StretchDirection="DownOnly"
                  SnapsToDevicePixels="True" RenderOptions.BitmapScalingMode="NearestNeighbor">
             <Grid>
                 <Grid.ColumnDefinitions>

--- a/UndertaleModTool/Editors/UndertaleTexturePageItemEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleTexturePageItemEditor.xaml.cs
@@ -8,6 +8,7 @@ using UndertaleModLib.Util;
 using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Data;
+using UndertaleModTool.Windows;
 
 namespace UndertaleModTool
 {
@@ -71,6 +72,29 @@ namespace UndertaleModTool
                     mainWindow.ShowError("Failed to export file: " + ex.Message, "Failed to export file");
                 }
                 worker.Cleanup();
+            }
+        }
+
+        private void FindReferencesButton_Click(object sender, RoutedEventArgs e)
+        {
+            var obj = (sender as FrameworkElement)?.DataContext;
+            if (obj is not UndertaleTexturePageItem item)
+                return;
+
+            FindReferencesTypesDialog dialog = null;
+            try
+            {
+                dialog = new(item, mainWindow.Data);
+                dialog.ShowDialog();
+            }
+            catch (Exception ex)
+            {
+                mainWindow.ShowError("An error occured in the object references related window.\n" +
+                                     $"Please report this on GitHub.\n\n{ex}");
+            }
+            finally
+            {
+                dialog?.Close();
             }
         }
     }

--- a/UndertaleModTool/Tab.cs
+++ b/UndertaleModTool/Tab.cs
@@ -540,6 +540,18 @@ namespace UndertaleModTool
                     };
                     break;
 
+                case UndertaleEmbeddedTextureEditor textureEditor:
+                    ScrollViewer texturePreviewViewer = textureEditor.TextureScroll;
+                    (double Left, double Top) texturePrevScrollPos = (texturePreviewViewer.HorizontalOffset, texturePreviewViewer.VerticalOffset);
+
+                    LastContentState = new TexturePageTabState()
+                    {
+                        MainScrollPosition = mainScrollPos,
+                        TexturePreviewScrollPosition = texturePrevScrollPos,
+                        TexturePreviewTransform = textureEditor.TextureViewbox.LayoutTransform
+                    };
+                    break;
+
                 default:
                     LastContentState = new()
                     {
@@ -849,6 +861,12 @@ namespace UndertaleModTool
                     }
                     break;
 
+                case TexturePageTabState texturePageTabState:
+                    UndertaleEmbeddedTextureEditor.OverriddenPreviewState = (texturePageTabState.TexturePreviewTransform,
+                                                                             texturePageTabState.TexturePreviewScrollPosition.Left,
+                                                                             texturePageTabState.TexturePreviewScrollPosition.Top);
+                    break;
+
                 default:
                     Debug.WriteLine($"The content state of a tab \"{this}\" is unknown?");
                     break;
@@ -1010,6 +1028,16 @@ namespace UndertaleModTool
         /// Texture pages, sprites, spine sprites, fonts, tilesets.
         /// </remarks>
         public (bool IsExpanded, double ScrollPos, object SelectedItem)[] GroupListsStates;
+    }
+
+    /// <summary>Stores the information about the tab with a texture page.</summary>
+    public class TexturePageTabState : TabContentState
+    {
+        /// <summary>The scroll position of the embedded texture editor preview.</summary>
+        public (double Left, double Top) TexturePreviewScrollPosition;
+
+        /// <summary>The scale of the embedded texture editor preview.</summary>
+        public Transform TexturePreviewTransform;
     }
 
 

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml.cs
@@ -378,7 +378,8 @@ namespace UndertaleModTool.Windows
 
                 item.IsSelected = true;
 
-                if (item.DataContext is Array)
+                // If it's a list header (e.g. "Sounds")
+                if (item.DataContext?.GetType().IsGenericType == true)
                     return;
 
                 Open(highlighted, true);

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml.cs
@@ -51,7 +51,7 @@ namespace UndertaleModTool.Windows
             else if (sourceObj is UndertaleString str)
                 sourceObjName = str.Content;
             else if (sourceObj is ValueTuple<UndertaleBackground, UndertaleBackground.TileID> tileTuple)
-                sourceObjName = $"Tile {tileTuple.Item2} of {tileTuple.Item1.Name.Content}";
+                sourceObjName = $"Tile {tileTuple.Item2.ID} of {tileTuple.Item1.Name.Content}";
             else
                 sourceObjName = sourceObj.GetType().Name;
             this.sourceObjName = sourceObjName;


### PR DESCRIPTION
## Description
1) Fixes #1291, fixes #1292.
2) Fixed the title of GMS 2 tile references ("Tile ***\*ID\**** of *\*tileset name*\*").
3) Added a context menu with "Find all references of this page item" and "Open in new tab" options for embedded texture image; added the "Find all references of this page item" button for the texture page item editor.
4) Made the texture page image zoomable, made it highlight the page items on mouse hover.
5) Changed the texture image hint.
