### PR TITLE
Object reference field improvements.

### DIFF
--- a/UndertaleModTool/Controls/AudioFileReference.xaml
+++ b/UndertaleModTool/Controls/AudioFileReference.xaml
@@ -31,7 +31,9 @@
                 </Style>
             </TextBox.Style>
         </local:TextBoxDark>
-        <local:TextBoxDark Grid.Column="1" x:Name="ObjectText" IsReadOnly="True" Cursor="Arrow" ToolTip="This is an object reference. Drag and drop an object of matching type from the tree on the left to change it!" AllowDrop="True"
+        <local:TextBoxDark Grid.Column="1" x:Name="ObjectText" IsReadOnly="True" Cursor="Arrow" AllowDrop="True"
+                           ToolTip="This is an object reference. Drag and drop an object of matching type from the tree on the left to change it!"
+                           ToolTipService.InitialShowDelay="250"
                            PreviewDragOver="TextBox_DragOver" PreviewDrop="TextBox_Drop" PreviewMouseDoubleClick="TextBox_MouseDoubleClick" PreviewMouseDown="Details_MouseDown">
             <TextBox.Style>
                 <Style TargetType="{x:Type TextBox}">

--- a/UndertaleModTool/Controls/UndertaleObjectReference.xaml
+++ b/UndertaleModTool/Controls/UndertaleObjectReference.xaml
@@ -6,12 +6,14 @@
              xmlns:local="clr-namespace:UndertaleModTool"
              xmlns:undertale="clr-namespace:UndertaleModLib.Models;assembly=UndertaleModLib"
              mc:Ignorable="d" 
-             d:DesignHeight="20" d:DesignWidth="300">
+             d:DesignHeight="20" d:DesignWidth="300"
+             Name="objectReference">
     <UserControl.Resources>
         <local:ContextMenuDark x:Key="contextMenu" Opened="MenuItem_ContextMenuOpened">
             <MenuItem Header="Open in new tab" Click="OpenInNewTabItem_Click"/>
             <MenuItem Header="Find all references" Click="FindAllReferencesItem_Click"/>
         </local:ContextMenuDark>
+        <Label x:Key="emptyReferenceLabel" Foreground="Gray" FontStyle="Italic" />
     </UserControl.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
@@ -23,21 +25,37 @@
                            ToolTip="This is an object reference. Drag and drop an object of matching type from the tree on the left to change it!"
                            ToolTipService.InitialShowDelay="250"
                            PreviewDragOver="TextBox_DragOver" PreviewDrop="TextBox_Drop" PreviewMouseDoubleClick="TextBox_MouseDoubleClick" PreviewMouseDown="Details_MouseDown"
-                           Text="{Binding ObjectReference, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
+                           Text="{Binding ObjectReference, ElementName=objectReference}">
+            <TextBox.Style>
+                <Style TargetType="{x:Type TextBox}">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding ObjectReference, ElementName=objectReference}" Value="{x:Null}">
+                            <Setter Property="Background">
+                                <Setter.Value>
+                                    <VisualBrush AlignmentX="Left" AlignmentY="Center" Stretch="None"
+                                                 Visual="{StaticResource emptyReferenceLabel}">
+                                    </VisualBrush>
+                                </Setter.Value>
+                            </Setter>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBox.Style>
+        </local:TextBoxDark>
         <local:ButtonDark Grid.Column="1" x:Name="DetailsButton" Click="Details_Click" MouseDown="Details_MouseDown">
             <Button.Style>
                 <Style TargetType="{x:Type Button}">
                     <Setter Property="Content" Value=" ... " />
                     <Setter Property="ToolTip" Value="Open referenced object" />
                     <Style.Triggers>
-                        <DataTrigger Binding="{Binding ObjectReference, RelativeSource={RelativeSource AncestorType=UserControl}}" Value="{x:Null}">
+                        <DataTrigger Binding="{Binding ObjectReference, ElementName=objectReference}" Value="{x:Null}">
                             <Setter Property="IsEnabled" Value="False"/>
                         </DataTrigger>
 
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
-                                <Condition Binding="{Binding ObjectType, RelativeSource={RelativeSource AncestorType=UserControl}}" Value="{x:Type undertale:UndertaleCode}" />
-                                <Condition Binding="{Binding ObjectReference, RelativeSource={RelativeSource AncestorType=UserControl}}" Value="{x:Null}" />
+                                <Condition Binding="{Binding ObjectType, ElementName=objectReference}" Value="{x:Type undertale:UndertaleCode}" />
+                                <Condition Binding="{Binding ObjectReference, ElementName=objectReference}" Value="{x:Null}" />
                             </MultiDataTrigger.Conditions>
                             <Setter Property="Content" Value=" + "/>
                             <Setter Property="ToolTip" Value="Create new code entry" />
@@ -51,12 +69,12 @@
             <Button.Style>
                 <Style TargetType="{x:Type Button}">
                     <Style.Triggers>
-                        <DataTrigger Binding="{Binding CanRemove, RelativeSource={RelativeSource AncestorType=UserControl}}" Value="False">
+                        <DataTrigger Binding="{Binding CanRemove, ElementName=objectReference}" Value="False">
                             <DataTrigger.Setters>
                                 <Setter Property="IsEnabled" Value="False"/>
                             </DataTrigger.Setters>
                         </DataTrigger>
-                        <DataTrigger Binding="{Binding ObjectReference, RelativeSource={RelativeSource AncestorType=UserControl}}" Value="{x:Null}">
+                        <DataTrigger Binding="{Binding ObjectReference, ElementName=objectReference}" Value="{x:Null}">
                             <DataTrigger.Setters>
                                 <Setter Property="IsEnabled" Value="False"/>
                             </DataTrigger.Setters>

--- a/UndertaleModTool/Controls/UndertaleObjectReference.xaml
+++ b/UndertaleModTool/Controls/UndertaleObjectReference.xaml
@@ -21,6 +21,7 @@
         </Grid.ColumnDefinitions>
         <local:TextBoxDark Grid.Column="0" x:Name="ObjectText" IsReadOnly="True" Cursor="Arrow" AllowDrop="True"
                            ToolTip="This is an object reference. Drag and drop an object of matching type from the tree on the left to change it!"
+                           ToolTipService.InitialShowDelay="250"
                            PreviewDragOver="TextBox_DragOver" PreviewDrop="TextBox_Drop" PreviewMouseDoubleClick="TextBox_MouseDoubleClick" PreviewMouseDown="Details_MouseDown"
                            Text="{Binding ObjectReference, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
         <local:ButtonDark Grid.Column="1" x:Name="DetailsButton" Click="Details_Click" MouseDown="Details_MouseDown">

--- a/UndertaleModTool/Controls/UndertaleObjectReference.xaml.cs
+++ b/UndertaleModTool/Controls/UndertaleObjectReference.xaml.cs
@@ -111,6 +111,21 @@ namespace UndertaleModTool
         public UndertaleObjectReference()
         {
             InitializeComponent();
+            Loaded += UndertaleObjectReference_Loaded;
+        }
+        private void UndertaleObjectReference_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (ObjectType is null)
+                return;
+
+            var label = TryFindResource("emptyReferenceLabel") as Label;
+            if (label is null)
+                return;
+            
+            string typeName = ObjectType.ToString();
+            if (typeName.StartsWith("UndertaleModLib.Models."))
+                typeName = typeName["UndertaleModLib.Models.".Length..];
+            label.Content = $"(drag & drop an object of type {typeName})";
         }
 
         public void ClearRemoveClickHandler()

--- a/UndertaleModTool/Controls/UndertaleObjectReference.xaml.cs
+++ b/UndertaleModTool/Controls/UndertaleObjectReference.xaml.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -27,6 +28,8 @@ namespace UndertaleModTool
     public partial class UndertaleObjectReference : UserControl
     {
         private static readonly MainWindow mainWindow = Application.Current.MainWindow as MainWindow;
+        private static readonly Regex camelCaseRegex = new("(?<=[a-z])([A-Z])", RegexOptions.Compiled);
+        private static readonly char[] vowels = { 'a', 'o', 'u', 'e', 'i', 'y' };
 
         public static DependencyProperty ObjectReferenceProperty =
             DependencyProperty.Register("ObjectReference", typeof(object),
@@ -123,9 +126,18 @@ namespace UndertaleModTool
                 return;
             
             string typeName = ObjectType.ToString();
-            if (typeName.StartsWith("UndertaleModLib.Models."))
-                typeName = typeName["UndertaleModLib.Models.".Length..];
-            label.Content = $"(drag & drop an object of type {typeName})";
+            string n = "";
+            if (typeName.StartsWith("UndertaleModLib.Models.Undertale"))
+            {
+                // "UndertaleAudioGroup" -> "audio group"
+                typeName = typeName["UndertaleModLib.Models.Undertale".Length..];
+                typeName = camelCaseRegex.Replace(typeName, " $1").ToLowerInvariant();
+            }
+            // If the first letter is a vowel
+            if (Array.IndexOf(vowels, typeName[0]) != -1)
+                n = "n";
+                
+            label.Content = $"(drag & drop a{n} {typeName})";
         }
 
         public void ClearRemoveClickHandler()

--- a/UndertaleModTool/Controls/UndertaleStringReference.xaml
+++ b/UndertaleModTool/Controls/UndertaleStringReference.xaml
@@ -17,8 +17,9 @@
             <ColumnDefinition Width="*"/>
             <ColumnDefinition Width="Auto"/>
         </Grid.ColumnDefinitions>
-        <local:TextBoxDark Grid.Column="0" x:Name="ObjectText" ToolTip="This is an string reference. Change the value here to edit this just this value of all referenced values, or drag and drop another string instance from the tree on the left to change the reference"
-                           AllowDrop="True" Text="{Binding ObjectReference.Content, RelativeSource={RelativeSource AncestorType=UserControl}, UpdateSourceTrigger=Explicit}"
+        <local:TextBoxDark Grid.Column="0" x:Name="ObjectText" AllowDrop="True"
+                           ToolTip="This is an string reference. Change the value here to edit this just this value of all referenced values, or drag and drop another string instance from the tree on the left to change the reference"
+                           Text="{Binding ObjectReference.Content, RelativeSource={RelativeSource AncestorType=UserControl}, UpdateSourceTrigger=Explicit}"
                            PreviewDragOver="TextBox_DragOver" PreviewDrop="TextBox_Drop" LostFocus="TextBox_LostFocus" PreviewMouseDown="Details_MouseDown">
             <TextBox.Style>
                 <Style TargetType="{x:Type TextBox}">


### PR DESCRIPTION
## Description
1. Made the object reference tooltip show earlier.
2. Added a hint for empty `UndertaleObjectReference` field (e.g. "_(drag & drop a code)_").

Closes #1359.