### PR TITLE
Fix YYSWF parsing on 2022.1 and beyond

### DIFF
--- a/UndertaleModLib/Models/UndertaleSprite.cs
+++ b/UndertaleModLib/Models/UndertaleSprite.cs
@@ -1177,6 +1177,9 @@ public class UndertaleYYSWFGradientFillData : UndertaleObject
     /// <summary>
     /// Unknown purpose. Probably to accomodate for new texture formats.
     /// </summary>
+    /// <remarks>
+    /// Presumably present in GM 2022.1+.
+    /// </remarks>
     public int? TPEIndex { get; set; }
 
     /// <inheritdoc />

--- a/UndertaleModLib/Models/UndertaleSprite.cs
+++ b/UndertaleModLib/Models/UndertaleSprite.cs
@@ -1667,6 +1667,9 @@ public class UndertaleYYSWFBitmapData : UndertaleObject
     /// <summary>
     /// Unknown purpose. Probably to accomodate for new texture formats.
     /// </summary>
+    /// <remarks>
+    /// Presumably present in GM 2022.1+.
+    /// </remarks>
     public int? TPEIndex { get; set; }
     public byte[] ImageData { get; set; }
     public byte[] AlphaData { get; set; }

--- a/UndertaleModLib/UndertaleIO.cs
+++ b/UndertaleModLib/UndertaleIO.cs
@@ -344,9 +344,7 @@ namespace UndertaleModLib
             if (poolSize != 0 && poolSize != objectPool.Count)
             {
                 SubmitWarning("Warning - the estimated object pool size differs from the actual size.\n" +
-                              "Please report this on UndertaleModTool GitHub.\n" +
-                              "Unless you have a .win with SWF sprites,\n" +
-                              "since YYSWF objects are not pooled due to overlapping.");
+                              "Please report this on UndertaleModTool GitHub.");
             }
 
             return false;

--- a/UndertaleModLib/UndertaleIO.cs
+++ b/UndertaleModLib/UndertaleIO.cs
@@ -344,7 +344,9 @@ namespace UndertaleModLib
             if (poolSize != 0 && poolSize != objectPool.Count)
             {
                 SubmitWarning("Warning - the estimated object pool size differs from the actual size.\n" +
-                              "Please report this on UndertaleModTool GitHub.");
+                              "Please report this on UndertaleModTool GitHub.\n" +
+                              "Unless you have a .win with SWF sprites,\n" +
+                              "since YYSWF objects are not pooled due to overlapping.");
             }
 
             return false;


### PR DESCRIPTION
## Description
<!-- A clear, in-depth description of what the changes are. Reference existing issues and add screenshots if necessary! -->

Fixes issue(s): #1343 

### Caveats
<!-- Any caveats, side effects or regressions of this PR -->

This *assumes* that the TPEIndex system is used on 2022.1 and beyond since this is what I had, older GM versions might use TPEIndex too but I don't have enough .wins nor free time to accurately determine this.

Also YYSWF objects are not pooled since they might overlap, i.e. an object might start directly at the parent object's address. If the pool system handles this correctly now, NoPool can be removed.

### Notes
<!-- Any notes or closing words -->

YYG if you are reading this please, for god's sake, version your damn changes correctly.