### PR TITLE
 add relative path solution to script's #load

### DIFF
--- a/UndertaleModTool/ImportCodeSystem.cs
+++ b/UndertaleModTool/ImportCodeSystem.cs
@@ -341,13 +341,6 @@ namespace UndertaleModTool
                                         Data.GameObjects.Add(gameObj);
                                     }
                                 }
-                                if (Data.GameObjects.ByName(methodNumberStr) != null)
-                                {
-                                    // It *needs* to have a valid value, make the user specify one, silly.
-                                    List<uint> possible_values = new List<uint>();
-                                    possible_values.Add(uint.MaxValue);
-                                    ReassignGUIDs(methodNumberStr, ReduceCollisionValue(possible_values));
-                                }
                             }
                             else
                             {

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -2580,6 +2580,18 @@ namespace UndertaleModTool
             string scriptText = $"#line 1 \"{path}\"\n" + File.ReadAllText(path);
             Debug.WriteLine(path);
 
+            // since attempting to load scripts with #load in a file will lead to it using the UTMT path,
+            // we can circumvent this by hardcoding the absolute path to the script directory
+            // in all instances of #load with a relative path
+            var scriptDir = Path.GetDirectoryName(path);
+            var loadPattern = new Regex(@"(?<=^#load\s+"")(([\\""]|[^""])+)(?=""\s*$)", RegexOptions.Multiline);
+            scriptText = loadPattern.Replace(scriptText, match =>
+            {
+                if (Path.IsPathRooted(match.Value))
+                    return match.Value;
+                return Path.Combine(scriptDir, match.Value);
+            });
+
             Dispatcher.Invoke(() => CommandBox.Text = "Running " + Path.GetFileName(path) + " ...");
             try
             {

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -2584,13 +2584,13 @@ namespace UndertaleModTool
             // we can circumvent this by hardcoding the absolute path to the script directory
             // in all instances of #load with a relative path
             var scriptDir = Path.GetDirectoryName(path);
-            var loadPattern = new Regex(@"(?<=^#load\s+"")(([\\""]|[^""])+)(?=""\s*$)", RegexOptions.Multiline);
-            scriptText = loadPattern.Replace(scriptText, match =>
+            var matches = Regex.Matches(scriptText, @"(?<=^#load\s+"").*\.csx(?=""\s*$)", RegexOptions.Multiline);
+            foreach (Match match in matches)
             {
                 if (Path.IsPathRooted(match.Value))
-                    return match.Value;
-                return Path.Combine(scriptDir, match.Value);
-            });
+                    continue;
+                scriptText = scriptText.Replace(match.Value, Path.Combine(scriptDir, match.Value));
+            }
 
             Dispatcher.Invoke(() => CommandBox.Text = "Running " + Path.GetFileName(path) + " ...");
             try


### PR DESCRIPTION
## Description
If attempting to use #load inside a csx script, and you supply a relative path, it will not work as one might believe, that is, that the relative path should be to the script path. To fix this, the goal is so that whenever someone uses #load to a relative path, it will "hardcode" that with an absolute path so that it will work.

### Caveats
The previous version of this PR had a small mistake but now the pattern was fixed and I can't see issues with this. It is working fine on my project so far