### PR TITLE
Suppress the missing XML comment warnings.

### DIFF
--- a/UndertaleModCli/UndertaleModCli.csproj
+++ b/UndertaleModCli/UndertaleModCli.csproj
@@ -4,9 +4,11 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
-	<Nullable>disable</Nullable>
-	<RollForward>LatestMajor</RollForward>
-	<GenerateDocumentationFile>True</GenerateDocumentationFile>
+	  <Nullable>disable</Nullable>
+	  <RollForward>LatestMajor</RollForward>
+	  <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <!-- Supress all missing XML comment warnings -->
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/UndertaleModCli/UndertaleModCli.csproj
+++ b/UndertaleModCli/UndertaleModCli.csproj
@@ -7,7 +7,7 @@
 	  <Nullable>disable</Nullable>
 	  <RollForward>LatestMajor</RollForward>
 	  <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <!-- Supress all missing XML comment warnings -->
+    <!-- Suppress all missing XML comment warnings -->
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
 

--- a/UndertaleModCli/UndertaleModCli.csproj
+++ b/UndertaleModCli/UndertaleModCli.csproj
@@ -4,9 +4,9 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
-	  <Nullable>disable</Nullable>
-	  <RollForward>LatestMajor</RollForward>
-	  <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <Nullable>disable</Nullable>
+    <RollForward>LatestMajor</RollForward>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <!-- Suppress all missing XML comment warnings -->
     <NoWarn>1591</NoWarn>
   </PropertyGroup>

--- a/UndertaleModLib/UndertaleDataExtensionMethods.cs
+++ b/UndertaleModLib/UndertaleDataExtensionMethods.cs
@@ -44,7 +44,7 @@ public static class UndertaleDataExtensionMethods
 	/// </summary>
 	/// <param name="list">The <see cref="List{T}"/> of <see cref="UndertaleString"/>.</param>
 	/// <param name="content">The string to create a <see cref="UndertaleString"/> of.</param>
-	/// <param name="createNew">Whether to create a new <see cref="UndertaleString"/> if the one with the same content exists.
+	/// <param name="createNew">Whether to create a new <see cref="UndertaleString"/> if the one with the same content exists.</param>
 	/// <returns><paramref name="content"/> as a <see cref="UndertaleString"/>.</returns>
 	/// <exception cref="ArgumentNullException"><paramref name="content"/> is null.</exception>
 	public static UndertaleString MakeString(this IList<UndertaleString> list, string content, bool createNew = false)

--- a/UndertaleModLib/UndertaleModLib.csproj
+++ b/UndertaleModLib/UndertaleModLib.csproj
@@ -8,6 +8,8 @@
     <Platforms>AnyCPU;x64</Platforms>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Supress all missing XML comment warnings -->
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />

--- a/UndertaleModLib/UndertaleModLib.csproj
+++ b/UndertaleModLib/UndertaleModLib.csproj
@@ -8,7 +8,7 @@
     <Platforms>AnyCPU;x64</Platforms>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- Supress all missing XML comment warnings -->
+    <!-- Suppress all missing XML comment warnings -->
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup>

--- a/UndertaleModTool/UndertaleModTool.csproj
+++ b/UndertaleModTool/UndertaleModTool.csproj
@@ -14,6 +14,8 @@
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
         <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
         <StartupObject>UndertaleModTool.Program</StartupObject>
+        <!-- Supress all missing XML comment warnings -->
+        <NoWarn>1591</NoWarn>
     </PropertyGroup>
     <ItemGroup>
       <None Remove="Resources\tabs_left_button.png" />

--- a/UndertaleModTool/UndertaleModTool.csproj
+++ b/UndertaleModTool/UndertaleModTool.csproj
@@ -14,7 +14,7 @@
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
         <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
         <StartupObject>UndertaleModTool.Program</StartupObject>
-        <!-- Supress all missing XML comment warnings -->
+        <!-- Suppress all missing XML comment warnings -->
         <NoWarn>1591</NoWarn>
     </PropertyGroup>
     <ItemGroup>

--- a/UndertaleModToolUpdater/UndertaleModToolUpdater.csproj
+++ b/UndertaleModToolUpdater/UndertaleModToolUpdater.csproj
@@ -7,6 +7,8 @@
     <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <!-- Supress all missing XML comment warnings -->
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Description
This PR removes all the "Missing XML comment for publicly visible type or member" unnecessary warnings that appeared as a side effect of [this commit](https://github.com/krzys-h/UndertaleModTool/commit/054debd29a841dae25ddc3639137a1c9240f1848).