### PR TITLE
Add LineHeight as a 2023.6 font attribute.

### DIFF
--- a/UndertaleModLib/Models/UndertaleFont.cs
+++ b/UndertaleModLib/Models/UndertaleFont.cs
@@ -92,6 +92,11 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
     /// <value><c>0</c> if SDF is disabled for this font.</value>
     public uint SDFSpread { get; set; }
 
+    /// <remarks>
+    /// Was introduced in GM 2023.6.
+    /// </remarks>
+    public uint LineHeight { get; set; }
+
     /// <summary>
     /// The glyphs that this font uses.
     /// </summary>
@@ -292,6 +297,8 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
             writer.Write(Ascender);
         if (writer.undertaleData.IsVersionAtLeast(2023, 2))
             writer.Write(SDFSpread);
+        if (writer.undertaleData.IsVersionAtLeast(2023, 6))
+            writer.Write(LineHeight);
         writer.WriteUndertaleObject(Glyphs);
     }
 
@@ -326,6 +333,8 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
             Ascender = reader.ReadUInt32();
         if (reader.undertaleData.IsVersionAtLeast(2023, 2))
             SDFSpread = reader.ReadUInt32();
+        if (reader.undertaleData.IsVersionAtLeast(2023, 6))
+            LineHeight = reader.ReadUInt32();
         Glyphs = reader.ReadUndertaleObject<UndertalePointerList<Glyph>>();
     }
 
@@ -339,6 +348,8 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
             skipSize += 4; // Ascender
         if (reader.undertaleData.IsVersionAtLeast(2023, 2))
             skipSize += 4; // SDFSpread
+        if (reader.undertaleData.IsVersionAtLeast(2023, 6))
+            skipSize += 4; // LineHeight
 
         reader.Position += skipSize;
 

--- a/UndertaleModTool/Converters/IsVersionAtLeastConverter.cs
+++ b/UndertaleModTool/Converters/IsVersionAtLeastConverter.cs
@@ -33,7 +33,7 @@ namespace UndertaleModTool
                 if (ver.Groups[3].Value != "")
                     release = uint.Parse(ver.Groups[3].Value);
                 if (ver.Groups[4].Value != "")
-                    release = uint.Parse(ver.Groups[4].Value);
+                    build = uint.Parse(ver.Groups[4].Value);
 
                 if (mainWindow.Data.IsVersionAtLeast(major, minor, release, build))
                     return Visibility.Visible;

--- a/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml
@@ -116,6 +116,11 @@
         <local:TextBoxDark Grid.Row="12" Grid.Column="1" Margin="3" Text="{Binding SDFSpread}"
                            Visibility="{Binding Mode=OneTime, Converter={StaticResource IsVersionAtLeastConverter}, ConverterParameter=2023.2}"/>
 
+        <TextBlock Grid.Row="13" Grid.Column="0" Margin="3" Text="Line height"
+                   Visibility="{Binding Mode=OneTime, Converter={StaticResource IsVersionAtLeastConverter}, ConverterParameter=2023.6}"/>
+        <local:TextBoxDark Grid.Row="13" Grid.Column="1" Margin="3" Text="{Binding LineHeight}"
+                           Visibility="{Binding Mode=OneTime, Converter={StaticResource IsVersionAtLeastConverter}, ConverterParameter=2023.6}"/>
+
         <TextBlock Grid.Row="13" Grid.ColumnSpan="2" Margin="3,30,3,3" HorizontalAlignment="Center" Foreground="DarkGray" FontStyle="Italic" TextWrapping="Wrap" TextAlignment="Center">
             Hint: You can click on any glyph here to highlight it in the "Glyphs".
         </TextBlock>

--- a/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/UndertaleFontEditor.xaml
@@ -121,10 +121,10 @@
         <local:TextBoxDark Grid.Row="13" Grid.Column="1" Margin="3" Text="{Binding LineHeight}"
                            Visibility="{Binding Mode=OneTime, Converter={StaticResource IsVersionAtLeastConverter}, ConverterParameter=2023.6}"/>
 
-        <TextBlock Grid.Row="13" Grid.ColumnSpan="2" Margin="3,30,3,3" HorizontalAlignment="Center" Foreground="DarkGray" FontStyle="Italic" TextWrapping="Wrap" TextAlignment="Center">
+        <TextBlock Grid.Row="14" Grid.ColumnSpan="2" Margin="3,30,3,3" HorizontalAlignment="Center" Foreground="DarkGray" FontStyle="Italic" TextWrapping="Wrap" TextAlignment="Center">
             Hint: You can click on any glyph here to highlight it in the "Glyphs".
         </TextBlock>
-        <Viewbox Grid.Row="14" Grid.ColumnSpan="2" Margin="3" Stretch="Uniform" StretchDirection="DownOnly">
+        <Viewbox Grid.Row="15" Grid.ColumnSpan="2" Margin="3" Stretch="Uniform" StretchDirection="DownOnly">
             <Grid MouseDown="Grid_MouseDown" Cursor="Hand">
                 <Grid.Background>
                     <SolidColorBrush Color="Black"/>
@@ -204,7 +204,7 @@
             </Grid>
         </Viewbox>
 
-        <StackPanel Grid.Row="15" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center">
+        <StackPanel Grid.Row="16" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center">
             <local:ButtonDark Margin="3" Width="220" Click="EditRectangleButton_Click">
                 <Button.Style>
                     <Style TargetType="Button">
@@ -240,8 +240,8 @@
             <local:ButtonDark Margin="3" Width="200" Content="Create an empty glyph" Click="CreateGlyphButton_Click"/>
         </StackPanel>
 
-        <TextBlock Name="GlyphsLabel" Grid.Row="16" Grid.ColumnSpan="2" Margin="3" HorizontalAlignment="Left">Glyphs:</TextBlock>
-        <Grid Grid.Row="17" Grid.ColumnSpan="2" MaxHeight="370" Margin="3">
+        <TextBlock Name="GlyphsLabel" Grid.Row="17" Grid.ColumnSpan="2" Margin="3" HorizontalAlignment="Left">Glyphs:</TextBlock>
+        <Grid Grid.Row="18" Grid.ColumnSpan="2" MaxHeight="370" Margin="3">
             <local:DataGridDark x:Name="GlyphsGrid" ItemsSource="{Binding Glyphs, Mode=OneWay}"
                                 AutoGenerateColumns="False" CanUserAddRows="True" CanUserDeleteRows="True" HorizontalGridLinesBrush="LightGray" VerticalGridLinesBrush="LightGray" HeadersVisibility="Column" SelectionMode="Single" SelectionUnit="FullRow"
                                 ScrollViewer.CanContentScroll="True"
@@ -446,19 +446,19 @@
             </Border>
         </Grid>
 
-        <TextBlock Grid.Row="18" Grid.ColumnSpan="2" Margin="3" TextWrapping="Wrap" HorizontalAlignment="Center" TextAlignment="Center">
+        <TextBlock Grid.Row="19" Grid.ColumnSpan="2" Margin="3" TextWrapping="Wrap" HorizontalAlignment="Center" TextAlignment="Center">
             Note that the glyphs need to be specified in ascending order.<LineBreak/>
             Press the button below to sort them appropriately.
         </TextBlock>
-        <local:ButtonDark Grid.Row="19" Grid.ColumnSpan="2" Margin="3" Click="Button_Sort_Click"
+        <local:ButtonDark Grid.Row="20" Grid.ColumnSpan="2" Margin="3" Click="Button_Sort_Click"
                           Content="Sort glyphs" Width="200" FontSize="14" Style="{StaticResource glyphsOperationButtonStyle}"/>
 
-        <TextBlock Grid.Row="20" Grid.ColumnSpan="2" Margin="3,6,3,3" TextWrapping="Wrap" HorizontalAlignment="Center" TextAlignment="Center">
+        <TextBlock Grid.Row="21" Grid.ColumnSpan="2" Margin="3,6,3,3" TextWrapping="Wrap" HorizontalAlignment="Center" TextAlignment="Center">
             Also, if you have added new characters or changed the character<LineBreak/>
             of an existing glyph, you should update the font range.<LineBreak/>
             Press the button below to do that.
         </TextBlock>
-        <local:ButtonDark Grid.Row="21" Grid.ColumnSpan="2" Margin="3" Click="Button_UpdateRange_Click"
+        <local:ButtonDark Grid.Row="22" Grid.ColumnSpan="2" Margin="3" Click="Button_UpdateRange_Click"
                           Content="Update range" Width="200" FontSize="14" Style="{StaticResource glyphsOperationButtonStyle}"/>
     </Grid>
 </local:DataUserControl>


### PR DESCRIPTION
## Description
Adds the new LineHeight value included in GM2023.6 fonts with appropriate version detection. Also, fixes an apparent typo in IsVersionAtLeastConverter that would set `build` to what should have been `release`, overriding the correct `build`. It likely didn't affect anything since most version checks aren't that precise, but better safe than sorry.

### Caveats
Has not been extensively tested. The original reporter of #1453 claims the same error occurs with GM2023.4, which I could not reproduce.

The LineHeight value has remarks on being added with 2023.6, but not a summary because I'm not 100% sure how it interacts with games. It's probably in the GameMaker changelog...

### Notes
N/A