### PR TITLE
Prevent blocks from being requeued in switch decompilation

### DIFF
--- a/UndertaleModLib/Decompiler/Decompiler.cs
+++ b/UndertaleModLib/Decompiler/Decompiler.cs
@@ -4066,8 +4066,13 @@ namespace UndertaleModLib.Decompiler
                 return meetPoint;
 
             Queue<Block> blocks = new Queue<Block>();
+            // Preventing the same block and its children from being queued repeatedly
+            // becomes increasingly important on large switches. The HashSet should give
+            // good performance while preventing this type of duplication.
+            HashSet<Block> usedBlocks = new HashSet<Block>(); 
 
             blocks.Enqueue(start);
+            usedBlocks.Add(start);
             while (blocks.Count > 0)
             {
                 Block test = blocks.Dequeue();
@@ -4076,10 +4081,16 @@ namespace UndertaleModLib.Decompiler
                     return end;
                 if (test == meetPoint)
                     return meetPoint;
-
-                blocks.Enqueue(test.nextBlockTrue);
-                if (test.nextBlockTrue != test.nextBlockFalse)
+                if (!usedBlocks.Contains(test.nextBlockTrue))
+                {
+                    blocks.Enqueue(test.nextBlockTrue);
+                    usedBlocks.Add(test.nextBlockTrue);
+                }
+                if (!usedBlocks.Contains(test.nextBlockFalse))
+                {
                     blocks.Enqueue(test.nextBlockFalse);
+                    usedBlocks.Add(test.nextBlockFalse);
+                }
 
             }
 


### PR DESCRIPTION
## Description
Resolves #1179, resolves #1446 by adding a HashSet of all parsed blocks to switch statement decompilation. Previously, the same block could be queued multiple times, which would cause a memory leak the more levels of blocks there are in a switch (see Notes). 

### Caveats
I do not have formal C# training and have not run benchmark tests on this code. At least one other pair of eyes would be appreciated.

### Notes
Take the following example.

Old code:
```
Start with Block 1
Block 1 links to Block 2 and Block 2. The code correctly detects both branches match and only queues Block 2 once.
Block 2 links to Block 3 and Block 6. The code queues both, in that order.
Block 3 links to Block 4 and Block 6. The code queues both again.
Block 6 links to Block 7 and Block 8. The code queues both of these.
Block 4 links to Block 6 and Block 6. The code queues Block 6 one more time.
At this point, the queue is: 6, 6, 7, 8, 6. Further parsing leads to: 7, 8, 6, 7, 8, 7, 8.
Block 7 links to Block 9 and Block 9. We suppose that Block 9 is the end condition that will terminate the loop.
```
However, at this point, the code still has to parse 6 more blocks before it actually reaches Block 9 and terminates. With more nested blocks, the problem grows exponentially.

New code:
```
Start with Block 1
Block 1 links to Block 2 and Block 2. The code queues Block 2, adding it to the HashSet. Because the HashSet now contains Block 2, it is not queued a second time.
Block 2 links to Block 3 and Block 6. The code queues both, in that order.
Block 3 links to Block 4 and Block 6. The code queues Block 4, but detects Block 6 is queued and skips it.
Block 6 links to Block 7 and Block 8. The code queues both.
Block 4 links to Block 6 and Block 6. Both are discarded.
Block 7 links to Block 9 and Block 9. Block 9 is queued once.
At this point, the queue is merely: 8, 9.
```
This represents a reduction from 15 iterations of the loop to 8. The effect is far more pronounced on a real script like scr_player_mach3 with extensive code inside each case of the switch statement (over 250 blocks in one case).

I'm not actually sure what multiple blocks linking to the same block represents in this case. But it absolutely happens and causes the leak.