### PR TITLE
fix importing collision event files when the objects already exist

### DIFF
--- a/UndertaleModTool/ImportCodeSystem.cs
+++ b/UndertaleModTool/ImportCodeSystem.cs
@@ -341,13 +341,6 @@ namespace UndertaleModTool
                                         Data.GameObjects.Add(gameObj);
                                     }
                                 }
-                                if (Data.GameObjects.ByName(methodNumberStr) != null)
-                                {
-                                    // It *needs* to have a valid value, make the user specify one, silly.
-                                    List<uint> possible_values = new List<uint>();
-                                    possible_values.Add(uint.MaxValue);
-                                    ReassignGUIDs(methodNumberStr, ReduceCollisionValue(possible_values));
-                                }
                             }
                             else
                             {


### PR DESCRIPTION
## Description
If you try using the `ImportGMLFile` for a collision event, for example, for a file named `gml_Object_obj_pipis_bullet_cone_Collision_obj_yheart_shot.gml`, and tried to link to the objects automatically, even if the objects in the event already existed, it would require you to type the object, despite it already knowing it. With this fix, this issue is removed.

### Caveats
In my tests, it worked perfectly. I'm not sure why the original code that caused this problem existed, so unless it had any special reason to be there, there should be no problems with this change.