### PR TITLE
A lot of font editor improvements.

### DIFF
--- a/UndertaleModLib/Models/UndertaleFont.cs
+++ b/UndertaleModLib/Models/UndertaleFont.cs
@@ -67,12 +67,12 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
     /// <summary>
     /// The x scale this font uses.
     /// </summary>
-    public float ScaleX { get; set; }
+    public float ScaleX { get; set; } = 1;
 
     /// <summary>
     /// The y scale this font uses.
     /// </summary>
-    public float ScaleY { get; set; }
+    public float ScaleY { get; set; } = 1;
 
     /// <summary>
     /// TODO: currently unknown, needs investigation.

--- a/UndertaleModLib/Models/UndertaleFont.cs
+++ b/UndertaleModLib/Models/UndertaleFont.cs
@@ -196,7 +196,7 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
             public static readonly uint ChildObjectsSize = 4;
 
             /// <summary>
-            /// The code point of character for the glyph.
+            /// The code point of the preceeding character.
             /// </summary>
             public short Character;
 

--- a/UndertaleModLib/Models/UndertaleFont.cs
+++ b/UndertaleModLib/Models/UndertaleFont.cs
@@ -75,14 +75,20 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
     public float ScaleY { get; set; }
 
     /// <summary>
-    /// TODO: currently unknown, needs investigation. GM 2022.2 specific?
+    /// TODO: currently unknown, needs investigation.
+    /// Probably this - <see href="https://en.wikipedia.org/wiki/Ascender_(typography)"/> 
     /// </summary>
+    /// <remarks>
+    /// Was introduced in GM 2022.2.
+    /// </remarks>
     public uint Ascender { get; set; }
 
     /// <summary>
     /// A spread value that's used for SDF rendering.
-    /// Introduced in GM 2023.2.
     /// </summary>
+    /// <remarks>
+    /// Was introduced in GM 2023.2.
+    /// </remarks>
     /// <value><c>0</c> if SDF is disabled for this font.</value>
     public uint SDFSpread { get; set; }
 
@@ -92,8 +98,11 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
     public UndertalePointerList<Glyph> Glyphs { get; private set; } = new UndertalePointerList<Glyph>();
 
     /// <summary>
-    /// TODO: currently unknown, needs investigation. Exists since bytecode 17, but seems to be only get checked since 2022.2+.
+    /// The maximum offset from the baseline to the top of the font
     /// </summary>
+    /// <remarks>
+    /// Exists since bytecode 17, but seems to be only get checked in GM 2022.2+.
+    /// </remarks>
     public int AscenderOffset { get; set; }
 
 
@@ -130,12 +139,12 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
 
 
         /// <summary>
-        /// TODO: something kerning related
+        /// The number of pixels to shift right when advancing to the next character.
         /// </summary>
         public short Shift { get; set; }
 
         /// <summary>
-        /// TODO: something kerning related.
+        /// The number of pixels to horizontally offset the rendering of this glyph.
         /// </summary>
         public short Offset { get; set; }
 
@@ -187,27 +196,27 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
             public static readonly uint ChildObjectsSize = 4;
 
             /// <summary>
-            /// TODO: unknown?
+            /// The code point of character for the glyph.
             /// </summary>
-            public short Other;
+            public short Character;
 
             /// <summary>
-            /// TODO: unknown?
+            /// An amount of pixels to add to the existing <see cref="Shift"/>.
             /// </summary>
-            public short Amount;
+            public short ShiftModifier;
 
             /// <inheritdoc />
             public void Serialize(UndertaleWriter writer)
             {
-                writer.Write(Other);
-                writer.Write(Amount);
+                writer.Write(Character);
+                writer.Write(ShiftModifier);
             }
 
             /// <inheritdoc />
             public void Unserialize(UndertaleReader reader)
             {
-                Other = reader.ReadInt16();
-                Amount = reader.ReadInt16();
+                Character = reader.ReadInt16();
+                ShiftModifier = reader.ReadInt16();
             }
 
             /// <summary>
@@ -216,7 +225,7 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
             /// <returns>The copy.</returns>
             public GlyphKerning Clone()
             {
-                return new GlyphKerning() { Amount = this.Amount, Other = this.Other };
+                return new GlyphKerning() { ShiftModifier = this.ShiftModifier, Character = this.Character };
             }
         }
 

--- a/UndertaleModLib/Models/UndertaleFont.cs
+++ b/UndertaleModLib/Models/UndertaleFont.cs
@@ -198,12 +198,12 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
             /// <summary>
             /// The code point of the preceeding character.
             /// </summary>
-            public short Character;
+            public short Character { get; set; }
 
             /// <summary>
             /// An amount of pixels to add to the existing <see cref="Shift"/>.
             /// </summary>
-            public short ShiftModifier;
+            public short ShiftModifier { get; set; }
 
             /// <inheritdoc />
             public void Serialize(UndertaleWriter writer)

--- a/UndertaleModLib/Models/UndertaleFont.cs
+++ b/UndertaleModLib/Models/UndertaleFont.cs
@@ -250,8 +250,6 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
 
             Kerning = new();
         }
-
-        
     }
 
     /// <inheritdoc />

--- a/UndertaleModLib/Models/UndertaleFont.cs
+++ b/UndertaleModLib/Models/UndertaleFont.cs
@@ -209,6 +209,38 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
                 Other = reader.ReadInt16();
                 Amount = reader.ReadInt16();
             }
+
+            /// <summary>
+            /// Makes a copy of this <see cref="GlyphKerning"/>.
+            /// </summary>
+            /// <returns>The copy.</returns>
+            public GlyphKerning Clone()
+            {
+                return new GlyphKerning() { Amount = this.Amount, Other = this.Other };
+            }
+        }
+
+        /// <summary>
+        /// Makes a copy of this <see cref="Glyph"/>.
+        /// </summary>
+        /// <returns>The copy.</returns>
+        public Glyph Clone()
+        {
+            var kerning = new UndertaleSimpleListShort<GlyphKerning>();
+            foreach (var kern in Kerning)
+                kerning.InternalAdd(kern.Clone());
+
+            return new Glyph()
+            {
+                Character = this.Character,
+                SourceX = this.SourceX,
+                SourceY = this.SourceY,
+                SourceWidth = this.SourceWidth,
+                SourceHeight = this.SourceHeight,
+                Shift = this.Shift,
+                Offset = this.Offset,
+                Kerning = kerning
+            };
         }
 
         /// <inheritdoc/>
@@ -218,6 +250,8 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
 
             Kerning = new();
         }
+
+        
     }
 
     /// <inheritdoc />

--- a/UndertaleModTool/Controls/System/DataGridDark.cs
+++ b/UndertaleModTool/Controls/System/DataGridDark.cs
@@ -1,17 +1,33 @@
-﻿using System.Windows;
+﻿using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+using System.Windows.Threading;
 
 namespace UndertaleModTool
 {
     /// <summary>
     /// A standard data grid which compatible with the dark mode.
     /// </summary>
-    public partial class DataGridDark : System.Windows.Controls.DataGrid
+    public partial class DataGridDark : DataGrid
     {
         /// <summary>Initializes a new instance of the data grid.</summary>
         public DataGridDark()
         {
             Loaded += DataGrid_Loaded;
+            AddingNewItem += DataGrid_AddingNewItem;
+        }
+        
+        private void DataGrid_AddingNewItem(object sender, AddingNewItemEventArgs e)
+        {
+            _ = Task.Run(() =>
+            {
+                Dispatcher.Invoke(() =>
+                {
+                    UpdateLayout();
+                    CommitEdit(DataGridEditingUnit.Row, true);
+                });
+            });
         }
 
         private void DataGrid_Loaded(object sender, RoutedEventArgs e)
@@ -21,6 +37,25 @@ namespace UndertaleModTool
                 return;
 
             pres.SetResourceReference(ForegroundProperty, "CustomTextBrush");
+        }
+
+        protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e)
+        {
+            if (e.Property == VisibilityProperty)
+            {
+                if ((Visibility)e.NewValue == Visibility.Visible)
+                {
+                    base.OnPropertyChanged(e);
+                    UpdateLayout();
+
+                    var pres = MainWindow.FindVisualChild<DataGridColumnHeadersPresenter>(this);
+                    pres?.SetResourceReference(ForegroundProperty, "CustomTextBrush");
+
+                    return;
+                }
+            }
+
+            base.OnPropertyChanged(e);
         }
     }
 }

--- a/UndertaleModTool/Controls/UndertaleTexturePageItemDisplay.xaml
+++ b/UndertaleModTool/Controls/UndertaleTexturePageItemDisplay.xaml
@@ -10,15 +10,15 @@
     <UserControl.Resources>
         <local:UndertaleCachedImageLoader x:Key="UndertaleCachedImageLoader"/>
     </UserControl.Resources>
-    <Canvas Width="{Binding BoundingWidth, Mode=OneWay}" Height="{Binding BoundingHeight, Mode=OneWay}" SnapsToDevicePixels="True">
+    <Canvas Width="{Binding BoundingWidth, Mode=OneWay}" Height="{Binding BoundingHeight, Mode=OneWay}"
+            SnapsToDevicePixels="True">
         <Border Canvas.Left="{Binding TargetX, Mode=OneWay}" Canvas.Top="{Binding TargetY, Mode=OneWay}"
                 Width="{Binding TargetWidth, Mode=OneWay}" Height="{Binding TargetHeight, Mode=OneWay}"
-                BorderBrush="DarkCyan" BorderThickness="1" Name="RenderAreaBorder" SnapsToDevicePixels="True" RenderOptions.BitmapScalingMode="NearestNeighbor">
+                BorderBrush="DarkCyan" BorderThickness="1" Name="RenderAreaBorder" RenderOptions.BitmapScalingMode="NearestNeighbor">
             <Border.Background>
                 <ImageBrush
                     ImageSource="{Binding ., Mode=OneWay, Converter={StaticResource UndertaleCachedImageLoader}, ConverterParameter=nocache}"
-                    TileMode="None"
-                    Stretch="UniformToFill">
+                    TileMode="None" Stretch="None">
                 </ImageBrush>
             </Border.Background>
         </Border>

--- a/UndertaleModTool/Controls/UndertaleTexturePageItemDisplay.xaml.cs
+++ b/UndertaleModTool/Controls/UndertaleTexturePageItemDisplay.xaml.cs
@@ -22,6 +22,26 @@ namespace UndertaleModTool
     /// </summary>
     public partial class UndertaleTexturePageItemDisplay : UserControl
     {
+        public static readonly DependencyProperty DisplayBorderProperty =
+            DependencyProperty.Register("DisplayBorder", typeof(bool),
+                typeof(UndertaleTexturePageItemDisplay),
+                new FrameworkPropertyMetadata(true,
+                    FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, (sender, e) =>
+                    {
+                        var inst = sender as UndertaleTexturePageItemDisplay;
+                        if (inst is null)
+                            return;
+                        if (e.NewValue is not bool val)
+                            return;
+
+                        inst.RenderAreaBorder.BorderThickness = new Thickness(val ? 1 : 0);
+                    }));
+        public bool DisplayBorder
+        {
+            get { return (bool)GetValue(DisplayBorderProperty); }
+            set { SetValue(DisplayBorderProperty, value); }
+        }
+
         public UndertaleTexturePageItemDisplay()
         {
             InitializeComponent();

--- a/UndertaleModTool/Converters/IsVersionAtLeastConverter.cs
+++ b/UndertaleModTool/Converters/IsVersionAtLeastConverter.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Windows;
+using System.Windows.Data;
+
+namespace UndertaleModTool
+{
+    public class IsVersionAtLeastConverter : IValueConverter
+    {
+        private static readonly MainWindow mainWindow = Application.Current.MainWindow as MainWindow;
+        private static readonly Regex versionRegex = new(@"(\d+)\.(\d+)(?:\.(\d+))?(?:\.(\d+))?", RegexOptions.Compiled);
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (mainWindow.Data?.GeneralInfo is null
+                || parameter is not string verStr
+                || verStr.Length == 0)
+                return Visibility.Hidden;
+
+            var ver = versionRegex.Match(verStr);
+            if (!ver.Success)
+                return Visibility.Hidden;
+            try
+            {
+                uint major = uint.Parse(ver.Groups[1].Value);
+                uint minor = uint.Parse(ver.Groups[2].Value);
+                uint release = 0;
+                uint build = 0;
+                if (ver.Groups[3].Value != "")
+                    release = uint.Parse(ver.Groups[3].Value);
+                if (ver.Groups[4].Value != "")
+                    release = uint.Parse(ver.Groups[4].Value);
+
+                if (mainWindow.Data.IsVersionAtLeast(major, minor, release, build))
+                    return Visibility.Visible;
+                else
+                    return Visibility.Collapsed;
+            }
+            catch
+            {
+                return Visibility.Hidden;
+            }
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/UndertaleModTool/Editors/UndertaleBackgroundEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleBackgroundEditor.xaml
@@ -20,8 +20,10 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
+        <Grid.Resources>
+            <local:IsVersionAtLeastConverter x:Key="IsVersionAtLeastConverter"/>
+        </Grid.Resources>
 
         <TextBlock Grid.Row="0" Grid.Column="0" Margin="3">Name</TextBlock>
         <local:UndertaleStringReference Grid.Row="0" Grid.Column="1" Margin="3" ObjectReference="{Binding Name}"/>
@@ -36,12 +38,13 @@
         <TextBlock Grid.Row="4" Grid.Column="0" Margin="3">Texture</TextBlock>
         <local:UndertaleObjectReference Grid.Row="4" Grid.Column="1" Margin="3" ObjectReference="{Binding Texture}" ObjectType="{x:Type undertale:UndertaleTexturePageItem}"/>
 
-        <Grid Grid.Row="5" Grid.ColumnSpan="2" Margin="0" Visibility="{Binding DataContext.IsGMS2, Mode=OneTime, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}">
+        <Grid Grid.Row="5" Grid.ColumnSpan="2" Margin="0" Visibility="{Binding Mode=OneTime, Converter={StaticResource IsVersionAtLeastConverter}, ConverterParameter=2.0}">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="1*"/>
                 <ColumnDefinition Width="3*"/>
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
@@ -123,15 +126,26 @@
                     </DataGridTemplateColumn>
                 </DataGrid.Columns>
             </local:DataGridDark>
+
+            <TextBlock Grid.Row="11" Grid.ColumnSpan="2" Margin="3" HorizontalAlignment="Center" Foreground="DarkGray" FontStyle="Italic" TextWrapping="Wrap" TextAlignment="Center">
+                Hint: You can click on any tile region below to highlight its ID above.
+            </TextBlock>
         </Grid>
 
-        <TextBlock Grid.Row="6" Grid.ColumnSpan="2" Margin="3" HorizontalAlignment="Center" Foreground="DarkGray" FontStyle="Italic" TextWrapping="Wrap" TextAlignment="Center">
-                Hint: You can click on any tile region below to highlight its ID above.
-        </TextBlock>
-        <Viewbox Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2" Stretch="Uniform" StretchDirection="DownOnly">
-            <Canvas Name="BGTexture" Cursor="Hand"
+        <Viewbox Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2" Stretch="Uniform" StretchDirection="DownOnly">
+            <Canvas Name="BGTexture"
                     Width="{Binding Texture.BoundingWidth, Mode=OneWay}" Height="{Binding Texture.BoundingHeight, Mode=OneWay}"
                     MouseLeftButtonDown="BGTexture_MouseLeftButtonDown" PreviewMouseRightButtonDown="BGTexture_PreviewMouseRightButtonDown">
+                <Canvas.Style>
+                    <Style TargetType="Canvas">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding Mode=OneTime, Converter={StaticResource IsVersionAtLeastConverter}, ConverterParameter=2.0}"
+                                         Value="Visible">
+                                <Setter Property="Cursor" Value="Hand"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Canvas.Style>
                 <Border>
                     <Border.Background>
                         <DrawingBrush Stretch="None" TileMode="Tile" Viewport="0,0,20,20" ViewportUnits="Absolute">

--- a/UndertaleModTool/Editors/UndertaleBackgroundEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleBackgroundEditor.xaml
@@ -20,6 +20,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <TextBlock Grid.Row="0" Grid.Column="0" Margin="3">Name</TextBlock>
@@ -124,8 +125,12 @@
             </local:DataGridDark>
         </Grid>
 
-        <Viewbox Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2" Stretch="Uniform" StretchDirection="DownOnly">
-            <Canvas Name="BGTexture" Width="{Binding Texture.BoundingWidth, Mode=OneWay}" Height="{Binding Texture.BoundingHeight, Mode=OneWay}"
+        <TextBlock Grid.Row="6" Grid.ColumnSpan="2" Margin="3" HorizontalAlignment="Center" Foreground="DarkGray" FontStyle="Italic" TextWrapping="Wrap" TextAlignment="Center">
+                Hint: You can click on any tile region below to highlight its ID above.
+        </TextBlock>
+        <Viewbox Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2" Stretch="Uniform" StretchDirection="DownOnly">
+            <Canvas Name="BGTexture" Cursor="Hand"
+                    Width="{Binding Texture.BoundingWidth, Mode=OneWay}" Height="{Binding Texture.BoundingHeight, Mode=OneWay}"
                     MouseLeftButtonDown="BGTexture_MouseLeftButtonDown" PreviewMouseRightButtonDown="BGTexture_PreviewMouseRightButtonDown">
                 <Border>
                     <Border.Background>

--- a/UndertaleModTool/Editors/UndertaleBackgroundEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleBackgroundEditor.xaml.cs
@@ -65,25 +65,8 @@ namespace UndertaleModTool
             }
         }
 
-        private bool SelectTileRegion(object sender, MouseButtonEventArgs e)
+        private bool ScrollTileIntoView(int tileIndex)
         {
-            if (!TileRectangle.IsVisible) // MainWindow.IsGMS2
-                return false;
-
-            Point pos = e.GetPosition((IInputElement)sender);
-            UndertaleBackground bg = DataContext as UndertaleBackground;
-            int x = (int)((int)pos.X / (bg.GMS2TileWidth + (2 * bg.GMS2OutputBorderX)));
-            int y = (int)((int)pos.Y / (bg.GMS2TileHeight + (2 * bg.GMS2OutputBorderY)));
-            int tileID = (int)((bg.GMS2TileColumns * y) + x);
-            if (tileID > bg.GMS2TileCount - 1)
-                return false;
-
-            e.Handled = true;
-
-            int tileIndex = bg.GMS2TileIds.FindIndex(x => x.ID == tileID);
-            if (tileIndex == -1)
-                return false;
-
             ScrollViewer tileListViewer = MainWindow.FindVisualChild<ScrollViewer>(TileIdList);
             if (tileListViewer is null)
             {
@@ -103,6 +86,27 @@ namespace UndertaleModTool
             dataEditorViewer.ScrollToVerticalOffset(initOffset);
 
             return true;
+        }
+        private bool SelectTileRegion(object sender, MouseButtonEventArgs e)
+        {
+            if (!TileRectangle.IsVisible) // MainWindow.IsGMS2
+                return false;
+
+            Point pos = e.GetPosition((IInputElement)sender);
+            UndertaleBackground bg = DataContext as UndertaleBackground;
+            int x = (int)((int)pos.X / (bg.GMS2TileWidth + (2 * bg.GMS2OutputBorderX)));
+            int y = (int)((int)pos.Y / (bg.GMS2TileHeight + (2 * bg.GMS2OutputBorderY)));
+            int tileID = (int)((bg.GMS2TileColumns * y) + x);
+            if (tileID > bg.GMS2TileCount - 1)
+                return false;
+
+            e.Handled = true;
+
+            int tileIndex = bg.GMS2TileIds.FindIndex(x => x.ID == tileID);
+            if (tileIndex == -1)
+                return false;
+
+            return ScrollTileIntoView(tileIndex);
         }
         private void BGTexture_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {

--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml
@@ -11,7 +11,7 @@
     <UserControl.Resources>
         <local:BooleanToVisibilityConverter x:Key="BoolFalseToVisConverter" local:trueValue="Collapsed" local:falseValue="Visible"/>
         <local:TextureLoadedWrapper x:Key="TextureLoadedWrapper"/>
-        <local:GeneratedMipsWrapper x:Key="GeneratedMipsWrapper"/>
+        <local:IsVersionAtLeastConverter x:Key="IsVersionAtLeastConverter"/>
     </UserControl.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
@@ -29,10 +29,10 @@
         <TextBlock Grid.Row="0" Grid.Column="0" Margin="3">Scaled</TextBlock>
         <local:TextBoxDark Grid.Row="0" Grid.Column="1" Margin="3" Text="{Binding Scaled}"/>
 
-        <TextBlock Grid.Row="1" Grid.Column="0" Margin="3"
-                   Visibility="{Binding Data, Mode=OneTime, Converter={StaticResource GeneratedMipsWrapper}, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}">Generated mips</TextBlock>
+        <TextBlock Grid.Row="1" Grid.Column="0" Margin="3" Text="Generated mips"
+                   Visibility="{Binding Mode=OneTime, Converter={StaticResource IsVersionAtLeastConverter}, ConverterParameter=2.0.6}"/>
         <local:TextBoxDark Grid.Row="1" Grid.Column="1" Margin="3" Text="{Binding GeneratedMips}"
-                 Visibility="{Binding Data, Mode=OneTime, Converter={StaticResource GeneratedMipsWrapper}, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}"/>
+                 Visibility="{Binding Mode=OneTime, Converter={StaticResource IsVersionAtLeastConverter}, ConverterParameter=2.0.6}"/>
 
         <TextBlock Grid.Row="2" Grid.Column="0" Margin="3">Size</TextBlock>
         <Grid Grid.Row="2" Grid.Column="1">

--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
@@ -327,20 +327,4 @@ namespace UndertaleModTool
             throw new NotImplementedException();
         }
     }
-
-    public class GeneratedMipsWrapper : IValueConverter
-    {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            if (value is not UndertaleData data)
-                return Visibility.Collapsed;
-
-            return data.IsVersionAtLeast(2, 0, 6) ? Visibility.Visible : Visibility.Collapsed;
-        }
-
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            throw new NotImplementedException();
-        }
-    }
 }

--- a/UndertaleModTool/Editors/UndertaleFontEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleFontEditor.xaml
@@ -88,12 +88,24 @@
         <local:TextBoxDark Grid.Row="10" Grid.Column="1" Margin="3" Text="{Binding SDFSpread}"/>
 
         <Viewbox Grid.Row="11" Grid.ColumnSpan="2" Margin="3,30,3,3" Stretch="Uniform" StretchDirection="DownOnly">
-            <Border>
-                <Border.Background>
+            <Grid>
+                <Grid.Background>
                     <SolidColorBrush Color="Black"/>
-                </Border.Background>
+                </Grid.Background>
                 <local:UndertaleTexturePageItemDisplay DataContext="{Binding Texture, Mode=OneWay}"/>
-            </Border>
+
+                <Canvas Name="GlyphsOverlayCanvas" UseLayoutRounding="True" SnapsToDevicePixels="True">
+                    <Rectangle Name="GlyphRectangle" Stroke="#FFB23131" Panel.ZIndex="50" StrokeThickness="1"
+                           Canvas.Left="{Binding SelectedItem.SourceX, ElementName=GlyphsGrid, Mode=OneWay, TargetNullValue=-1, FallbackValue=-1}"
+                           Canvas.Top="{Binding SelectedItem.SourceY, ElementName=GlyphsGrid, Mode=OneWay, TargetNullValue=-1, FallbackValue=-1}"
+                           Width="{Binding SelectedItem.SourceWidth, ElementName=GlyphsGrid, Mode=OneWay, TargetNullValue=0, FallbackValue=0}"
+                           Height="{Binding SelectedItem.SourceHeight, ElementName=GlyphsGrid, Mode=OneWay, TargetNullValue=0, FallbackValue=0}">
+                        <Rectangle.Fill>
+                            <SolidColorBrush Color="Red" Opacity=".1"/>
+                        </Rectangle.Fill>
+                    </Rectangle>
+                </Canvas>
+            </Grid>
         </Viewbox>
 
         <TextBlock Grid.Row="12" Grid.Column="0" Margin="3">Glyphs:</TextBlock>

--- a/UndertaleModTool/Editors/UndertaleFontEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleFontEditor.xaml
@@ -29,6 +29,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <TextBlock Grid.Row="0" Grid.Column="0" Margin="3">Name</TextBlock>
@@ -87,8 +88,11 @@
         <TextBlock Grid.Row="10" Grid.Column="0" Margin="3">SDF spread value</TextBlock>
         <local:TextBoxDark Grid.Row="10" Grid.Column="1" Margin="3" Text="{Binding SDFSpread}"/>
 
-        <Viewbox Grid.Row="11" Grid.ColumnSpan="2" Margin="3,30,3,3" Stretch="Uniform" StretchDirection="DownOnly">
-            <Grid>
+        <TextBlock Grid.Row="11" Grid.ColumnSpan="2" Margin="3,30,3,3" HorizontalAlignment="Center" Foreground="DarkGray" FontStyle="Italic" TextWrapping="Wrap" TextAlignment="Center">
+                Hint: You can click on any glyph here to highlight it in the "Glyphs".
+        </TextBlock>
+        <Viewbox Grid.Row="12" Grid.ColumnSpan="2" Margin="3" Stretch="Uniform" StretchDirection="DownOnly">
+            <Grid MouseDown="Grid_MouseDown" Cursor="Hand">
                 <Grid.Background>
                     <SolidColorBrush Color="Black"/>
                 </Grid.Background>
@@ -108,8 +112,8 @@
             </Grid>
         </Viewbox>
 
-        <TextBlock Grid.Row="12" Grid.Column="0" Margin="3">Glyphs:</TextBlock>
-        <local:DataGridDark Grid.Row="13" Grid.ColumnSpan="2" MaxHeight="370" Margin="3" x:Name="GlyphsGrid" ItemsSource="{Binding Glyphs, Mode=OneWay}"
+        <TextBlock Grid.Row="13" Grid.Column="0" Margin="3">Glyphs:</TextBlock>
+        <local:DataGridDark Grid.Row="14" Grid.ColumnSpan="2" MaxHeight="370" Margin="3" x:Name="GlyphsGrid" ItemsSource="{Binding Glyphs, Mode=OneWay}"
                             AutoGenerateColumns="False" CanUserAddRows="True" CanUserDeleteRows="True" HorizontalGridLinesBrush="LightGray" VerticalGridLinesBrush="LightGray" HeadersVisibility="Column" SelectionMode="Single" SelectionUnit="FullRow"
                             ScrollViewer.CanContentScroll="True"
                             VirtualizingPanel.IsVirtualizing="True"
@@ -182,10 +186,10 @@
             </DataGrid.Columns>
         </local:DataGridDark>
 
-        <TextBlock Grid.Row="14" Grid.Column="0" Grid.ColumnSpan="2" Margin="3" TextWrapping="Wrap" HorizontalAlignment="Center">
+        <TextBlock Grid.Row="15" Grid.Column="0" Grid.ColumnSpan="2" Margin="3" TextWrapping="Wrap" HorizontalAlignment="Center">
             Note that the glyphs need to be specified in ascending order.<LineBreak/>
             Press the button below to sort them appropriately.
         </TextBlock>
-        <local:ButtonDark Grid.Row="15" Grid.Column="0" Grid.ColumnSpan="2" Margin="3" Click="Button_Sort_Click">Sort glyphs</local:ButtonDark>
+        <local:ButtonDark Grid.Row="16" Grid.Column="0" Grid.ColumnSpan="2" Margin="3" Click="Button_Sort_Click">Sort glyphs</local:ButtonDark>
     </Grid>
 </local:DataUserControl>

--- a/UndertaleModTool/Editors/UndertaleFontEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleFontEditor.xaml
@@ -87,7 +87,7 @@
         <TextBlock Grid.Row="10" Grid.Column="0" Margin="3">SDF spread value</TextBlock>
         <local:TextBoxDark Grid.Row="10" Grid.Column="1" Margin="3" Text="{Binding SDFSpread}"/>
 
-        <Viewbox Grid.Row="11" Grid.Column="1" Stretch="Uniform" StretchDirection="DownOnly">
+        <Viewbox Grid.Row="11" Grid.ColumnSpan="2" Margin="3,30,3,3" Stretch="Uniform" StretchDirection="DownOnly">
             <Border>
                 <Border.Background>
                     <SolidColorBrush Color="Black"/>
@@ -96,7 +96,7 @@
             </Border>
         </Viewbox>
 
-        <TextBlock Grid.Row="12" Grid.Column="0" Margin="3,30,3,3">Glyphs:</TextBlock>
+        <TextBlock Grid.Row="12" Grid.Column="0" Margin="3">Glyphs:</TextBlock>
         <local:DataGridDark Grid.Row="13" Grid.ColumnSpan="2" MaxHeight="370" Margin="3" x:Name="GlyphsGrid" ItemsSource="{Binding Glyphs, Mode=OneWay}"
                             AutoGenerateColumns="False" CanUserAddRows="True" CanUserDeleteRows="True" HorizontalGridLinesBrush="LightGray" VerticalGridLinesBrush="LightGray" HeadersVisibility="Column" SelectionMode="Single" SelectionUnit="FullRow"
                             ScrollViewer.CanContentScroll="True"

--- a/UndertaleModTool/Editors/UndertaleFontEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleFontEditor.xaml
@@ -8,6 +8,9 @@
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800" d:DataContext="{d:DesignInstance undertale:UndertaleFont}">
     <Grid>
+        <Grid.Resources>
+            <local:CharConverter x:Key="CharConverter"/>
+        </Grid.Resources>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="1*"/>
             <ColumnDefinition Width="3*"/>
@@ -147,7 +150,9 @@
                 <DataGridTemplateColumn Header="Char" Width="*">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <local:TextBoxDark Text="{Binding Character, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" Margin="20,0,0,0" />
+                            <local:TextBoxDark Text="{Binding Character, Mode=TwoWay, UpdateSourceTrigger=LostFocus, Converter={StaticResource CharConverter}}"
+                                               Margin="20,0,0,0" MaxLength="1"
+                                               ToolTip="{Binding Character, Mode=OneWay}" ToolTipService.InitialShowDelay="250"/>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>

--- a/UndertaleModTool/Editors/UndertaleFontEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleFontEditor.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -80,6 +81,34 @@ namespace UndertaleModTool
                 dataEditorViewer.UpdateLayout();
                 dataEditorViewer.ScrollToVerticalOffset(initOffset);
             }
+        }
+    }
+
+    public class CharConverter : IValueConverter
+    {
+        private static readonly MainWindow mainWindow = Application.Current.MainWindow as MainWindow;
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is not ushort charNum)
+                return "(error)";
+
+            return System.Convert.ToChar(charNum);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is not string charStr || charStr.Length == 0)
+                return new ValidationResult(false, null);
+
+            uint charNum = charStr[0];
+            if (charNum > ushort.MaxValue)
+            {
+                mainWindow.ShowError("The character code is greater than the maximum (65535)");
+                return new ValidationResult(false, null);
+            }
+
+            return (ushort)charNum;
         }
     }
 }

--- a/UndertaleModTool/Editors/UndertaleFontEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleFontEditor.xaml.cs
@@ -21,6 +21,8 @@ namespace UndertaleModTool
     /// </summary>
     public partial class UndertaleFontEditor : DataUserControl
     {
+        private static readonly MainWindow mainWindow = Application.Current.MainWindow as MainWindow;
+
         public UndertaleFontEditor()
         {
             InitializeComponent();
@@ -36,6 +38,48 @@ namespace UndertaleModTool
             font.Glyphs.Clear();
             foreach (var glyph in copy)
                 font.Glyphs.Add(glyph);
+        }
+
+        private void Grid_MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (DataContext is not UndertaleFont font)
+                return;
+
+            var pos = e.GetPosition(sender as IInputElement);
+            for (int i = 0; i < font.Glyphs.Count; i++)
+            {
+                var glyph = font.Glyphs[i];
+
+                if (pos.X > glyph.SourceX && pos.X < glyph.SourceX + glyph.SourceWidth
+                    && pos.Y > glyph.SourceY && pos.Y < glyph.SourceY + glyph.SourceHeight)
+                {
+                    GlyphsGrid.SelectedItem = glyph;
+
+                    // "ScrollIntoView(glyph)" is noticeably slower
+                    ScrollGlyphIntoView(i);
+                    break;
+                }
+            }
+        }
+        private void ScrollGlyphIntoView(int glyphIndex)
+        {
+            ScrollViewer glyphListViewer = MainWindow.FindVisualChild<ScrollViewer>(GlyphsGrid);
+            if (glyphListViewer is null)
+            {
+                mainWindow.ShowError("Cannot find the glyphs table scroll viewer.");
+                return;
+            }
+            glyphListViewer.ScrollToVerticalOffset(glyphIndex + 1 - (glyphListViewer.ViewportHeight / 2)); // DataGrid offset is logical
+            glyphListViewer.UpdateLayout();
+
+            ScrollViewer dataEditorViewer = mainWindow.DataEditor.Parent as ScrollViewer;
+            if (dataEditorViewer is not null)
+            {
+                double initOffset = dataEditorViewer.VerticalOffset;
+
+                dataEditorViewer.UpdateLayout();
+                dataEditorViewer.ScrollToVerticalOffset(initOffset);
+            }
         }
     }
 }

--- a/UndertaleModTool/Editors/UndertaleFontEditor/EditGlyphRectangleWindow.xaml
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/EditGlyphRectangleWindow.xaml
@@ -7,18 +7,19 @@
         xmlns:utmt="clr-namespace:UndertaleModTool"
         xmlns:undertale="clr-namespace:UndertaleModLib.Models;assembly=UndertaleModLib"
         mc:Ignorable="d"
-        Title="Edit a font glyph rectangle" Name="editGlyphRectangleWindow" Height="450" Width="800"
-        Loaded="Window_Loaded" IsVisibleChanged="Window_IsVisibleChanged">
+        Title="Edit a font glyph rectangle" Name="editGlyphRectangleWindow" Height="575" Width="800"
+        Loaded="Window_Loaded" IsVisibleChanged="Window_IsVisibleChanged" DataContext="{Binding RelativeSource={RelativeSource Self}}">
     <Grid>
         <Grid.Resources>
             <utmt:EqualityConverter x:Key="EqualityConverter"/>
         </Grid.Resources>
         <Grid.RowDefinitions>
+            <RowDefinition Height="16px"/>
+            <RowDefinition Height="450px"/>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="350px"/>
         </Grid.RowDefinitions>
 
-        <ScrollViewer Name="TextureScroll" Grid.Row="1" Grid.Column="0" Margin="3"
+        <ScrollViewer Name="TextureScroll" Grid.Row="1" Margin="3"
                       HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Visible"
                       PreviewMouseWheel="TextureScroll_MouseWheel" ScrollChanged="TextureScroll_ScrollChanged">
             <ScrollViewer.Background>
@@ -26,18 +27,18 @@
             </ScrollViewer.Background>
             <Viewbox Grid.Row="1" Name="TextureViewbox"
                      Stretch="Uniform" StretchDirection="DownOnly"
-                     SnapsToDevicePixels="True" RenderOptions.BitmapScalingMode="NearestNeighbor" UseLayoutRounding="True">
+                     SnapsToDevicePixels="True" RenderOptions.BitmapScalingMode="NearestNeighbor" UseLayoutRounding="True"
+                     MouseLeftButtonDown="TextureViewbox_MouseLeftButtonDown" MouseMove="TextureViewbox_MouseMove" MouseLeftButtonUp="TextureViewbox_MouseLeftButtonUp">
                 <Grid>
                     <Grid.Background>
                         <SolidColorBrush Color="Black"/>
                     </Grid.Background>
 
-                    <utmt:UndertaleTexturePageItemDisplay DataContext="{Binding Texture, Mode=OneWay}" DisplayBorder="False"/>
+                    <utmt:UndertaleTexturePageItemDisplay DataContext="{Binding Font.Texture, Mode=OneWay}" DisplayBorder="False"/>
                     <ItemsControl ItemsSource="{Binding Glyphs, Mode=OneWay}">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
-                                <Canvas IsItemsHost="True"
-                                        MouseLeftButtonDown="Canvas_MouseLeftButtonDown" MouseMove="Canvas_MouseMove"/>
+                                <Canvas IsItemsHost="True" Loaded="Canvas_Loaded"/>
                             </ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemContainerStyle>
@@ -54,7 +55,7 @@
                             
                             <DataTemplate x:Key="selectedGlyphTemplate">
                                 <Rectangle Width="{Binding SourceWidth, Mode=OneWay}" Height="{Binding SourceHeight, Mode=OneWay}"
-                                           StrokeThickness="1">
+                                           StrokeThickness="1" Panel.ZIndex="1">
                                     <Rectangle.Stroke>
                                         <SolidColorBrush Color="OrangeRed" Opacity="0.5"/>
                                     </Rectangle.Stroke>
@@ -65,7 +66,7 @@
                             </DataTemplate>
                             <DataTemplate x:Key="glyphTemplate">
                                 <Rectangle Width="{Binding SourceWidth, Mode=OneWay}" Height="{Binding SourceHeight, Mode=OneWay}"
-                                           StrokeThickness="1">
+                                           StrokeThickness="1" Panel.ZIndex="0">
                                     <Rectangle.Stroke>
                                         <SolidColorBrush Color="Yellow" Opacity="0.25"/>
                                     </Rectangle.Stroke>
@@ -99,6 +100,8 @@
                 </Grid>
             </Viewbox>
         </ScrollViewer>
-        
+
+        <utmt:ButtonDark Grid.Row="2" Margin="3,13,3,3" Click="SaveButton_Click" Width="150" Height="40"
+                         FontSize="16">Save changes</utmt:ButtonDark>
     </Grid>
 </Window>

--- a/UndertaleModTool/Editors/UndertaleFontEditor/EditGlyphRectangleWindow.xaml
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/EditGlyphRectangleWindow.xaml
@@ -1,0 +1,104 @@
+﻿<Window x:Class="UndertaleModTool.Editors.UndertaleFontEditor.EditGlyphRectangleWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:UndertaleModTool.Editors.UndertaleFontEditor"
+        xmlns:utmt="clr-namespace:UndertaleModTool"
+        xmlns:undertale="clr-namespace:UndertaleModLib.Models;assembly=UndertaleModLib"
+        mc:Ignorable="d"
+        Title="Edit a font glyph rectangle" Name="editGlyphRectangleWindow" Height="450" Width="800"
+        Loaded="Window_Loaded" IsVisibleChanged="Window_IsVisibleChanged">
+    <Grid>
+        <Grid.Resources>
+            <utmt:EqualityConverter x:Key="EqualityConverter"/>
+        </Grid.Resources>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="350px"/>
+        </Grid.RowDefinitions>
+
+        <ScrollViewer Name="TextureScroll" Grid.Row="1" Grid.Column="0" Margin="3"
+                      HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Visible"
+                      PreviewMouseWheel="TextureScroll_MouseWheel" ScrollChanged="TextureScroll_ScrollChanged">
+            <ScrollViewer.Background>
+                <DynamicResource ResourceKey="{x:Static SystemColors.MenuBrushKey}"/>
+            </ScrollViewer.Background>
+            <Viewbox Grid.Row="1" Name="TextureViewbox"
+                     Stretch="Uniform" StretchDirection="DownOnly"
+                     SnapsToDevicePixels="True" RenderOptions.BitmapScalingMode="NearestNeighbor" UseLayoutRounding="True">
+                <Grid>
+                    <Grid.Background>
+                        <SolidColorBrush Color="Black"/>
+                    </Grid.Background>
+
+                    <utmt:UndertaleTexturePageItemDisplay DataContext="{Binding Texture, Mode=OneWay}" DisplayBorder="False"/>
+                    <ItemsControl ItemsSource="{Binding Glyphs, Mode=OneWay}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <Canvas IsItemsHost="True"
+                                        MouseLeftButtonDown="Canvas_MouseLeftButtonDown" MouseMove="Canvas_MouseMove"/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemContainerStyle>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="Canvas.Left" Value="{Binding SourceX, Mode=OneWay}"/>
+                                <Setter Property="Canvas.Top" Value="{Binding SourceY, Mode=OneWay}"/>
+                            </Style>
+                        </ItemsControl.ItemContainerStyle>
+                        <ItemsControl.Resources>
+                            <Style TargetType="TextBlock">
+                                <!-- Hide "{NewItemPlaceholder}" -->
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                            </Style>
+                            
+                            <DataTemplate x:Key="selectedGlyphTemplate">
+                                <Rectangle Width="{Binding SourceWidth, Mode=OneWay}" Height="{Binding SourceHeight, Mode=OneWay}"
+                                           StrokeThickness="1">
+                                    <Rectangle.Stroke>
+                                        <SolidColorBrush Color="OrangeRed" Opacity="0.5"/>
+                                    </Rectangle.Stroke>
+                                    <Rectangle.Fill>
+                                        <SolidColorBrush Color="Red" Opacity="0.1"/>
+                                    </Rectangle.Fill>
+                                </Rectangle>
+                            </DataTemplate>
+                            <DataTemplate x:Key="glyphTemplate">
+                                <Rectangle Width="{Binding SourceWidth, Mode=OneWay}" Height="{Binding SourceHeight, Mode=OneWay}"
+                                           StrokeThickness="1">
+                                    <Rectangle.Stroke>
+                                        <SolidColorBrush Color="Yellow" Opacity="0.25"/>
+                                    </Rectangle.Stroke>
+                                    <Rectangle.Fill>
+                                        <SolidColorBrush Color="Yellow" Opacity="0.05"/>
+                                    </Rectangle.Fill>
+                                </Rectangle>
+                            </DataTemplate>
+                            <Style x:Key="contentControlStyle" TargetType="ContentControl">
+                                <Setter Property="ContentTemplate" Value="{StaticResource glyphTemplate}"/>
+                                <Style.Triggers>
+                                    <DataTrigger Value="True">
+                                        <DataTrigger.Binding>
+                                            <MultiBinding Converter="{StaticResource EqualityConverter}" Mode="OneWay">
+                                                <Binding Mode="OneTime"/>
+                                                <Binding Path="SelectedGlyph" Mode="OneWay" Source="{x:Reference editGlyphRectangleWindow}"/>
+                                            </MultiBinding>
+                                        </DataTrigger.Binding>
+                                        <Setter Property="ContentTemplate"
+                                                Value="{StaticResource selectedGlyphTemplate}"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                            
+                            <DataTemplate DataType="{x:Type undertale:UndertaleFont+Glyph}">
+                                <ContentControl Name="RectangleContent" Content="{Binding}"
+                                                Style="{StaticResource contentControlStyle}"/>
+                            </DataTemplate>
+                        </ItemsControl.Resources>
+                    </ItemsControl>
+                </Grid>
+            </Viewbox>
+        </ScrollViewer>
+        
+    </Grid>
+</Window>

--- a/UndertaleModTool/Editors/UndertaleFontEditor/EditGlyphRectangleWindow.xaml
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/EditGlyphRectangleWindow.xaml
@@ -60,19 +60,72 @@
                             </Style>
                             
                             <DataTemplate x:Key="selectedGlyphTemplate">
-                                <Rectangle Width="{Binding SourceWidth, Mode=OneWay}" Height="{Binding SourceHeight, Mode=OneWay}"
-                                           StrokeThickness="1" Panel.ZIndex="1"
-                                           ToolTipService.InitialShowDelay="500" ToolTipService.BetweenShowDelay="500">
-                                    <Rectangle.ToolTip>
-                                        <TextBlock Text="{Binding Character, Mode=OneWay, Converter={StaticResource CharConverter}}"/>
-                                    </Rectangle.ToolTip>
-                                    <Rectangle.Stroke>
-                                        <SolidColorBrush Color="OrangeRed" Opacity="0.5"/>
-                                    </Rectangle.Stroke>
-                                    <Rectangle.Fill>
-                                        <SolidColorBrush Color="Red" Opacity="0.1"/>
-                                    </Rectangle.Fill>
-                                </Rectangle>
+                                <Grid>
+                                    <Grid.Resources>
+                                        <Style TargetType="Rectangle">
+                                            <Setter Property="VerticalAlignment" Value="Top"/>
+                                            <Setter Property="HorizontalAlignment" Value="Left"/>
+                                        </Style>
+                                    </Grid.Resources>
+                                    <Rectangle Width="{Binding SourceWidth, Mode=OneWay}" Height="{Binding SourceHeight, Mode=OneWay}"
+                                               StrokeThickness="1" Panel.ZIndex="1"
+                                               ToolTipService.InitialShowDelay="500" ToolTipService.BetweenShowDelay="500">
+                                        <Rectangle.ToolTip>
+                                            <TextBlock Text="{Binding Character, Mode=OneWay, Converter={StaticResource CharConverter}}"/>
+                                        </Rectangle.ToolTip>
+                                        <Rectangle.Stroke>
+                                            <SolidColorBrush Color="OrangeRed" Opacity="0.5"/>
+                                        </Rectangle.Stroke>
+                                        <Rectangle.Fill>
+                                            <SolidColorBrush Color="Red" Opacity="0.1"/>
+                                        </Rectangle.Fill>
+                                    </Rectangle>
+
+                                    <Grid Panel.ZIndex="2">
+                                        <Grid.Style>
+                                            <Style TargetType="Grid">
+                                                <Style.Triggers>
+                                                    <EventTrigger RoutedEvent="Loaded">
+                                                        <BeginStoryboard>
+                                                            <BeginStoryboard.Storyboard>
+                                                                <Storyboard RepeatBehavior="Forever">
+                                                                    <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="Opacity"
+                                                                                                   Duration="0:0:2">
+                                                                        <DiscreteDoubleKeyFrame Value="1" KeyTime="0:0:0" />
+                                                                        <DiscreteDoubleKeyFrame Value="0" KeyTime="0:0:1" />
+                                                                    </DoubleAnimationUsingKeyFrames>
+                                                                </Storyboard>
+                                                            </BeginStoryboard.Storyboard>
+                                                        </BeginStoryboard>
+                                                    </EventTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Grid.Style>
+                                        <Rectangle Width="1" Height="{Binding SourceHeight, Mode=OneWay}" Stroke="Blue">
+                                            <Rectangle.RenderTransform>
+                                                <TransformGroup>
+                                                    <TranslateTransform X="{Binding Offset, Mode=OneWay}"/>
+                                                </TransformGroup>
+                                            </Rectangle.RenderTransform>
+                                        </Rectangle>
+                                        <Rectangle Width="{Binding Shift, Mode=OneWay}" Height="1" Stroke="LawnGreen">
+                                            <Rectangle.RenderTransform>
+                                                <TransformGroup>
+                                                    <TranslateTransform Y="-1"/>
+                                                    <TranslateTransform Y="{Binding SourceHeight, Mode=OneWay}"/>
+                                                </TransformGroup>
+                                            </Rectangle.RenderTransform>
+                                        </Rectangle>
+                                        <Rectangle Width="1" Height="1" Stroke="#FF3E8080">
+                                            <Rectangle.RenderTransform>
+                                                <TransformGroup>
+                                                    <TranslateTransform Y="-1"/>
+                                                    <TranslateTransform Y="{Binding SourceHeight, Mode=OneWay}"/>
+                                                </TransformGroup>
+                                            </Rectangle.RenderTransform>
+                                        </Rectangle>
+                                    </Grid>
+                                </Grid>
                             </DataTemplate>
                             <DataTemplate x:Key="glyphTemplate">
                                 <Rectangle Width="{Binding SourceWidth, Mode=OneWay}" Height="{Binding SourceHeight, Mode=OneWay}"

--- a/UndertaleModTool/Editors/UndertaleFontEditor/EditGlyphRectangleWindow.xaml
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/EditGlyphRectangleWindow.xaml
@@ -15,10 +15,15 @@
             <utmt:CharConverter x:Key="CharConverter"/>
         </Grid.Resources>
         <Grid.RowDefinitions>
-            <RowDefinition Height="16px"/>
-            <RowDefinition Height="450px"/>
+            <RowDefinition Height="42px"/>
+            <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Margin="3" FontStyle="Italic" FontSize="14" Foreground="Gray" HorizontalAlignment="Center">
+            Double-click an inactive rectangle to switch to it.<LineBreak/>
+            Drag mouse on desired region if it's an empty character.
+        </TextBlock>
 
         <ScrollViewer Name="TextureScroll" Grid.Row="1" Margin="3"
                       HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Visible"
@@ -29,7 +34,7 @@
             <Viewbox Grid.Row="1" Name="TextureViewbox"
                      Stretch="Uniform" StretchDirection="DownOnly"
                      SnapsToDevicePixels="True" RenderOptions.BitmapScalingMode="NearestNeighbor" UseLayoutRounding="True"
-                     MouseLeftButtonDown="TextureViewbox_MouseLeftButtonDown" MouseMove="TextureViewbox_MouseMove" MouseLeftButtonUp="TextureViewbox_MouseLeftButtonUp">
+                     MouseLeftButtonDown="TextureViewbox_MouseLeftButtonDown" MouseLeftButtonUp="TextureViewbox_MouseLeftButtonUp">
                 <Grid>
                     <Grid.Background>
                         <SolidColorBrush Color="Black"/>
@@ -101,7 +106,7 @@
                             </Style>
                             
                             <DataTemplate DataType="{x:Type undertale:UndertaleFont+Glyph}">
-                                <ContentControl Name="RectangleContent" Content="{Binding}"
+                                <ContentControl Name="RectangleContent" Content="{Binding .}"
                                                 Style="{StaticResource contentControlStyle}"/>
                             </DataTemplate>
                         </ItemsControl.Resources>
@@ -110,7 +115,7 @@
             </Viewbox>
         </ScrollViewer>
 
-        <utmt:ButtonDark Grid.Row="2" Margin="3,13,3,3" Click="SaveButton_Click" Width="150" Height="40"
-                         FontSize="16">Save changes</utmt:ButtonDark>
+        <utmt:ButtonDark Grid.Row="2" Margin="3,9,3,12" Click="SaveButton_Click" Width="160" Height="50"
+                         FontSize="18">Save changes</utmt:ButtonDark>
     </Grid>
 </Window>

--- a/UndertaleModTool/Editors/UndertaleFontEditor/EditGlyphRectangleWindow.xaml
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/EditGlyphRectangleWindow.xaml
@@ -12,6 +12,7 @@
     <Grid>
         <Grid.Resources>
             <utmt:EqualityConverter x:Key="EqualityConverter"/>
+            <utmt:CharConverter x:Key="CharConverter"/>
         </Grid.Resources>
         <Grid.RowDefinitions>
             <RowDefinition Height="16px"/>
@@ -55,7 +56,11 @@
                             
                             <DataTemplate x:Key="selectedGlyphTemplate">
                                 <Rectangle Width="{Binding SourceWidth, Mode=OneWay}" Height="{Binding SourceHeight, Mode=OneWay}"
-                                           StrokeThickness="1" Panel.ZIndex="1">
+                                           StrokeThickness="1" Panel.ZIndex="1"
+                                           ToolTipService.InitialShowDelay="500" ToolTipService.BetweenShowDelay="500">
+                                    <Rectangle.ToolTip>
+                                        <TextBlock Text="{Binding Character, Mode=OneWay, Converter={StaticResource CharConverter}}"/>
+                                    </Rectangle.ToolTip>
                                     <Rectangle.Stroke>
                                         <SolidColorBrush Color="OrangeRed" Opacity="0.5"/>
                                     </Rectangle.Stroke>
@@ -66,7 +71,11 @@
                             </DataTemplate>
                             <DataTemplate x:Key="glyphTemplate">
                                 <Rectangle Width="{Binding SourceWidth, Mode=OneWay}" Height="{Binding SourceHeight, Mode=OneWay}"
-                                           StrokeThickness="1" Panel.ZIndex="0">
+                                           StrokeThickness="1" Panel.ZIndex="0"
+                                           ToolTipService.InitialShowDelay="500" ToolTipService.BetweenShowDelay="500">
+                                    <Rectangle.ToolTip>
+                                        <TextBlock Text="{Binding Character, Mode=OneWay, Converter={StaticResource CharConverter}}"/>
+                                    </Rectangle.ToolTip>
                                     <Rectangle.Stroke>
                                         <SolidColorBrush Color="Yellow" Opacity="0.25"/>
                                     </Rectangle.Stroke>

--- a/UndertaleModTool/Editors/UndertaleFontEditor/EditGlyphRectangleWindow.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/EditGlyphRectangleWindow.xaml.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+using System.Windows.Threading;
+using UndertaleModLib.Models;
+
+namespace UndertaleModTool.Editors.UndertaleFontEditor
+{
+    /// <summary>
+    /// Interaction logic for EditGlyphRectangleWindow.xaml
+    /// </summary>
+    public partial class EditGlyphRectangleWindow : Window
+    {
+        public UndertaleFont.Glyph SelectedGlyph { get; set; }
+        private readonly IList<UndertaleFont.Glyph> glyphs;
+
+        public EditGlyphRectangleWindow(UndertaleFont font, UndertaleFont.Glyph selectedGlyph)
+        {
+            InitializeComponent();
+
+            if (font is null || selectedGlyph is null)
+            {
+                Close();
+                return;
+            }
+
+            DataContext = font;
+            SelectedGlyph = selectedGlyph;
+            glyphs = font.Glyphs;
+
+
+        }
+
+        private void Window_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (!IsVisible || IsLoaded)
+                return;
+
+            if (Settings.Instance.EnableDarkMode)
+                MainWindow.SetDarkTitleBarForWindow(this, true, false);
+        }
+
+        private void Window_Loaded(object sender, RoutedEventArgs e)
+        {
+            var scrollPres = MainWindow.FindVisualChild<ScrollContentPresenter>(TextureScroll);
+            if (scrollPres is null)
+                return;
+
+            double initScale = 1;
+            if (DataContext is UndertaleFont font)
+            {
+                int textureWidth = font.Texture?.BoundingWidth ?? 1;
+                if (textureWidth < scrollPres.ActualWidth)
+                    initScale = scrollPres.ActualWidth / textureWidth;
+            }
+
+            TextureViewbox.LayoutTransform = new MatrixTransform(initScale, 0, 0, initScale, 0, 0); ;
+            TextureViewbox.UpdateLayout();
+            TextureScroll.ScrollToTop();
+            TextureScroll.ScrollToLeftEnd();
+        }
+
+        private void TextureScroll_ScrollChanged(object sender, ScrollChangedEventArgs e)
+        {
+            if (e.ExtentHeightChange != 0 || e.ExtentWidthChange != 0)
+            {
+                double xMousePositionOnScrollViewer = Mouse.GetPosition(TextureScroll).X;
+                double yMousePositionOnScrollViewer = Mouse.GetPosition(TextureScroll).Y;
+                double offsetX = e.HorizontalOffset + xMousePositionOnScrollViewer;
+                double offsetY = e.VerticalOffset + yMousePositionOnScrollViewer;
+
+                double oldExtentWidth = e.ExtentWidth - e.ExtentWidthChange;
+                double oldExtentHeight = e.ExtentHeight - e.ExtentHeightChange;
+
+                double relx = offsetX / oldExtentWidth;
+                double rely = offsetY / oldExtentHeight;
+
+                offsetX = Math.Max(relx * e.ExtentWidth - xMousePositionOnScrollViewer, 0);
+                offsetY = Math.Max(rely * e.ExtentHeight - yMousePositionOnScrollViewer, 0);
+
+                TextureScroll.ScrollToHorizontalOffset(offsetX);
+                TextureScroll.ScrollToVerticalOffset(offsetY);
+            }
+        }
+
+        private void TextureScroll_MouseWheel(object sender, MouseWheelEventArgs e)
+        {
+            e.Handled = true;
+            var mousePos = e.GetPosition(TextureScroll);
+            var transform = TextureViewbox.LayoutTransform as MatrixTransform;
+            var matrix = transform.Matrix;
+            var scale = e.Delta >= 0 ? 1.1 : (1.0 / 1.1); // choose appropriate scaling factor
+
+            if ((matrix.M11 > 0.2 || (matrix.M11 <= 0.2 && scale > 1)) && (matrix.M11 < 3 || (matrix.M11 >= 3 && scale < 1)))
+            {
+                matrix.ScaleAtPrepend(scale, scale, mousePos.X, mousePos.Y);
+            }
+            TextureViewbox.LayoutTransform = new MatrixTransform(matrix);
+        }
+
+        private void Canvas_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (e.ClickCount >= 2)
+            {
+
+            }
+        }
+        private void Canvas_MouseMove(object sender, MouseEventArgs e)
+        {
+
+        }
+    }
+}

--- a/UndertaleModTool/Editors/UndertaleFontEditor/EditGlyphRectangleWindow.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/EditGlyphRectangleWindow.xaml.cs
@@ -177,7 +177,6 @@ namespace UndertaleModTool.Editors.UndertaleFontEditor
         private void TextureViewbox_MouseMove(object sender, MouseEventArgs e)
         {
             var pos = e.GetPosition(canvas);
-            var hitType = GetHitType(selectedRect, pos);
 
             if (dragInProgress)
             {
@@ -188,7 +187,7 @@ namespace UndertaleModTool.Editors.UndertaleFontEditor
                 double newY = SelectedGlyph.SourceY;
                 double newWidth = SelectedGlyph.SourceWidth;
                 double newHeight = SelectedGlyph.SourceHeight;
-                
+
                 switch (initType)
                 {
                     case HitType.Body:
@@ -234,20 +233,36 @@ namespace UndertaleModTool.Editors.UndertaleFontEditor
                 if (Math.Abs(offsetX) < 1 && Math.Abs(offsetY) < 1)
                     return;
 
-                if (newX >= 0)
+                bool outOfLeft = newX < 0;
+                bool outOfTop = newY < 0;
+                bool outOfRight = newX + newWidth > Font.Texture.BoundingWidth;
+                bool outOfBottom = newY + newHeight > Font.Texture.BoundingHeight;
+                if (!outOfLeft && !outOfRight)
                     SelectedGlyph.SourceX = (ushort)Math.Round(newX);
-                if (newY >= 0)
+                if (!outOfTop && !outOfBottom)
                     SelectedGlyph.SourceY = (ushort)Math.Round(newY);
-                if (newWidth >= 0)
+                if (newWidth >= 0 && !outOfRight)
                     SelectedGlyph.SourceWidth = (ushort)Math.Round(newWidth);
-                if (newHeight >= 0)
+                if (newHeight >= 0 && !outOfBottom)
                     SelectedGlyph.SourceHeight = (ushort)Math.Round(newHeight);
+
+                if (outOfLeft)
+                    SelectedGlyph.SourceX = 0;
+                if (outOfRight)
+                    SelectedGlyph.SourceX = (ushort)(Font.Texture.BoundingWidth - SelectedGlyph.SourceWidth);
+                if (outOfTop)
+                    SelectedGlyph.SourceY = 0;
+                if (outOfBottom)
+                    SelectedGlyph.SourceY = (ushort)(Font.Texture.BoundingHeight - SelectedGlyph.SourceHeight);
 
                 initPoint.X = Math.Round(pos.X);
                 initPoint.Y = Math.Round(pos.Y);
             }
             else
+            {
+                var hitType = GetHitType(selectedRect, pos);
                 canvas.Cursor = GetCursorForType(hitType);
+            }
         }
 
         private void SaveButton_Click(object sender, RoutedEventArgs e)

--- a/UndertaleModTool/Editors/UndertaleFontEditor/EditGlyphRectangleWindow.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/EditGlyphRectangleWindow.xaml.cs
@@ -32,6 +32,7 @@ namespace UndertaleModTool.Editors.UndertaleFontEditor
         private bool dragInProgress = false;
         private Point initPoint;
         private HitType initType;
+        private short initShift;
         private Canvas canvas;
 
         public event PropertyChangedEventHandler PropertyChanged;
@@ -198,6 +199,7 @@ namespace UndertaleModTool.Editors.UndertaleFontEditor
             {
                 SelectedGlyph.SourceX = (ushort)Math.Round(initPoint.X);
                 SelectedGlyph.SourceY = (ushort)Math.Round(initPoint.Y);
+                initShift = SelectedGlyph.Shift;
             }
             else
                 initType = GetHitType(selectedRect, initPoint);
@@ -230,6 +232,7 @@ namespace UndertaleModTool.Editors.UndertaleFontEditor
                 double newY = SelectedGlyph.SourceY;
                 double newWidth = SelectedGlyph.SourceWidth;
                 double newHeight = SelectedGlyph.SourceHeight;
+                double newShift = SelectedGlyph.Shift;
 
                 switch (initType)
                 {
@@ -242,27 +245,33 @@ namespace UndertaleModTool.Editors.UndertaleFontEditor
                         newY += offsetY;
                         newWidth -= offsetX;
                         newHeight -= offsetY;
+                        newShift -= offsetX;
                         break;
                     case HitType.UR:
                         newY += offsetY;
                         newWidth += offsetX;
                         newHeight -= offsetY;
+                        newShift += offsetX;
                         break;
                     case HitType.LR:
                         newWidth += offsetX;
                         newHeight += offsetY;
+                        newShift += offsetX;
                         break;
                     case HitType.LL:
                         newX += offsetX;
                         newWidth -= offsetX;
                         newHeight += offsetY;
+                        newShift -= offsetX;
                         break;
                     case HitType.L:
                         newX += offsetX;
                         newWidth -= offsetX;
+                        newShift -= offsetX;
                         break;
                     case HitType.R:
                         newWidth += offsetX;
+                        newShift += offsetX;
                         break;
                     case HitType.B:
                         newHeight += offsetY;
@@ -298,6 +307,8 @@ namespace UndertaleModTool.Editors.UndertaleFontEditor
                 if (outOfBottom)
                     SelectedGlyph.SourceY = (ushort)(Font.Texture.BoundingHeight - SelectedGlyph.SourceHeight);
 
+                SelectedGlyph.Shift = (short)Math.Round(newShift);
+
                 initPoint.X = Math.Round(pos.X);
                 initPoint.Y = Math.Round(pos.Y);
             }
@@ -325,6 +336,8 @@ namespace UndertaleModTool.Editors.UndertaleFontEditor
                     SelectedGlyph.SourceWidth = (ushort)Math.Round(offsetX);
                 if (!outOfBottom)
                     SelectedGlyph.SourceHeight = (ushort)Math.Round(offsetY);
+
+                SelectedGlyph.Shift = (short)(initShift + (short)Math.Round(offsetX));
             }
             else
             {

--- a/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml
@@ -141,7 +141,7 @@
         </Viewbox>
 
         <StackPanel Grid.Row="15" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center">
-            <local:ButtonDark Margin="3" Width="230" Click="EditRectangleButton_Click">
+            <local:ButtonDark Margin="3" Width="220" Click="EditRectangleButton_Click">
                 <Button.Style>
                     <Style TargetType="Button">
                         <Style.Triggers>
@@ -176,81 +176,209 @@
             <local:ButtonDark Margin="3" Width="200" Content="Create an empty glyph" Click="CreateGlyphButton_Click"/>
         </StackPanel>
 
-        <TextBlock Grid.Row="16" Grid.Column="0" Margin="3">Glyphs:</TextBlock>
-        <local:DataGridDark Grid.Row="17" Grid.ColumnSpan="2" MaxHeight="370" Margin="3" x:Name="GlyphsGrid" ItemsSource="{Binding Glyphs, Mode=OneWay}"
-                            AutoGenerateColumns="False" CanUserAddRows="True" CanUserDeleteRows="True" HorizontalGridLinesBrush="LightGray" VerticalGridLinesBrush="LightGray" HeadersVisibility="Column" SelectionMode="Single" SelectionUnit="FullRow"
-                            ScrollViewer.CanContentScroll="True"
-                            VirtualizingPanel.IsVirtualizing="True"
-                            VirtualizingPanel.VirtualizationMode="Recycling">
-            <DataGrid.Resources>
-                <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="#FF26A0DA"/>
-                <Style TargetType="{x:Type DataGridCell}">
-                    <Setter Property="Template">
-                        <Setter.Value>
-                            <ControlTemplate TargetType="{x:Type DataGridCell}">
-                                <Grid Background="{TemplateBinding Background}">
-                                    <ContentPresenter VerticalAlignment="Center" />
+        <TextBlock Name="GlyphsLabel" Grid.Row="16" Grid.ColumnSpan="2" Margin="3" HorizontalAlignment="Left">Glyphs:</TextBlock>
+        <Grid Grid.Row="17" Grid.ColumnSpan="2" MaxHeight="370" Margin="3">
+            <local:DataGridDark x:Name="GlyphsGrid" ItemsSource="{Binding Glyphs, Mode=OneWay}"
+                                AutoGenerateColumns="False" CanUserAddRows="True" CanUserDeleteRows="True" HorizontalGridLinesBrush="LightGray" VerticalGridLinesBrush="LightGray" HeadersVisibility="Column" SelectionMode="Single" SelectionUnit="FullRow"
+                                ScrollViewer.CanContentScroll="True"
+                                VirtualizingPanel.IsVirtualizing="True"
+                                VirtualizingPanel.VirtualizationMode="Recycling">
+                <DataGrid.Resources>
+                    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="#FF26A0DA"/>
+                    <Style TargetType="{x:Type DataGridCell}">
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="{x:Type DataGridCell}">
+                                    <Grid Background="{TemplateBinding Background}">
+                                        <ContentPresenter VerticalAlignment="Center" />
+                                    </Grid>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding DataContext, RelativeSource={RelativeSource AncestorType={x:Type DataGridRow}}}" Value="{x:Static CollectionView.NewItemPlaceholder}">
+                                <Setter Property="Template">
+                                    <Setter.Value>
+                                        <ControlTemplate>
+                                            <TextBlock Margin="5" TextAlignment="Center" FontStyle="Italic">Double click to add</TextBlock>
+                                        </ControlTemplate>
+                                    </Setter.Value>
+                                </Setter>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                    <Style x:Key="kerningButtonStyle" TargetType="Button">
+                        <Setter Property="Content" Value="Edit"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding Kerning.Count, Mode=OneWay, FallbackValue=0}"
+                                         Value="0">
+                                <Setter Property="Content" Value="Add"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </DataGrid.Resources>
+                <DataGrid.Columns>
+                    <DataGridTemplateColumn Header="Char" Width="*">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <local:TextBoxDark Text="{Binding Character, Mode=TwoWay, UpdateSourceTrigger=LostFocus, Converter={StaticResource CharConverter}}"
+                                                   Margin="20,0,0,0" MaxLength="1"
+                                                   ToolTip="{Binding Character, Mode=OneWay}" ToolTipService.InitialShowDelay="250">
+                                    <TextBox.Style>
+                                        <Style TargetType="TextBox">
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Character, Mode=OneWay}" Value="0">
+                                                    <Setter Property="ToolTipService.IsEnabled" Value="False"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBox.Style>
+                                </local:TextBoxDark>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                    <DataGridTemplateColumn Header="Source position/size" Width="*">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <local:TextBoxDark Grid.Column="0" Text="{Binding SourceX, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
+                                    <local:TextBoxDark Grid.Column="1" Text="{Binding SourceY, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
+                                    <local:TextBoxDark Grid.Column="2" Text="{Binding SourceWidth, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
+                                    <local:TextBoxDark Grid.Column="3" Text="{Binding SourceHeight, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
                                 </Grid>
-                            </ControlTemplate>
-                        </Setter.Value>
-                    </Setter>
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding DataContext, RelativeSource={RelativeSource AncestorType={x:Type DataGridRow}}}" Value="{x:Static CollectionView.NewItemPlaceholder}">
-                            <Setter Property="Template">
-                                <Setter.Value>
-                                    <ControlTemplate>
-                                        <TextBlock Margin="5" TextAlignment="Center" FontStyle="Italic">Double click to add</TextBlock>
-                                    </ControlTemplate>
-                                </Setter.Value>
-                            </Setter>
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </DataGrid.Resources>
-            <DataGrid.Columns>
-                <DataGridTemplateColumn Header="Char" Width="*">
-                    <DataGridTemplateColumn.CellTemplate>
-                        <DataTemplate>
-                            <local:TextBoxDark Text="{Binding Character, Mode=TwoWay, UpdateSourceTrigger=LostFocus, Converter={StaticResource CharConverter}}"
-                                               Margin="20,0,0,0" MaxLength="1"
-                                               ToolTip="{Binding Character, Mode=OneWay}" ToolTipService.InitialShowDelay="250"/>
-                        </DataTemplate>
-                    </DataGridTemplateColumn.CellTemplate>
-                </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="Source position/size" Width="*">
-                    <DataGridTemplateColumn.CellTemplate>
-                        <DataTemplate>
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="*"/>
-                                </Grid.ColumnDefinitions>
-                                <local:TextBoxDark Grid.Column="0" Text="{Binding SourceX, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
-                                <local:TextBoxDark Grid.Column="1" Text="{Binding SourceY, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
-                                <local:TextBoxDark Grid.Column="2" Text="{Binding SourceWidth, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
-                                <local:TextBoxDark Grid.Column="3" Text="{Binding SourceHeight, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
-                            </Grid>
-                        </DataTemplate>
-                    </DataGridTemplateColumn.CellTemplate>
-                </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="Shift" Width="*">
-                    <DataGridTemplateColumn.CellTemplate>
-                        <DataTemplate>
-                            <local:TextBoxDark Text="{Binding Shift, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
-                        </DataTemplate>
-                    </DataGridTemplateColumn.CellTemplate>
-                </DataGridTemplateColumn>
-                <DataGridTemplateColumn Header="Offset" Width="*">
-                    <DataGridTemplateColumn.CellTemplate>
-                        <DataTemplate>
-                            <local:TextBoxDark Text="{Binding Offset, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
-                        </DataTemplate>
-                    </DataGridTemplateColumn.CellTemplate>
-                </DataGridTemplateColumn>
-            </DataGrid.Columns>
-        </local:DataGridDark>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                    <DataGridTemplateColumn Width="*">
+                        <DataGridTemplateColumn.Header>
+                            <StackPanel Orientation="Horizontal" ToolTipService.InitialShowDelay="250"
+                                    ToolTip="The number of pixels to shift right when advancing to the next character.">
+                                <TextBlock Text="Shift" Margin="0,0,3,0"/>
+                                <TextBlock Text="(?)" Foreground="Gray" FontSize="11"/>
+                            </StackPanel>
+                        </DataGridTemplateColumn.Header>
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <local:TextBoxDark Text="{Binding Shift, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                    <DataGridTemplateColumn Width="*">
+                        <DataGridTemplateColumn.Header>
+                            <StackPanel Orientation="Horizontal" ToolTipService.InitialShowDelay="250"
+                                    ToolTip="The number of pixels to horizontally offset the rendering of the glyph.">
+                                <TextBlock Text="Offset" Margin="0,0,3,0"/>
+                                <TextBlock Text="(?)" Foreground="Gray" FontSize="11"/>
+                            </StackPanel>
+                        </DataGridTemplateColumn.Header>
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <local:TextBoxDark Text="{Binding Offset, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                    <DataGridTemplateColumn Header="Kerning" Width="60">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <local:ButtonDark Click="EditKerningButton_Click" Style="{StaticResource kerningButtonStyle}"/>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                </DataGrid.Columns>
+            </local:DataGridDark>
+
+            <Border Name="GlyphKerningBorder" BorderBrush="#FFABADB3" BorderThickness="1" Visibility="Collapsed">
+                <Border.CommandBindings>
+                    <CommandBinding Command="NavigationCommands.BrowseBack" Executed="Command_GoBack" />
+                </Border.CommandBindings>
+                <StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="2">
+                        <local:ButtonDark Click="KerningBackButton_Click" Width="40" Height="19">
+                            <Image Name="BackButtonImage" Stretch="None">
+                                <Image.Style>
+                                    <Style TargetType="Image">
+                                        <Style.Triggers>
+                                            <Trigger Property="IsMouseOver" Value="False">
+                                                <Setter Property="Source" Value="/Resources/arrow_blue.png" />
+                                            </Trigger>
+                                            <Trigger Property="IsMouseOver" Value="True">
+                                                <Setter Property="Source" Value="/Resources/arrow_red.png" />
+                                            </Trigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Image.Style>
+                            </Image>
+                        </local:ButtonDark>
+                        <TextBlock Text="Go back" Margin="3,-1,0,0" VerticalAlignment="Center"/>
+                    </StackPanel>
+
+                    <local:DataGridDark x:Name="GlyphKerningGrid" IsEnabled="False" Visibility="{Binding Visibility, Mode=OneWay, ElementName=GlyphKerningBorder}"
+                                        AutoGenerateColumns="False" CanUserAddRows="True" CanUserDeleteRows="True" HorizontalGridLinesBrush="LightGray" VerticalGridLinesBrush="LightGray" HeadersVisibility="Column" SelectionMode="Single" SelectionUnit="FullRow"
+                                        ScrollViewer.CanContentScroll="True"
+                                        VirtualizingPanel.IsVirtualizing="True"
+                                        VirtualizingPanel.VirtualizationMode="Recycling">
+                        <DataGrid.Resources>
+                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="#FF26A0DA"/>
+                            <Style TargetType="{x:Type DataGridCell}">
+                                <Setter Property="Template">
+                                    <Setter.Value>
+                                        <ControlTemplate TargetType="{x:Type DataGridCell}">
+                                            <Grid Background="{TemplateBinding Background}">
+                                                <ContentPresenter VerticalAlignment="Center" />
+                                            </Grid>
+                                        </ControlTemplate>
+                                    </Setter.Value>
+                                </Setter>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding DataContext, RelativeSource={RelativeSource AncestorType={x:Type DataGridRow}}}" Value="{x:Static CollectionView.NewItemPlaceholder}">
+                                        <Setter Property="Template">
+                                            <Setter.Value>
+                                                <ControlTemplate>
+                                                    <TextBlock Margin="5" TextAlignment="Center" FontStyle="Italic">Double click to add</TextBlock>
+                                                </ControlTemplate>
+                                            </Setter.Value>
+                                        </Setter>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </DataGrid.Resources>
+                        <DataGrid.Columns>
+                            <DataGridTemplateColumn Header="Preceeding char" Width="Auto">
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <local:TextBoxDark Text="{Binding Character, Mode=TwoWay, UpdateSourceTrigger=LostFocus, Converter={StaticResource CharConverter}}"
+                                                           MaxLength="1" ToolTip="{Binding Character, Mode=OneWay}" ToolTipService.InitialShowDelay="250">
+                                            <TextBox.Style>
+                                                <Style TargetType="TextBox">
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding Character, Mode=OneWay}" Value="0">
+                                                            <Setter Property="ToolTipService.IsEnabled" Value="False"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBox.Style>
+                                        </local:TextBoxDark>
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
+                            <DataGridTemplateColumn Header="Add. shift" Width="Auto">
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <local:TextBoxDark Text="{Binding ShiftModifier, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
+                        </DataGrid.Columns>
+                    </local:DataGridDark>
+                </StackPanel>
+            </Border>
+        </Grid>
 
         <TextBlock Grid.Row="18" Grid.ColumnSpan="2" Margin="3" TextWrapping="Wrap" HorizontalAlignment="Center" TextAlignment="Center">
             Note that the glyphs need to be specified in ascending order.<LineBreak/>

--- a/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml
@@ -102,14 +102,14 @@
                 </Grid.Background>
                 <local:UndertaleTexturePageItemDisplay DataContext="{Binding Texture, Mode=OneWay}"/>
 
-                <Canvas Name="GlyphsOverlayCanvas" UseLayoutRounding="True" SnapsToDevicePixels="True">
+                <Canvas Name="GlyphsOverlayCanvas" SnapsToDevicePixels="True">
                     <Rectangle Name="GlyphRectangle" Stroke="#FFB23131" Panel.ZIndex="50" StrokeThickness="1"
                                Canvas.Left="{Binding SelectedItem.SourceX, ElementName=GlyphsGrid, Mode=OneWay, TargetNullValue=-1, FallbackValue=-1}"
                                Canvas.Top="{Binding SelectedItem.SourceY, ElementName=GlyphsGrid, Mode=OneWay, TargetNullValue=-1, FallbackValue=-1}"
                                Width="{Binding SelectedItem.SourceWidth, ElementName=GlyphsGrid, Mode=OneWay, TargetNullValue=0, FallbackValue=0}"
                                Height="{Binding SelectedItem.SourceHeight, ElementName=GlyphsGrid, Mode=OneWay, TargetNullValue=0, FallbackValue=0}">
                         <Rectangle.Fill>
-                            <SolidColorBrush Color="Red" Opacity=".1"/>
+                            <SolidColorBrush Color="Red" Opacity="0.2"/>
                         </Rectangle.Fill>
                     </Rectangle>
                 </Canvas>
@@ -117,7 +117,7 @@
         </Viewbox>
 
         <local:ButtonDark Grid.Row="13" Grid.ColumnSpan="2" Margin="3" HorizontalAlignment="Center" Width="250"
-                          Content="Edit selected glyph rectangle" Click="EditRectangleButton_Click"/>
+                          Content="Edit a selected glyph rectangle" Click="EditRectangleButton_Click"/>
 
         <TextBlock Grid.Row="14" Grid.Column="0" Margin="3">Glyphs:</TextBlock>
         <local:DataGridDark Grid.Row="15" Grid.ColumnSpan="2" MaxHeight="370" Margin="3" x:Name="GlyphsGrid" ItemsSource="{Binding Glyphs, Mode=OneWay}"

--- a/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml
@@ -10,6 +10,7 @@
     <Grid>
         <Grid.Resources>
             <local:CharConverter x:Key="CharConverter"/>
+            <local:IsVersionAtLeastConverter x:Key="IsVersionAtLeastConverter"/>
             <Style x:Key="glyphsOperationButtonStyle" TargetType="Button">
                 <Style.Triggers>
                     <DataTrigger Binding="{Binding Glyphs.Count, Mode=OneWay, FallbackValue=0}" Value="0">
@@ -23,6 +24,8 @@
             <ColumnDefinition Width="3*"/>
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -98,13 +101,25 @@
             <local:TextBoxDark Grid.Column="1" Margin="3" Text="{Binding ScaleY}"/>
         </Grid>
 
-        <TextBlock Grid.Row="10" Grid.Column="0" Margin="3">SDF spread value</TextBlock>
-        <local:TextBoxDark Grid.Row="10" Grid.Column="1" Margin="3" Text="{Binding SDFSpread}"/>
+        <TextBlock Grid.Row="10" Grid.Column="0" Margin="3" Text="Ascender"
+                   Visibility="{Binding Mode=OneTime, Converter={StaticResource IsVersionAtLeastConverter}, ConverterParameter=2022.2}"/>
+        <local:TextBoxDark Grid.Row="10" Grid.Column="1" Margin="3" Text="{Binding Ascender}"
+                           Visibility="{Binding Mode=OneTime, Converter={StaticResource IsVersionAtLeastConverter}, ConverterParameter=2022.2}"/>
 
-        <TextBlock Grid.Row="11" Grid.ColumnSpan="2" Margin="3,30,3,3" HorizontalAlignment="Center" Foreground="DarkGray" FontStyle="Italic" TextWrapping="Wrap" TextAlignment="Center">
+        <TextBlock Grid.Row="11" Grid.Column="0" Margin="3" Text="Ascender offset"
+                   Visibility="{Binding Mode=OneTime, Converter={StaticResource IsVersionAtLeastConverter}, ConverterParameter=2022.2}"/>
+        <local:TextBoxDark Grid.Row="11" Grid.Column="1" Margin="3" Text="{Binding AscenderOffset}"
+                           Visibility="{Binding Mode=OneTime, Converter={StaticResource IsVersionAtLeastConverter}, ConverterParameter=2022.2}"/>
+
+        <TextBlock Grid.Row="12" Grid.Column="0" Margin="3" Text="SDF spread value"
+                   Visibility="{Binding Mode=OneTime, Converter={StaticResource IsVersionAtLeastConverter}, ConverterParameter=2023.2}"/>
+        <local:TextBoxDark Grid.Row="12" Grid.Column="1" Margin="3" Text="{Binding SDFSpread}"
+                           Visibility="{Binding Mode=OneTime, Converter={StaticResource IsVersionAtLeastConverter}, ConverterParameter=2023.2}"/>
+
+        <TextBlock Grid.Row="13" Grid.ColumnSpan="2" Margin="3,30,3,3" HorizontalAlignment="Center" Foreground="DarkGray" FontStyle="Italic" TextWrapping="Wrap" TextAlignment="Center">
                 Hint: You can click on any glyph here to highlight it in the "Glyphs".
         </TextBlock>
-        <Viewbox Grid.Row="12" Grid.ColumnSpan="2" Margin="3" Stretch="Uniform" StretchDirection="DownOnly">
+        <Viewbox Grid.Row="14" Grid.ColumnSpan="2" Margin="3" Stretch="Uniform" StretchDirection="DownOnly">
             <Grid MouseDown="Grid_MouseDown" Cursor="Hand">
                 <Grid.Background>
                     <SolidColorBrush Color="Black"/>
@@ -125,7 +140,7 @@
             </Grid>
         </Viewbox>
 
-        <StackPanel Grid.Row="13" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center">
+        <StackPanel Grid.Row="15" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center">
             <local:ButtonDark Margin="3" Width="230" Click="EditRectangleButton_Click">
                 <Button.Style>
                     <Style TargetType="Button">
@@ -161,8 +176,8 @@
             <local:ButtonDark Margin="3" Width="200" Content="Create an empty glyph" Click="CreateGlyphButton_Click"/>
         </StackPanel>
 
-        <TextBlock Grid.Row="14" Grid.Column="0" Margin="3">Glyphs:</TextBlock>
-        <local:DataGridDark Grid.Row="15" Grid.ColumnSpan="2" MaxHeight="370" Margin="3" x:Name="GlyphsGrid" ItemsSource="{Binding Glyphs, Mode=OneWay}"
+        <TextBlock Grid.Row="16" Grid.Column="0" Margin="3">Glyphs:</TextBlock>
+        <local:DataGridDark Grid.Row="17" Grid.ColumnSpan="2" MaxHeight="370" Margin="3" x:Name="GlyphsGrid" ItemsSource="{Binding Glyphs, Mode=OneWay}"
                             AutoGenerateColumns="False" CanUserAddRows="True" CanUserDeleteRows="True" HorizontalGridLinesBrush="LightGray" VerticalGridLinesBrush="LightGray" HeadersVisibility="Column" SelectionMode="Single" SelectionUnit="FullRow"
                             ScrollViewer.CanContentScroll="True"
                             VirtualizingPanel.IsVirtualizing="True"
@@ -237,19 +252,19 @@
             </DataGrid.Columns>
         </local:DataGridDark>
 
-        <TextBlock Grid.Row="16" Grid.ColumnSpan="2" Margin="3" TextWrapping="Wrap" HorizontalAlignment="Center" TextAlignment="Center">
+        <TextBlock Grid.Row="18" Grid.ColumnSpan="2" Margin="3" TextWrapping="Wrap" HorizontalAlignment="Center" TextAlignment="Center">
             Note that the glyphs need to be specified in ascending order.<LineBreak/>
             Press the button below to sort them appropriately.
         </TextBlock>
-        <local:ButtonDark Grid.Row="17" Grid.ColumnSpan="2" Margin="3" Click="Button_Sort_Click"
+        <local:ButtonDark Grid.Row="19" Grid.ColumnSpan="2" Margin="3" Click="Button_Sort_Click"
                           Content="Sort glyphs" Width="200" FontSize="14" Style="{StaticResource glyphsOperationButtonStyle}"/>
 
-        <TextBlock Grid.Row="18" Grid.ColumnSpan="2" Margin="3,6,3,3" TextWrapping="Wrap" HorizontalAlignment="Center" TextAlignment="Center">
+        <TextBlock Grid.Row="20" Grid.ColumnSpan="2" Margin="3,6,3,3" TextWrapping="Wrap" HorizontalAlignment="Center" TextAlignment="Center">
             Also, if you have added new characters or changed the character<LineBreak/>
             of an existing glyph, you should update the font range.<LineBreak/>
             Press the button below to do that.
         </TextBlock>
-        <local:ButtonDark Grid.Row="19" Grid.ColumnSpan="2" Margin="3" Click="Button_UpdateRange_Click"
+        <local:ButtonDark Grid.Row="21" Grid.ColumnSpan="2" Margin="3" Click="Button_UpdateRange_Click"
                           Content="Update range" Width="200" FontSize="14" Style="{StaticResource glyphsOperationButtonStyle}"/>
     </Grid>
 </local:DataUserControl>

--- a/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml
@@ -33,6 +33,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <TextBlock Grid.Row="0" Grid.Column="0" Margin="3">Name</TextBlock>
@@ -103,10 +104,10 @@
 
                 <Canvas Name="GlyphsOverlayCanvas" UseLayoutRounding="True" SnapsToDevicePixels="True">
                     <Rectangle Name="GlyphRectangle" Stroke="#FFB23131" Panel.ZIndex="50" StrokeThickness="1"
-                           Canvas.Left="{Binding SelectedItem.SourceX, ElementName=GlyphsGrid, Mode=OneWay, TargetNullValue=-1, FallbackValue=-1}"
-                           Canvas.Top="{Binding SelectedItem.SourceY, ElementName=GlyphsGrid, Mode=OneWay, TargetNullValue=-1, FallbackValue=-1}"
-                           Width="{Binding SelectedItem.SourceWidth, ElementName=GlyphsGrid, Mode=OneWay, TargetNullValue=0, FallbackValue=0}"
-                           Height="{Binding SelectedItem.SourceHeight, ElementName=GlyphsGrid, Mode=OneWay, TargetNullValue=0, FallbackValue=0}">
+                               Canvas.Left="{Binding SelectedItem.SourceX, ElementName=GlyphsGrid, Mode=OneWay, TargetNullValue=-1, FallbackValue=-1}"
+                               Canvas.Top="{Binding SelectedItem.SourceY, ElementName=GlyphsGrid, Mode=OneWay, TargetNullValue=-1, FallbackValue=-1}"
+                               Width="{Binding SelectedItem.SourceWidth, ElementName=GlyphsGrid, Mode=OneWay, TargetNullValue=0, FallbackValue=0}"
+                               Height="{Binding SelectedItem.SourceHeight, ElementName=GlyphsGrid, Mode=OneWay, TargetNullValue=0, FallbackValue=0}">
                         <Rectangle.Fill>
                             <SolidColorBrush Color="Red" Opacity=".1"/>
                         </Rectangle.Fill>
@@ -115,8 +116,11 @@
             </Grid>
         </Viewbox>
 
-        <TextBlock Grid.Row="13" Grid.Column="0" Margin="3">Glyphs:</TextBlock>
-        <local:DataGridDark Grid.Row="14" Grid.ColumnSpan="2" MaxHeight="370" Margin="3" x:Name="GlyphsGrid" ItemsSource="{Binding Glyphs, Mode=OneWay}"
+        <local:ButtonDark Grid.Row="13" Grid.ColumnSpan="2" Margin="3" HorizontalAlignment="Center" Width="250"
+                          Content="Edit selected glyph rectangle" Click="EditRectangleButton_Click"/>
+
+        <TextBlock Grid.Row="14" Grid.Column="0" Margin="3">Glyphs:</TextBlock>
+        <local:DataGridDark Grid.Row="15" Grid.ColumnSpan="2" MaxHeight="370" Margin="3" x:Name="GlyphsGrid" ItemsSource="{Binding Glyphs, Mode=OneWay}"
                             AutoGenerateColumns="False" CanUserAddRows="True" CanUserDeleteRows="True" HorizontalGridLinesBrush="LightGray" VerticalGridLinesBrush="LightGray" HeadersVisibility="Column" SelectionMode="Single" SelectionUnit="FullRow"
                             ScrollViewer.CanContentScroll="True"
                             VirtualizingPanel.IsVirtualizing="True"
@@ -191,10 +195,10 @@
             </DataGrid.Columns>
         </local:DataGridDark>
 
-        <TextBlock Grid.Row="15" Grid.Column="0" Grid.ColumnSpan="2" Margin="3" TextWrapping="Wrap" HorizontalAlignment="Center">
+        <TextBlock Grid.Row="16" Grid.Column="0" Grid.ColumnSpan="2" Margin="3" TextWrapping="Wrap" HorizontalAlignment="Center">
             Note that the glyphs need to be specified in ascending order.<LineBreak/>
             Press the button below to sort them appropriately.
         </TextBlock>
-        <local:ButtonDark Grid.Row="16" Grid.Column="0" Grid.ColumnSpan="2" Margin="3" Click="Button_Sort_Click">Sort glyphs</local:ButtonDark>
+        <local:ButtonDark Grid.Row="17" Grid.Column="0" Grid.ColumnSpan="2" Margin="3" Click="Button_Sort_Click">Sort glyphs</local:ButtonDark>
     </Grid>
 </local:DataUserControl>

--- a/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml
@@ -117,7 +117,7 @@
                            Visibility="{Binding Mode=OneTime, Converter={StaticResource IsVersionAtLeastConverter}, ConverterParameter=2023.2}"/>
 
         <TextBlock Grid.Row="13" Grid.ColumnSpan="2" Margin="3,30,3,3" HorizontalAlignment="Center" Foreground="DarkGray" FontStyle="Italic" TextWrapping="Wrap" TextAlignment="Center">
-                Hint: You can click on any glyph here to highlight it in the "Glyphs".
+            Hint: You can click on any glyph here to highlight it in the "Glyphs".
         </TextBlock>
         <Viewbox Grid.Row="14" Grid.ColumnSpan="2" Margin="3" Stretch="Uniform" StretchDirection="DownOnly">
             <Grid MouseDown="Grid_MouseDown" Cursor="Hand">
@@ -126,16 +126,75 @@
                 </Grid.Background>
                 <local:UndertaleTexturePageItemDisplay DataContext="{Binding Texture, Mode=OneWay}"/>
 
-                <Canvas Name="GlyphsOverlayCanvas" SnapsToDevicePixels="True">
-                    <Rectangle Name="GlyphRectangle" Stroke="#FFB23131" Panel.ZIndex="50" StrokeThickness="1"
-                               Canvas.Left="{Binding SelectedItem.SourceX, ElementName=GlyphsGrid, Mode=OneWay, TargetNullValue=-1, FallbackValue=-1}"
-                               Canvas.Top="{Binding SelectedItem.SourceY, ElementName=GlyphsGrid, Mode=OneWay, TargetNullValue=-1, FallbackValue=-1}"
-                               Width="{Binding SelectedItem.SourceWidth, ElementName=GlyphsGrid, Mode=OneWay, TargetNullValue=0, FallbackValue=0}"
-                               Height="{Binding SelectedItem.SourceHeight, ElementName=GlyphsGrid, Mode=OneWay, TargetNullValue=0, FallbackValue=0}">
-                        <Rectangle.Fill>
-                            <SolidColorBrush Color="Red" Opacity="0.2"/>
-                        </Rectangle.Fill>
-                    </Rectangle>
+                <Canvas Name="GlyphsOverlayCanvas" SnapsToDevicePixels="True"
+                        DataContext="{Binding SelectedItem, ElementName=GlyphsGrid, Mode=OneWay}">
+                    <Grid Canvas.Left="{Binding SourceX, Mode=OneWay, FallbackValue=-1}"
+                          Canvas.Top="{Binding SourceY, Mode=OneWay, FallbackValue=-1}">
+                        <Grid.Resources>
+                            <Style TargetType="Rectangle">
+                                <Setter Property="VerticalAlignment" Value="Top"/>
+                                <Setter Property="HorizontalAlignment" Value="Left"/>
+                                <Style.Triggers>
+                                    <Trigger Property="DataContext" Value="{x:Null}">
+                                        <Setter Property="Visibility" Value="Hidden"/>
+                                    </Trigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Grid.Resources>
+
+                        <Rectangle Name="GlyphRectangle" Stroke="#FFB23131" StrokeThickness="1"
+                               Width="{Binding SourceWidth, Mode=OneWay, FallbackValue=0}"
+                               Height="{Binding SourceHeight, Mode=OneWay, FallbackValue=0}">
+                            <Rectangle.Fill>
+                                <SolidColorBrush Color="Red" Opacity="0.2"/>
+                            </Rectangle.Fill>
+                        </Rectangle>
+
+                        <Grid Panel.ZIndex="1">
+                            <Grid.Style>
+                                <Style TargetType="Grid">
+                                    <Style.Triggers>
+                                        <EventTrigger RoutedEvent="Loaded">
+                                            <BeginStoryboard>
+                                                <BeginStoryboard.Storyboard>
+                                                    <Storyboard RepeatBehavior="Forever">
+                                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="Opacity"
+                                                                                                   Duration="0:0:2">
+                                                            <DiscreteDoubleKeyFrame Value="1" KeyTime="0:0:0" />
+                                                            <DiscreteDoubleKeyFrame Value="0" KeyTime="0:0:1" />
+                                                        </DoubleAnimationUsingKeyFrames>
+                                                    </Storyboard>
+                                                </BeginStoryboard.Storyboard>
+                                            </BeginStoryboard>
+                                        </EventTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Grid.Style>
+                            <Rectangle Width="1" Height="{Binding SourceHeight, Mode=OneWay, FallbackValue=0}" Stroke="Blue">
+                                <Rectangle.RenderTransform>
+                                    <TransformGroup>
+                                        <TranslateTransform X="{Binding Offset, Mode=OneWay, FallbackValue=0}"/>
+                                    </TransformGroup>
+                                </Rectangle.RenderTransform>
+                            </Rectangle>
+                            <Rectangle Width="{Binding Shift, Mode=OneWay, FallbackValue=0}" Height="1" Stroke="LawnGreen">
+                                <Rectangle.RenderTransform>
+                                    <TransformGroup>
+                                        <TranslateTransform Y="-1"/>
+                                        <TranslateTransform Y="{Binding SourceHeight, Mode=OneWay, FallbackValue=0}"/>
+                                    </TransformGroup>
+                                </Rectangle.RenderTransform>
+                            </Rectangle>
+                            <Rectangle Width="1" Height="1" Stroke="#FF3E8080">
+                                <Rectangle.RenderTransform>
+                                    <TransformGroup>
+                                        <TranslateTransform Y="-1"/>
+                                        <TranslateTransform Y="{Binding SourceHeight, Mode=OneWay, FallbackValue=0}"/>
+                                    </TransformGroup>
+                                </Rectangle.RenderTransform>
+                            </Rectangle>
+                        </Grid>
+                    </Grid>
                 </Canvas>
             </Grid>
         </Viewbox>
@@ -258,9 +317,11 @@
                     <DataGridTemplateColumn Width="*">
                         <DataGridTemplateColumn.Header>
                             <StackPanel Orientation="Horizontal" ToolTipService.InitialShowDelay="250"
-                                    ToolTip="The number of pixels to shift right when advancing to the next character.">
+                                    ToolTip="The number of pixels to shift right when advancing to the next character.&#13;
+                                             It's highlighed in green on the texture above.">
                                 <TextBlock Text="Shift" Margin="0,0,3,0"/>
-                                <TextBlock Text="(?)" Foreground="Gray" FontSize="11"/>
+                                <TextBlock Text="(?)" Foreground="Gray" FontSize="11" Margin="0,0,3,0"/>
+                                <Rectangle Width="7" Height="7" Fill="LawnGreen"/>
                             </StackPanel>
                         </DataGridTemplateColumn.Header>
                         <DataGridTemplateColumn.CellTemplate>
@@ -272,9 +333,11 @@
                     <DataGridTemplateColumn Width="*">
                         <DataGridTemplateColumn.Header>
                             <StackPanel Orientation="Horizontal" ToolTipService.InitialShowDelay="250"
-                                    ToolTip="The number of pixels to horizontally offset the rendering of the glyph.">
+                                    ToolTip="The number of pixels to horizontally offset the rendering of the glyph.&#13;
+                                             It's highlighed in blue on the texture above.">
                                 <TextBlock Text="Offset" Margin="0,0,3,0"/>
-                                <TextBlock Text="(?)" Foreground="Gray" FontSize="11"/>
+                                <TextBlock Text="(?)" Foreground="Gray" FontSize="11" Margin="0,0,3,0"/>
+                                <Rectangle Width="7" Height="7" Fill="Blue"/>
                             </StackPanel>
                         </DataGridTemplateColumn.Header>
                         <DataGridTemplateColumn.CellTemplate>

--- a/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml
@@ -10,12 +10,21 @@
     <Grid>
         <Grid.Resources>
             <local:CharConverter x:Key="CharConverter"/>
+            <Style x:Key="glyphsOperationButtonStyle" TargetType="Button">
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding Glyphs.Count, Mode=OneWay, FallbackValue=0}" Value="0">
+                        <Setter Property="IsEnabled" Value="False"/>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
         </Grid.Resources>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="1*"/>
             <ColumnDefinition Width="3*"/>
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -228,10 +237,19 @@
             </DataGrid.Columns>
         </local:DataGridDark>
 
-        <TextBlock Grid.Row="16" Grid.Column="0" Grid.ColumnSpan="2" Margin="3" TextWrapping="Wrap" HorizontalAlignment="Center">
+        <TextBlock Grid.Row="16" Grid.ColumnSpan="2" Margin="3" TextWrapping="Wrap" HorizontalAlignment="Center" TextAlignment="Center">
             Note that the glyphs need to be specified in ascending order.<LineBreak/>
             Press the button below to sort them appropriately.
         </TextBlock>
-        <local:ButtonDark Grid.Row="17" Grid.Column="0" Grid.ColumnSpan="2" Margin="3" Click="Button_Sort_Click">Sort glyphs</local:ButtonDark>
+        <local:ButtonDark Grid.Row="17" Grid.ColumnSpan="2" Margin="3" Click="Button_Sort_Click"
+                          Content="Sort glyphs" Width="200" FontSize="14" Style="{StaticResource glyphsOperationButtonStyle}"/>
+
+        <TextBlock Grid.Row="18" Grid.ColumnSpan="2" Margin="3,6,3,3" TextWrapping="Wrap" HorizontalAlignment="Center" TextAlignment="Center">
+            Also, if you have added new characters or changed the character<LineBreak/>
+            of an existing glyph, you should update the font range.<LineBreak/>
+            Press the button below to do that.
+        </TextBlock>
+        <local:ButtonDark Grid.Row="19" Grid.ColumnSpan="2" Margin="3" Click="Button_UpdateRange_Click"
+                          Content="Update range" Width="200" FontSize="14" Style="{StaticResource glyphsOperationButtonStyle}"/>
     </Grid>
 </local:DataUserControl>

--- a/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml
@@ -116,8 +116,41 @@
             </Grid>
         </Viewbox>
 
-        <local:ButtonDark Grid.Row="13" Grid.ColumnSpan="2" Margin="3" HorizontalAlignment="Center" Width="250"
-                          Content="Edit a selected glyph rectangle" Click="EditRectangleButton_Click"/>
+        <StackPanel Grid.Row="13" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center">
+            <local:ButtonDark Margin="3" Width="230" Click="EditRectangleButton_Click">
+                <Button.Style>
+                    <Style TargetType="Button">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding SelectedItem, ElementName=GlyphsGrid, Mode=OneWay}"
+                                         Value="{x:Null}">
+                                <Setter Property="IsEnabled" Value="False"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Button.Style>
+                <Button.Content>
+                    <TextBlock>
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Text" Value="Edit a selected glyph rectangle"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding SelectedItem.SourceWidth, ElementName=GlyphsGrid, Mode=OneWay, FallbackValue=-1}"
+                                                 Value="0">
+                                        <Setter Property="Text" Value="Select a region of an empty glyph"/>
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding SelectedItem.SourceHeight, ElementName=GlyphsGrid, Mode=OneWay, FallbackValue=-1}"
+                                                 Value="0">
+                                        <Setter Property="Text" Value="Select a region of an empty glyph"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </Button.Content>
+            </local:ButtonDark>
+
+            <local:ButtonDark Margin="3" Width="200" Content="Create an empty glyph" Click="CreateGlyphButton_Click"/>
+        </StackPanel>
 
         <TextBlock Grid.Row="14" Grid.Column="0" Margin="3">Glyphs:</TextBlock>
         <local:DataGridDark Grid.Row="15" Grid.ColumnSpan="2" MaxHeight="370" Margin="3" x:Name="GlyphsGrid" ItemsSource="{Binding Glyphs, Mode=OneWay}"

--- a/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml
@@ -317,8 +317,7 @@
                     <DataGridTemplateColumn Width="*">
                         <DataGridTemplateColumn.Header>
                             <StackPanel Orientation="Horizontal" ToolTipService.InitialShowDelay="250"
-                                    ToolTip="The number of pixels to shift right when advancing to the next character.&#13;
-                                             It's highlighed in green on the texture above.">
+                                    ToolTip="The number of pixels to shift right when advancing to the next character.&#13;It's highlighed in green on the texture above.">
                                 <TextBlock Text="Shift" Margin="0,0,3,0"/>
                                 <TextBlock Text="(?)" Foreground="Gray" FontSize="11" Margin="0,0,3,0"/>
                                 <Rectangle Width="7" Height="7" Fill="LawnGreen"/>
@@ -333,8 +332,7 @@
                     <DataGridTemplateColumn Width="*">
                         <DataGridTemplateColumn.Header>
                             <StackPanel Orientation="Horizontal" ToolTipService.InitialShowDelay="250"
-                                    ToolTip="The number of pixels to horizontally offset the rendering of the glyph.&#13;
-                                             It's highlighed in blue on the texture above.">
+                                    ToolTip="The number of pixels to horizontally offset the rendering of the glyph.&#13;It's highlighed in blue on the texture above.">
                                 <TextBlock Text="Offset" Margin="0,0,3,0"/>
                                 <TextBlock Text="(?)" Foreground="Gray" FontSize="11" Margin="0,0,3,0"/>
                                 <Rectangle Width="7" Height="7" Fill="Blue"/>

--- a/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml
@@ -159,7 +159,7 @@
                                                 <BeginStoryboard.Storyboard>
                                                     <Storyboard RepeatBehavior="Forever">
                                                         <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="Opacity"
-                                                                                                   Duration="0:0:2">
+                                                                                       Duration="0:0:2">
                                                             <DiscreteDoubleKeyFrame Value="1" KeyTime="0:0:0" />
                                                             <DiscreteDoubleKeyFrame Value="0" KeyTime="0:0:1" />
                                                         </DoubleAnimationUsingKeyFrames>
@@ -347,7 +347,7 @@
                     <DataGridTemplateColumn Header="Kerning" Width="60">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <local:ButtonDark Click="EditKerningButton_Click" Style="{StaticResource kerningButtonStyle}"/>
+                                <local:ButtonDark Margin="0,-1" Click="EditKerningButton_Click" Style="{StaticResource kerningButtonStyle}"/>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>

--- a/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml.cs
@@ -14,6 +14,7 @@ using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
 using UndertaleModLib.Models;
+using UndertaleModTool.Editors.UndertaleFontEditor;
 
 namespace UndertaleModTool
 {
@@ -85,7 +86,14 @@ namespace UndertaleModTool
 
         private void EditRectangleButton_Click(object sender, RoutedEventArgs e)
         {
+            if (GlyphsGrid.SelectedItem is not UndertaleFont.Glyph glyph)
+            {
+                mainWindow.ShowError("No glyph selected.");
+                return;
+            }
 
+            var window = new EditGlyphRectangleWindow(DataContext as UndertaleFont, glyph);
+            window.Show();
         }
     }
 

--- a/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml.cs
@@ -115,6 +115,12 @@ namespace UndertaleModTool
                 return;
             }
 
+            if (DataContext is UndertaleFont font && font.Texture is null)
+            {
+                mainWindow.ShowError("The font has no texture.");
+                return;
+            }
+
             EditGlyphRectangleWindow dialog = null;
             try
             {

--- a/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml.cs
@@ -82,6 +82,11 @@ namespace UndertaleModTool
                 dataEditorViewer.ScrollToVerticalOffset(initOffset);
             }
         }
+
+        private void EditRectangleButton_Click(object sender, RoutedEventArgs e)
+        {
+
+        }
     }
 
     public class CharConverter : IValueConverter

--- a/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml.cs
@@ -115,11 +115,24 @@ namespace UndertaleModTool
                 return;
             }
 
-            var window = new EditGlyphRectangleWindow(DataContext as UndertaleFont, glyph);
-            if (window.ShowDialog() == true)
+            EditGlyphRectangleWindow dialog = null;
+            try
             {
-                GlyphsGrid.SelectedItem = window.SelectedGlyph;
-                ScrollGlyphIntoView(window.SelectedGlyph);
+                dialog = new(DataContext as UndertaleFont, glyph);
+                if (dialog.ShowDialog() == true)
+                {
+                    GlyphsGrid.SelectedItem = dialog.SelectedGlyph;
+                    ScrollGlyphIntoView(dialog.SelectedGlyph);
+                }
+            }
+            catch (Exception ex)
+            {
+                mainWindow.ShowError("An error occured in the glyph rectangle editor window.\n" +
+                                     $"Please report this on GitHub.\n\n{ex}");
+            }
+            finally
+            {
+                dialog?.Close();
             }
         }
         private void CreateGlyphButton_Click(object sender, RoutedEventArgs e)

--- a/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml.cs
@@ -141,12 +141,15 @@ namespace UndertaleModTool
                 return;
 
             int index = font.Glyphs.Count - 1;
-            if (font.Glyphs[index].SourceWidth == 0
-                || font.Glyphs[index].SourceHeight == 0)
+            if (index >= 0)
             {
-                mainWindow.ShowWarning("The last glyph has zero size.\n"+
-                                       "You can use the button on the left to fix that.");
-                return;
+                if (font.Glyphs[index].SourceWidth == 0
+                || font.Glyphs[index].SourceHeight == 0)
+                {
+                    mainWindow.ShowWarning("The last glyph has zero size.\n" +
+                                           "You can use the button on the left to fix that.");
+                    return;
+                }
             }
 
             font.Glyphs.Add(new());

--- a/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml.cs
@@ -32,7 +32,8 @@ namespace UndertaleModTool
 
         private void Button_Sort_Click(object sender, RoutedEventArgs e)
         {
-            UndertaleFont font = this.DataContext as UndertaleFont;
+            if (DataContext is not UndertaleFont font)
+                return;
 
             // There is no way to sort an ObservableCollection in place so we have to do this
             var copy = font.Glyphs.ToList();
@@ -107,6 +108,26 @@ namespace UndertaleModTool
                 GlyphsGrid.SelectedItem = window.SelectedGlyph;
                 ScrollGlyphIntoView(window.SelectedGlyph);
             }
+        }
+        private void CreateGlyphButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is not UndertaleFont font)
+                return;
+
+            int index = font.Glyphs.Count - 1;
+            if (font.Glyphs[index].SourceWidth == 0
+                || font.Glyphs[index].SourceHeight == 0)
+            {
+                mainWindow.ShowWarning("The last glyph has zero size.\n"+
+                                       "You can use the button on the left to fix that.");
+                return;
+            }
+
+            font.Glyphs.Add(new());
+            index++;
+
+            GlyphsGrid.SelectedIndex = index;
+            ScrollGlyphIntoView(index);
         }
     }
 

--- a/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml.cs
@@ -41,6 +41,19 @@ namespace UndertaleModTool
             font.Glyphs.Clear();
             foreach (var glyph in copy)
                 font.Glyphs.Add(glyph);
+
+            mainWindow.ShowMessage("The glyphs were sorted successfully.");
+        }
+        private void Button_UpdateRange_Click(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is not UndertaleFont font)
+                return;
+
+            var characters = font.Glyphs.Select(x => x.Character);
+            font.RangeStart = characters.Min();
+            font.RangeEnd = characters.Max();
+
+            mainWindow.ShowMessage("The range was updated successfully.");
         }
 
         private void Grid_MouseDown(object sender, MouseButtonEventArgs e)

--- a/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml.cs
@@ -63,6 +63,15 @@ namespace UndertaleModTool
                 }
             }
         }
+        private void ScrollGlyphIntoView(UndertaleFont.Glyph glyph)
+        {
+            if (DataContext is not UndertaleFont font)
+                return;
+
+            int index = font.Glyphs.IndexOf(glyph);
+            if (index != -1)
+                ScrollGlyphIntoView(index);
+        }
         private void ScrollGlyphIntoView(int glyphIndex)
         {
             ScrollViewer glyphListViewer = MainWindow.FindVisualChild<ScrollViewer>(GlyphsGrid);
@@ -93,7 +102,11 @@ namespace UndertaleModTool
             }
 
             var window = new EditGlyphRectangleWindow(DataContext as UndertaleFont, glyph);
-            window.Show();
+            if (window.ShowDialog() == true)
+            {
+                GlyphsGrid.SelectedItem = window.SelectedGlyph;
+                ScrollGlyphIntoView(window.SelectedGlyph);
+            }
         }
     }
 

--- a/UndertaleModTool/Editors/UndertaleGameObjectEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleGameObjectEditor.xaml.cs
@@ -36,18 +36,6 @@ namespace UndertaleModTool
             UndertaleGameObject.Event obj = new UndertaleGameObject.Event();
             obj.Actions.Add(new UndertaleGameObject.EventAction());
             e.NewItem = obj;
-
-            _ = Task.Run(() =>
-            {
-                Dispatcher.Invoke(() =>
-                {
-                    // re-focus focused element when grid is updated
-                    FrameworkElement elem = Keyboard.FocusedElement as FrameworkElement;
-                    (sender as DataGrid).MoveFocus(new TraversalRequest(FocusNavigationDirection.Up));
-                    elem?.Focus();
-                },
-                DispatcherPriority.ContextIdle);
-            });
         }
 
         // mouse wheel scrolling fix

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
@@ -28,7 +28,7 @@
         <local:TileLayerTemplateSelector x:Key="TileLayerTemplateSelector"/>
         <local:TileRectanglesConverter x:Key="TileRectanglesConverter"/>
         <local:CachedImageLoaderWithIndex x:Key="CachedImageLoaderWithIndex"/>
-        <local:IsGMS2_2_2_302Converter x:Key="IsGMS2_2_2_302Converter"/>
+        <local:IsVersionAtLeastConverter x:Key="IsVersionAtLeastConverter"/>
         <local:NegateNumberConverter x:Key="NegateNumberConverter"/>
         <local:ParentGridHeightConverter x:Key="ParentGridHeightConverter"/>
         <CompositeCollection x:Key="AllObjectsGMS1">
@@ -650,7 +650,7 @@
                             <TextBlock Grid.Row="6" Grid.Column="0" Margin="3">Rotation</TextBlock>
                             <local:TextBoxDark Grid.Row="6" Grid.Column="2" Margin="3" Text="{Binding Rotation}"/>
 
-                            <Grid Grid.Row="7" Grid.ColumnSpan="3" Visibility="{Binding Data, Mode=OneTime, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type local:MainWindow}}, Converter={StaticResource IsGMS2_2_2_302Converter}}">
+                            <Grid Grid.Row="7" Grid.ColumnSpan="3" Visibility="{Binding Mode=OneTime, Converter={StaticResource IsVersionAtLeastConverter},ConverterParameter=2.2.2.302}">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto" SharedSizeGroup="FirstColumn"/>
                                     <ColumnDefinition Width="5"/>

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -2444,20 +2444,4 @@ namespace UndertaleModTool
             throw new NotImplementedException();
         }
     }
-
-    public class IsGMS2_2_2_302Converter : IValueConverter
-    {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            if (value is not UndertaleData data)
-                return Visibility.Collapsed;
-
-            return data.IsVersionAtLeast(2, 2, 2, 302) ? Visibility.Visible : Visibility.Collapsed;
-        }
-
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            throw new NotImplementedException();
-        }
-    }
 }


### PR DESCRIPTION
## Description

1. **Added the red marker for the selected glyph, made the font texture clickable** (closes #124).
2. Fixed the bug with font texture artifacts (fixes #1319).
3. **Made the glyphs table show and accept actual characters** (the codes can be seen on hover).
4. The cyan border of the texture page item display can be disabled with the `DisplayBorder` property.
5. Added the new two buttons - **"Edit a selected glyph rectangle"** and "Create an empty rectangle".
The first button opens a window where you can either **edit a selected glyph rectangle/area by using mouse** or select a rectangle for new glyph (by dragging mouse).
Also, **you can look all glyph rectangles and zoom the texture.**
6. Added the "Update range" button that updates the font range start and end values.
7. Added the missing font ascender UI fields.
8. **Added the missing documentation for some classes and properties in "UndertaleFont.cs".**
9. **Added an ability to edit glyph kerning** (closes #1181).
10. Fixed some `DataGrid` row related crashes (fixes #1325).
11. **Added the preview for glyph shift and offset values (blinking blue and green lines)**; added a hint for these grid rows.
12. Added the hint for the tileset editor image and made the cursor "hand".
13. Added the `IsVersionAtLeastConverter` WPF converter.
14. New fonts have scale of 1.