### PR TITLE
Room order grid controls

### DIFF
--- a/UndertaleModTool/Controls/UndertaleObjectReference.xaml
+++ b/UndertaleModTool/Controls/UndertaleObjectReference.xaml
@@ -12,6 +12,7 @@
         <local:ContextMenuDark x:Key="contextMenu" Opened="MenuItem_ContextMenuOpened">
             <MenuItem Header="Open in new tab" Click="OpenInNewTabItem_Click"/>
             <MenuItem Header="Find all references" Click="FindAllReferencesItem_Click"/>
+            <MenuItem Header="Copy name to clipboard" Click="CopyNameToClipboard_Click"/>
         </local:ContextMenuDark>
         <Label x:Key="emptyReferenceLabel" Foreground="Gray" FontStyle="Italic" />
     </UserControl.Resources>
@@ -21,7 +22,7 @@
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="Auto"/>
         </Grid.ColumnDefinitions>
-        <local:TextBoxDark Grid.Column="0" x:Name="ObjectText" IsReadOnly="True" Cursor="Arrow" AllowDrop="True"
+        <local:TextBoxDark Grid.Column="0" x:Name="ObjectText" IsReadOnly="True" Cursor="Arrow" AllowDrop="True" Focusable="False"
                            ToolTip="This is an object reference. Drag and drop an object of matching type from the tree on the left to change it!"
                            ToolTipService.InitialShowDelay="250"
                            PreviewDragOver="TextBox_DragOver" PreviewDrop="TextBox_Drop" PreviewMouseDoubleClick="TextBox_MouseDoubleClick" PreviewMouseDown="Details_MouseDown"

--- a/UndertaleModTool/Controls/UndertaleObjectReference.xaml.cs
+++ b/UndertaleModTool/Controls/UndertaleObjectReference.xaml.cs
@@ -226,6 +226,10 @@ namespace UndertaleModTool
                 dialog?.Close();
             }
         }
+        private void CopyNameToClipboard_Click(object sender, RoutedEventArgs e)
+        {
+            mainWindow.CopyItemName(ObjectReference);
+        }
 
         private void Remove_Click(object sender, RoutedEventArgs e)
         {

--- a/UndertaleModTool/Editors/UndertaleGeneralInfoEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleGeneralInfoEditor.xaml
@@ -158,7 +158,7 @@
                 <TextBlock Grid.Row="21" Grid.Column="0" Margin="3">Room order</TextBlock>
                 <Expander Grid.Row="21" Grid.Column="1" Margin="3" Header="List" Name="RoomListExpander">
                     <local:DataGridDark ItemsSource="{Binding GeneralInfo.RoomOrder}" MaxHeight="369" x:Name="RoomListGrid"
-                                        AutoGenerateColumns="False" CanUserAddRows="True" CanUserDeleteRows="True" HorizontalGridLinesBrush="LightGray" VerticalGridLinesBrush="LightGray" HeadersVisibility="None" SelectionMode="Single" SelectionUnit="FullRow"
+                                        AutoGenerateColumns="False" CanUserAddRows="True" CanUserDeleteRows="True" HorizontalGridLinesBrush="LightGray" VerticalGridLinesBrush="LightGray" HeadersVisibility="None" SelectionMode="Extended" SelectionUnit="FullRow"
                                         ScrollViewer.CanContentScroll="True"
                                         VirtualizingPanel.IsVirtualizing="True"
                                         VirtualizingPanel.VirtualizationMode="Recycling"

--- a/UndertaleModTool/Editors/UndertaleGeneralInfoEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleGeneralInfoEditor.xaml
@@ -155,14 +155,14 @@
 
                 <TextBlock Grid.Row="20" Grid.Column="0" Margin="3">Debugger port</TextBlock>
                 <local:TextBoxDark Grid.Row="20" Grid.Column="1" Margin="3" Text="{Binding GeneralInfo.DebuggerPort}"/>
-
                 <TextBlock Grid.Row="21" Grid.Column="0" Margin="3">Room order</TextBlock>
                 <Expander Grid.Row="21" Grid.Column="1" Margin="3" Header="List" Name="RoomListExpander">
                     <local:DataGridDark ItemsSource="{Binding GeneralInfo.RoomOrder}" MaxHeight="369" x:Name="RoomListGrid"
                                         AutoGenerateColumns="False" CanUserAddRows="True" CanUserDeleteRows="True" HorizontalGridLinesBrush="LightGray" VerticalGridLinesBrush="LightGray" HeadersVisibility="None" SelectionMode="Single" SelectionUnit="FullRow"
                                         ScrollViewer.CanContentScroll="True"
                                         VirtualizingPanel.IsVirtualizing="True"
-                                        VirtualizingPanel.VirtualizationMode="Recycling">
+                                        VirtualizingPanel.VirtualizationMode="Recycling"
+                                        KeyDown="RoomListGrid_KeyDown">
                         <DataGrid.Resources>
                             <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="#FF26A0DA"/>
                             <Style TargetType="{x:Type DataGridCell}">

--- a/UndertaleModTool/Editors/UndertaleGeneralInfoEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleGeneralInfoEditor.xaml
@@ -188,6 +188,12 @@
                                 </Style.Triggers>
                             </Style>
                         </DataGrid.Resources>
+                        <DataGrid.CommandBindings>
+                            <CommandBinding Command="New" Executed="Command_New"/>
+                        </DataGrid.CommandBindings>
+                        <DataGrid.InputBindings>
+                            <KeyBinding Modifiers="Control" Key="N" Command="New"/>
+                        </DataGrid.InputBindings>
                         <DataGrid.Columns>
                             <DataGridTemplateColumn Width="*">
                                 <DataGridTemplateColumn.CellTemplate>

--- a/UndertaleModTool/Editors/UndertaleGeneralInfoEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleGeneralInfoEditor.xaml.cs
@@ -104,11 +104,14 @@ namespace UndertaleModTool
 
         private void SyncRoomList_Click(object sender, RoutedEventArgs e)
         {
-            IList<UndertaleRoom> rooms = mainWindow.Data.Rooms;
-            IList<UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM>> roomOrder = (this.DataContext as GeneralInfoEditor).GeneralInfo.RoomOrder;
-            roomOrder.Clear();
-            foreach(var room in rooms)
-                roomOrder.Add(new UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM>() { Resource = room });
+            if (mainWindow.ShowQuestion("Sync room order with room list?\n\nThis will undo all changes made to the room order.", MessageBoxImage.Warning, "Confirmation") == MessageBoxResult.Yes)
+            {
+                IList<UndertaleRoom> rooms = mainWindow.Data.Rooms;
+                IList<UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM>> roomOrder = (this.DataContext as GeneralInfoEditor).GeneralInfo.RoomOrder;
+                roomOrder.Clear();
+                foreach (var room in rooms)
+                    roomOrder.Add(new UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM>() { Resource = room });
+            }
         }
 
         private void DebuggerCheckBox_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)

--- a/UndertaleModTool/Editors/UndertaleGeneralInfoEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleGeneralInfoEditor.xaml.cs
@@ -30,10 +30,14 @@ namespace UndertaleModTool
             InitializeComponent();
         }
 
+        private void SelectItem(UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM> room)
+        {
+            RoomListGrid.ScrollIntoView(room); // This works with a virtualized DataGrid
+            RoomListGrid.SelectedItem = room;
+        }
+
         private void MoveItem(UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM> room, int dist)
         {
-            // TODO: enable virtualizing of RoomListGrid and make this method work with it
-
             IList<UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM>> roomOrder = (this.DataContext as GeneralInfoEditor).GeneralInfo.RoomOrder;
 
             int index = roomOrder.IndexOf(room);
@@ -46,13 +50,12 @@ namespace UndertaleModTool
             int newIndex = Math.Clamp(index + dist, 0 , roomOrder.Count - 1);
             if (newIndex != index)
             {
-                UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM> prevRoom = roomOrder[newIndex];
-                roomOrder[newIndex] = roomOrder[index];
-                roomOrder[index] = prevRoom;
+                // Tuple syntax for swapping values. Looks nicer and isn't any slower.
+                // See https://www.reddit.com/r/ProgrammerTIL/comments/8ssiqb/comment/e12301f/
+                (roomOrder[newIndex], roomOrder[index]) = (roomOrder[index], roomOrder[newIndex]);
             }
 
-            RoomListGrid.UpdateLayout();
-            RoomListGrid.SelectedItem = RoomListGrid.Items[newIndex];
+            SelectItem(roomOrder[newIndex]);
         }
 
         private void RoomListGrid_KeyDown(object sender, KeyEventArgs e)

--- a/UndertaleModTool/Editors/UndertaleGeneralInfoEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleGeneralInfoEditor.xaml.cs
@@ -99,22 +99,36 @@ namespace UndertaleModTool
                 return;
 
             List<UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM>> selectedRooms = selected.Cast<UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM>>().ToList();
-
+            int dist = (Keyboard.Modifiers & ModifierKeys.Shift) == ModifierKeys.Shift ? 5 : 1;
             switch (e.Key)
             {
                 case Key.OemMinus:
-                    MoveItem(selectedRooms, -1);
+                    MoveItem(selectedRooms, -dist);
                     break;
                 case Key.OemPlus:
-                    MoveItem(selectedRooms, 1);
-                    break;
-                 case Key.N: // Insert new blank room after selected rooms
-                    int index = selectedRooms.Select(room => roomOrder.IndexOf(room)).Max();
-                    UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM> newRoom = new();
-                    roomOrder.Insert(index + 1, newRoom);
-                    SelectItems(new List<UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM>> { newRoom }, newRoom);
+                    MoveItem(selectedRooms, dist);
                     break;
             }
+        }
+
+        /// <summary>
+        /// Insert new blank room after selected rooms.
+        /// </summary>
+        private void Command_New(object sender, RoutedEventArgs e)
+        {
+            IList<UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM>> roomOrder = (this.DataContext as GeneralInfoEditor).GeneralInfo.RoomOrder;
+
+            System.Collections.IList selected = RoomListGrid.SelectedItems;
+            selected.Remove(CollectionView.NewItemPlaceholder);
+            if (selected.Count == 0)
+                return;
+
+            List<UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM>> selectedRooms = selected.Cast<UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM>>().ToList();
+
+            int index = selectedRooms.Select(room => roomOrder.IndexOf(room)).Max();
+            UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM> newRoom = new();
+            roomOrder.Insert(index + 1, newRoom);
+            SelectItems(new List<UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM>> { newRoom }, newRoom);
         }
 
         private void SyncRoomList_Click(object sender, RoutedEventArgs e)
@@ -143,7 +157,6 @@ namespace UndertaleModTool
             if (result == MessageBoxResult.Yes)
                 checkBox.IsChecked = false;
         }
-
     }
 
     public class TimestampDateTimeConverter : IValueConverter

--- a/UndertaleModTool/Editors/UndertaleGeneralInfoEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleGeneralInfoEditor.xaml.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Documents;
 using System.Windows.Input;
@@ -30,10 +31,18 @@ namespace UndertaleModTool
             InitializeComponent();
         }
 
-        private void SelectItem(UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM> room)
+        private void SelectItem(object room)
         {
             RoomListGrid.ScrollIntoView(room); // This works with a virtualized DataGrid
             RoomListGrid.SelectedItem = room;
+            RoomListGrid.CurrentItem= room;
+            RoomListGrid.UpdateLayout();
+
+            // Set focus to the selected Element
+            DataGridRow row = RoomListGrid.ItemContainerGenerator.ContainerFromItem(room) as DataGridRow;
+            DataGridCellsPresenter presenter = MainWindow.FindVisualChild<DataGridCellsPresenter>(row) as DataGridCellsPresenter;
+            DataGridCell cell = presenter.ItemContainerGenerator.ContainerFromIndex(0) as DataGridCell;
+            cell.Focus();
         }
 
         private void MoveItem(UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM> room, int dist)

--- a/UndertaleModTool/Editors/UndertaleGeneralInfoEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleGeneralInfoEditor.xaml.cs
@@ -31,6 +31,10 @@ namespace UndertaleModTool
             InitializeComponent();
         }
 
+        /// <summary>
+        /// Selects the given room inside the RoomOrderList.
+        /// </summary>
+        /// <param name="room">the room to select.</param>
         private void SelectItem(object room)
         {
             RoomListGrid.ScrollIntoView(room); // This works with a virtualized DataGrid
@@ -45,6 +49,11 @@ namespace UndertaleModTool
             cell.Focus();
         }
 
+        /// <summary>
+        /// Moves the given room up and down the RoomOrderList./>.
+        /// </summary>
+        /// <param name="room">The room to move.</param>
+        /// <param name="dist">Distance to move it. Positive - down, negative - up.</param>
         private void MoveItem(UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM> room, int dist)
         {
             IList<UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM>> roomOrder = (this.DataContext as GeneralInfoEditor).GeneralInfo.RoomOrder;
@@ -69,6 +78,8 @@ namespace UndertaleModTool
 
         private void RoomListGrid_KeyDown(object sender, KeyEventArgs e)
         {
+            IList<UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM>> roomOrder = (this.DataContext as GeneralInfoEditor).GeneralInfo.RoomOrder;
+
             object selected = RoomListGrid.SelectedItem;
             if (selected == null)
                 return;
@@ -81,6 +92,12 @@ namespace UndertaleModTool
                     break;
                 case Key.OemPlus:
                     MoveItem(room, 1);
+                    break;
+                 case Key.N: // Insert new blank room
+                    int index = roomOrder.IndexOf(room);
+                    UndertaleResourceById < UndertaleRoom, UndertaleChunkROOM > newRoom = new();
+                    roomOrder.Insert(index + 1, newRoom);
+                    SelectItem(newRoom);
                     break;
             }
         }

--- a/UndertaleModTool/Editors/UndertaleGeneralInfoEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleGeneralInfoEditor.xaml.cs
@@ -81,6 +81,7 @@ namespace UndertaleModTool
             indexes.Sort();
             if (dist > 0)
                 indexes.Reverse();
+
             object current = RoomListGrid.CurrentItem; // In case changing the order changes CurrentItem
             foreach(int index in indexes)
                 (roomOrder[index + dist], roomOrder[index]) = (roomOrder[index], roomOrder[index + dist]);
@@ -92,20 +93,23 @@ namespace UndertaleModTool
         {
             IList<UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM>> roomOrder = (this.DataContext as GeneralInfoEditor).GeneralInfo.RoomOrder;
 
-            List<UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM>> selected = RoomListGrid.SelectedItems.Cast<UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM>>().ToList();
+            System.Collections.IList selected = RoomListGrid.SelectedItems;
+            selected.Remove(CollectionView.NewItemPlaceholder);
             if (selected.Count == 0)
                 return;
+
+            List<UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM>> selectedRooms = selected.Cast<UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM>>().ToList();
 
             switch (e.Key)
             {
                 case Key.OemMinus:
-                    MoveItem(selected, -1);
+                    MoveItem(selectedRooms, -1);
                     break;
                 case Key.OemPlus:
-                    MoveItem(selected, 1);
+                    MoveItem(selectedRooms, 1);
                     break;
                  case Key.N: // Insert new blank room after selected rooms
-                    int index = selected.Select(room => roomOrder.IndexOf(room)).Max();
+                    int index = selectedRooms.Select(room => roomOrder.IndexOf(room)).Max();
                     UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM> newRoom = new();
                     roomOrder.Insert(index + 1, newRoom);
                     SelectItems(new List<UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM>> { newRoom }, newRoom);

--- a/UndertaleModTool/Editors/UndertaleGeneralInfoEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleGeneralInfoEditor.xaml.cs
@@ -30,6 +30,49 @@ namespace UndertaleModTool
             InitializeComponent();
         }
 
+        private void MoveItem(UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM> room, int dist)
+        {
+            // TODO: enable virtualizing of RoomListGrid and make this method work with it
+
+            IList<UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM>> roomOrder = (this.DataContext as GeneralInfoEditor).GeneralInfo.RoomOrder;
+
+            int index = roomOrder.IndexOf(room);
+            if (index == -1)
+            {
+                mainWindow.ShowError("Can't change room position - room not found in room order.");
+                return;
+            }
+
+            int newIndex = Math.Clamp(index + dist, 0 , roomOrder.Count - 1);
+            if (newIndex != index)
+            {
+                UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM> prevRoom = roomOrder[newIndex];
+                roomOrder[newIndex] = roomOrder[index];
+                roomOrder[index] = prevRoom;
+            }
+
+            RoomListGrid.UpdateLayout();
+            RoomListGrid.SelectedItem = RoomListGrid.Items[newIndex];
+        }
+
+        private void RoomListGrid_KeyDown(object sender, KeyEventArgs e)
+        {
+            object selected = RoomListGrid.SelectedItem;
+            if (selected == null)
+                return;
+            UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM> room = selected as UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM>;
+            
+            switch(e.Key)
+            {
+                case Key.OemMinus:
+                    MoveItem(room, -1);
+                    break;
+                case Key.OemPlus:
+                    MoveItem(room, 1);
+                    break;
+            }
+        }
+
         private void SyncRoomList_Click(object sender, RoutedEventArgs e)
         {
             IList<UndertaleRoom> rooms = mainWindow.Data.Rooms;
@@ -53,6 +96,7 @@ namespace UndertaleModTool
             if (result == MessageBoxResult.Yes)
                 checkBox.IsChecked = false;
         }
+
     }
 
     public class TimestampDateTimeConverter : IValueConverter

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -1847,7 +1847,7 @@ namespace UndertaleModTool
                 }
             }
         }
-        private void CopyItemName(object obj)
+        public void CopyItemName(object obj)
         {
             string name = null;
 


### PR DESCRIPTION
## Description
<!-- A clear, in-depth description of what the changes are. Reference existing issues and add screenshots if necessary! -->
Fix #1370.
Items can be moved up and down the list with - and + (faster when holding shift), and empty items can be inserted with ctrl+n.
### Caveats
<!-- Any caveats, side effects or regressions of this PR -->
- The controls aren't useable via the mouse.
- I'm unsure about ctrl+n as the keybind for inserting a new room, especially given that it's already taken for creating a new file.
- I've made the textbox of UndertaleObjectReference non-focusable because it was taking the focus when clicking on it in the list, which means you can't scroll via keyboard or use any of the new controls. I've added a way to copy the name of the object via the context menu as a replacement for being able to directly copy the text.
### Notes
<!-- Any notes or closing words -->