### PR TITLE
Room object context menu

### DIFF
--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
@@ -88,6 +88,11 @@
                                     <Binding Path="ObjectDefinition.Name.Content" Mode="OneWay" TargetNullValue="?" FallbackValue="EmptyInstance"/>
                                 </MultiBinding>
                             </TextBlock.Text>
+                            <TextBlock.ContextMenu>
+                                <local:ContextMenuDark>
+                                    <MenuItem Header="Delete" Click="MenuItem_Delete_Click"/>
+                                </local:ContextMenuDark>
+                            </TextBlock.ContextMenu>
                         </TextBlock>
                     </DataTemplate>
                     <DataTemplate DataType="{x:Type undertale:UndertaleRoom+Tile}">

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
@@ -103,6 +103,11 @@
                                     <Binding Path="ObjectDefinition.Name.Content" Mode="OneWay" TargetNullValue="?" FallbackValue="EmptyTile"/>
                                 </MultiBinding>
                             </TextBlock.Text>
+                            <TextBlock.ContextMenu>
+                                <local:ContextMenuDark>
+                                    <MenuItem Header="Delete" Click="MenuItem_Delete_Click"/>
+                                </local:ContextMenuDark>
+                            </TextBlock.ContextMenu>
                         </TextBlock>
                     </DataTemplate>
                     <DataTemplate DataType="{x:Type undertale:UndertaleRoom+SpriteInstance}">
@@ -113,6 +118,11 @@
                                     <Binding Path="Sprite.Name.Content" Mode="OneWay" TargetNullValue="?" FallbackValue="EmptySprite"/>
                                 </MultiBinding>
                             </TextBlock.Text>
+                            <TextBlock.ContextMenu>
+                                <local:ContextMenuDark>
+                                    <MenuItem Header="Delete" Click="MenuItem_Delete_Click"/>
+                                </local:ContextMenuDark>
+                            </TextBlock.ContextMenu>
                         </TextBlock>
                     </DataTemplate>
                     <DataTemplate DataType="{x:Type undertale:UndertaleRoom+ParticleSystemInstance}">
@@ -154,6 +164,11 @@
                                             </Style.Triggers>
                                         </Style>
                                     </TextBlock.Style>
+                                    <TextBlock.ContextMenu>
+                                        <local:ContextMenuDark>
+                                            <MenuItem Header="Delete" Click="MenuItem_Delete_Click"/>
+                                        </local:ContextMenuDark>
+                                    </TextBlock.ContextMenu>
                                 </TextBlock>
                             </HierarchicalDataTemplate>
                         </TreeViewItem.ItemTemplate>
@@ -231,6 +246,7 @@
                                             <TextBlock.ContextMenu>
                                                 <local:ContextMenuDark>
                                                     <MenuItem Header="New Object Instance" Click="MenuItem_NewGMS2ObjectInstance_Click"/>
+                                                    <MenuItem Header="Delete" Click="MenuItem_Delete_Click"/>
                                                 </local:ContextMenuDark>
                                             </TextBlock.ContextMenu>
                                         </TextBlock>
@@ -238,7 +254,13 @@
                                 </local:LayerDataTemplateSelector.InstancesDataTemplate>
                                 <local:LayerDataTemplateSelector.TilesDataTemplate>
                                     <HierarchicalDataTemplate ItemTemplateSelector="{x:Null}">
-                                        <TextBlock Text="{Binding LayerName.Content, Mode=OneWay}" Style="{StaticResource LayerItemStyle}"/>
+                                        <TextBlock Text="{Binding LayerName.Content, Mode=OneWay}" Style="{StaticResource LayerItemStyle}">
+                                            <TextBlock.ContextMenu>
+                                                <local:ContextMenuDark>
+                                                    <MenuItem Header="Delete" Click="MenuItem_Delete_Click"/>
+                                                </local:ContextMenuDark>
+                                            </TextBlock.ContextMenu>
+                                        </TextBlock>
                                     </HierarchicalDataTemplate>
                                 </local:LayerDataTemplateSelector.TilesDataTemplate>
                                 <local:LayerDataTemplateSelector.AssetsDataTemplate>
@@ -261,6 +283,7 @@
                                                 <local:ContextMenuDark>
                                                     <MenuItem Header="New Legacy Tile" Click="MenuItem_NewLegacyTile_Click"/>
                                                     <MenuItem Header="New Sprite Instance" Click="MenuItem_NewSprite_Click"/>
+                                                    <MenuItem Header="Delete" Click="MenuItem_Delete_Click"/>
                                                 </local:ContextMenuDark>
                                             </TextBlock.ContextMenu>
                                         </TextBlock>
@@ -268,7 +291,13 @@
                                 </local:LayerDataTemplateSelector.AssetsDataTemplate>
                                 <local:LayerDataTemplateSelector.BackgroundDataTemplate>
                                     <HierarchicalDataTemplate ItemTemplateSelector="{x:Null}">
-                                        <TextBlock Text="{Binding LayerName.Content, Mode=OneWay}" Style="{StaticResource LayerItemStyle}" />
+                                        <TextBlock Text="{Binding LayerName.Content, Mode=OneWay}" Style="{StaticResource LayerItemStyle}">
+                                            <TextBlock.ContextMenu>
+                                                <local:ContextMenuDark>
+                                                    <MenuItem Header="Delete" Click="MenuItem_Delete_Click"/>
+                                                </local:ContextMenuDark>
+                                            </TextBlock.ContextMenu>
+                                        </TextBlock>
                                     </HierarchicalDataTemplate>
                                 </local:LayerDataTemplateSelector.BackgroundDataTemplate>
                                 <local:LayerDataTemplateSelector.EffectDataTemplate>

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -1482,6 +1482,31 @@ namespace UndertaleModTool
         {
             AddGMS1Tile(this.DataContext as UndertaleRoom);
         }
+        private void MenuItem_Delete_Click(Object sender, RoutedEventArgs e)
+        {
+            UndertaleRoom room = this.DataContext as UndertaleRoom;
+            MenuItem menuitem = sender as MenuItem;
+            UndertaleObject obj = menuitem.DataContext as UndertaleObject;
+
+            // We need to check before deleting the object but can only clear the editor after deleting the object
+            bool clearEditor = (obj == (ObjectEditor.Content as UndertaleObject));
+
+            if (obj is GameObject gameObj)
+            {
+                if (mainWindow.IsGMS2 == Visibility.Visible)
+                {
+                    foreach (var layer in room.Layers)
+                        if (layer.InstancesData != null)
+                            layer.InstancesData.Instances.Remove(gameObj);
+                    roomObjDict.Remove(gameObj.InstanceID, out _);
+                }
+
+                room.GameObjects.Remove(gameObj);
+            }
+
+            if (clearEditor)
+                ObjectEditor.Content = null;
+        }
 
         public static void GenerateSpriteCache(UndertaleRoom room)
         {


### PR DESCRIPTION
## Description
<!-- A clear, in-depth description of what the changes are. Reference existing issues and add screenshots if necessary! -->
Fixes #1290 by adding a context menu with a deletion option to all objects in the room editor treeview.
The option is also added to backgrounds, views, layers, sprites and particle system instances.
![image](https://user-images.githubusercontent.com/63353113/231028186-c356c0f8-fe73-4bbd-aa58-7e325d97d19f.png)

### Notes
<!-- Any notes or closing words -->
In future more option can and should probably be added to the context menu such as copy.