### PR TITLE
A fix of the "Disassembly" freeze.

### DIFF
--- a/UndertaleModLib/Decompiler/Assembler.cs
+++ b/UndertaleModLib/Decompiler/Assembler.cs
@@ -42,6 +42,9 @@ namespace UndertaleModLib.Decompiler
             { "pushref", -11 }
         };
 
+        private static readonly Regex callInstrRegex = new(@"^(.*)\(argc=(.*)\)$", RegexOptions.Compiled);
+        private static readonly Regex codeEntryRegex = new(@"^\(locals=(.*)\,\s*argc=(.*)\)$", RegexOptions.Compiled);
+
         // TODO: Improve the error messages
 
         public static UndertaleInstruction AssembleOne(string source, IList<UndertaleFunction> funcs, IList<UndertaleVariable> vars, IList<UndertaleString> strg, Dictionary<string, UndertaleVariable> localvars = null, UndertaleData data = null)
@@ -206,7 +209,7 @@ namespace UndertaleModLib.Decompiler
                     break;
 
                 case UndertaleInstruction.InstructionType.CallInstruction:
-                    Match match = Regex.Match(line, @"^(.*)\(argc=(.*)\)$");
+                    Match match = callInstrRegex.Match(line);
                     if (!match.Success)
                         throw new Exception("Call instruction format error");
 
@@ -255,7 +258,7 @@ namespace UndertaleModLib.Decompiler
 
         public static List<UndertaleInstruction> Assemble(string source, IList<UndertaleFunction> funcs, IList<UndertaleVariable> vars, IList<UndertaleString> strg, UndertaleData data = null)
         {
-            var strReader = new StringReader(source);
+            StringReader strReader = new(source);
             uint addr = 0;
             Dictionary<string, uint> labels = new Dictionary<string, uint>();
             Dictionary<UndertaleInstruction, string> labelTargets = new Dictionary<UndertaleInstruction, string>();
@@ -281,7 +284,7 @@ namespace UndertaleModLib.Decompiler
                         throw new Exception($"Failed to find code entry with name \"{codeName}\".");
                     string info = line.Substring(space + 1);
 
-                    Match match = Regex.Match(info, @"^\(locals=(.*)\,\s*argc=(.*)\)$");
+                    Match match = codeEntryRegex.Match(info);
                     if (!match.Success)
                         throw new Exception("Sub-code entry format error");
                     code.LocalsCount = ushort.Parse(match.Groups[1].Value);

--- a/UndertaleModLib/Decompiler/Assembler.cs
+++ b/UndertaleModLib/Decompiler/Assembler.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -254,15 +255,16 @@ namespace UndertaleModLib.Decompiler
 
         public static List<UndertaleInstruction> Assemble(string source, IList<UndertaleFunction> funcs, IList<UndertaleVariable> vars, IList<UndertaleString> strg, UndertaleData data = null)
         {
-            var lines = source.Replace("\r", "", StringComparison.InvariantCulture).Split('\n');
+            var strReader = new StringReader(source);
             uint addr = 0;
             Dictionary<string, uint> labels = new Dictionary<string, uint>();
             Dictionary<UndertaleInstruction, string> labelTargets = new Dictionary<UndertaleInstruction, string>();
             List<UndertaleInstruction> instructions = new List<UndertaleInstruction>();
             Dictionary<string, UndertaleVariable> localvars = new Dictionary<string, UndertaleVariable>();
-            foreach (var fullline in lines)
+            string fullLine;
+            while ((fullLine = strReader.ReadLine()) is not null)
             {
-                string line = fullline;
+                string line = fullLine;
                 if (line.Length == 0)
                     continue;
 

--- a/UndertaleModLib/Decompiler/Decompiler.cs
+++ b/UndertaleModLib/Decompiler/Decompiler.cs
@@ -3986,6 +3986,8 @@ namespace UndertaleModLib.Decompiler
                 data.KnownSubFunctions = new Dictionary<string, UndertaleFunction>();
                 GlobalDecompileContext globalDecompileContext = new GlobalDecompileContext(data, false);
 
+                // TODO: Is this necessary?
+                // Doesn't the latter `Parallel.ForEach()` already cover this?
                 foreach (var func in data.Functions)
                 {
                     if (func.Name.Content.StartsWith("gml_Script_"))

--- a/UndertaleModLib/Decompiler/Decompiler.cs
+++ b/UndertaleModLib/Decompiler/Decompiler.cs
@@ -3990,7 +3990,7 @@ namespace UndertaleModLib.Decompiler
                 {
                     if (func.Name.Content.StartsWith("gml_Script_"))
                     {
-                        var funcName = func.Name.Content.Substring("gml_Script_".Length);
+                        var funcName = func.Name.Content[("gml_Script_".Length)..];
                         data.KnownSubFunctions.TryAdd(funcName, func);
                     }
                 }
@@ -4013,7 +4013,7 @@ namespace UndertaleModLib.Decompiler
                             {
                                 lock (data.KnownSubFunctions)
                                 {
-                                    data.KnownSubFunctions.Add(assign.Destination.Var.Name.Content, funcDef.Function);
+                                    data.KnownSubFunctions.TryAdd(assign.Destination.Var.Name.Content, funcDef.Function);
                                 }
                             }
                         }

--- a/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
@@ -714,20 +714,19 @@ namespace UndertaleModTool
                                     for (int i = 0; i < matches.Length; i++)
                                     {
                                         Match match = matches[i];
-                                        if (match.Success)
-                                        {
-                                            if (currDict.TryGetValue(match.Groups[1].Value, out string text))
-                                            {
-                                                if (i != matches.Length - 1) // if not the last
-                                                    decompLinesBuilder.Append($"{text}; ");
-                                                else
-                                                    decompLinesBuilder.Append(text + '\n');
-                                            }
-                                        }
+                                        if (!currDict.TryGetValue(match.Groups[1].Value, out string text))
+                                            continue;
+
+                                        if (i != matches.Length - 1) // If not the last
+                                            decompLinesBuilder.Append($"{text}; ");
+                                        else
+                                            decompLinesBuilder.Append(text + '\n');
                                     }
                                 }
                                 else
+                                {
                                     decompLinesBuilder.Append(line + '\n');
+                                }
                             }
 
                             decompiled = decompLinesBuilder.ToString();

--- a/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
@@ -557,8 +557,8 @@ namespace UndertaleModTool
         }
 
         public static Dictionary<string, string> gettextJSON = null;
-        private static readonly Regex gettextRegex = new("scr_gettext\\(\\\"(\\w*)\\\"\\)", RegexOptions.Compiled);
-        private static readonly Regex getlangRegex = new("scr_84_get_lang_string(\\w*)\\(\\\"(\\w*)\\\"\\)", RegexOptions.Compiled);
+        private static readonly Regex gettextRegex = new("scr_gettext\\(\\\"(.*?)\\\"\\)", RegexOptions.Compiled);
+        private static readonly Regex getlangRegex = new("scr_84_get_lang_string(?:.*?)\\(\\\"(.*?)\\\"\\)", RegexOptions.Compiled);
         private string UpdateGettextJSON(string json)
         {
             try


### PR DESCRIPTION
## Description
1) Fixes #1487, fixes #1586.
2) Improves the "Decompiled" code tab performance for the code entries with "scr_gettext()" or "scr_84_get_lang_string()" a little.