### PR TITLE
Import modified code

### DIFF
--- a/UndertaleModLib/Scripting/IScriptInterface.cs
+++ b/UndertaleModLib/Scripting/IScriptInterface.cs
@@ -581,7 +581,8 @@ namespace UndertaleModLib.Scripting
         /// <param name="checkDecompiler">If this is <see langword="false"/> an empty string
         /// will be used for replacing the code entry in the case that anything fails.</param>
         /// <param name="throwOnError">Whether a <see cref="ScriptException"/> will be thrown on any errors.</param>
-        void ImportGMLFile(string fileName, bool doParse = true, bool checkDecompiler = false, bool throwOnError = false);
+        /// <param name="canBeModified">Whether the file can use the custom "modified" file syntax</param>
+        void ImportGMLFile(string fileName, bool doParse = true, bool checkDecompiler = false, bool throwOnError = false, bool canBeModified = false);
 
         /// <summary>
         /// Replaces/Imports all GM-Bytecode ASM in a specific code entry with a specified file.

--- a/UndertaleModTool/ImportCodeSystem.cs
+++ b/UndertaleModTool/ImportCodeSystem.cs
@@ -45,9 +45,9 @@ namespace UndertaleModTool
             ImportCode(codeName, gmlCode, false, doParse, nukeProfile, checkDecompiler);
         }
 
-        public void ImportGMLFile(string fileName, bool doParse = true, bool checkDecompiler = false, bool throwOnError = false)
+        public void ImportGMLFile(string fileName, bool doParse = true, bool checkDecompiler = false, bool throwOnError = false, bool canBeModified = false)
         {
-            ImportCodeFromFile(fileName, true, doParse, true, checkDecompiler, throwOnError);
+            ImportCodeFromFile(fileName, true, doParse, true, checkDecompiler, throwOnError, canBeModified);
         }
 
         public void ImportASMFile(string fileName, bool doParse = true, bool nukeProfile = true, bool checkDecompiler = false, bool throwOnError = false)
@@ -163,7 +163,7 @@ namespace UndertaleModTool
             }
         }
 
-        void ImportCodeFromFile(string file, bool IsGML = true, bool doParse = true, bool destroyASM = true, bool CheckDecompiler = false, bool throwOnError = false)
+        void ImportCodeFromFile(string file, bool IsGML = true, bool doParse = true, bool destroyASM = true, bool CheckDecompiler = false, bool throwOnError = false, bool canBeModified = false)
         {
             try
             {
@@ -175,7 +175,7 @@ namespace UndertaleModTool
                     return;
                 string codeName = Path.GetFileNameWithoutExtension(file);
                 string gmlCode = File.ReadAllText(file);
-                ImportCode(codeName, gmlCode, IsGML, doParse, destroyASM, CheckDecompiler, throwOnError);
+                ImportCode(codeName, gmlCode, IsGML, doParse, destroyASM, CheckDecompiler, throwOnError, canBeModified);
             }
             catch (ScriptException exc) when (throwOnError && exc.Message == "*codeImportError*")
             {
@@ -249,9 +249,9 @@ namespace UndertaleModTool
             public ModifiedCommandException(string line) : base("Unknown command in modified code: " + line) { }
         }
 
-        void ImportCode(string codeName, string gmlCode, bool IsGML = true, bool doParse = true, bool destroyASM = true, bool CheckDecompiler = false, bool throwOnError = false)
+        void ImportCode(string codeName, string gmlCode, bool IsGML = true, bool doParse = true, bool destroyASM = true, bool CheckDecompiler = false, bool throwOnError = false, bool canBeModified = false)
         {
-            ImportCodeType codeType = gmlCode.StartsWith("/// MODIFIED") ? ImportCodeType.Modified : ImportCodeType.Literal;
+            ImportCodeType codeType = canBeModified && gmlCode.StartsWith("/// MODIFIED") ? ImportCodeType.Modified : ImportCodeType.Literal;
             bool SkipPortions = false;
             UndertaleCode code = Data.Code.ByName(codeName);
             if (code is null)


### PR DESCRIPTION
## Description

# The issue
Currently, the `ImportGMLFile` method from the scripting interact only allows you to import the whole code and replace it. This means that in order to modify only parts of the code, you need to either:
1. Include the entire code entry as a .GML file, and only edit what you must
2. Define some methods in the script to replace only what you must

However, the following issues exist with these two approaches:

1. In the first approach:
* If only a small change is required, the file ends up having a lot of redundant and irrelevant information for the project, since the whole code must be copied.
* If a small version change happens, the change might end up breaking, which possibly would not have happened if the whole change had to be explicited, that is, following an approach like 2.

2. In the second approach:
* The code can become less organized: Either a big number of GML code files would need to be embedded in the CSX, or specific code files would need to be created for sections of the GML, and then manually called for each file and case, which could become unnecessarily repetitive for big projects.

# The attempted solution
In order to fix this, a simple declarative syntax has been created. It starts with `ImportGMLFile`, if the `canBeModified` boolean is set to true, then the code will take into consideration that the system *might* be used (but it could not be, as well):

```cs
// in a CSX script
ImportGMLFile(somePath + "/gml_Object_obj_time_Create_0.gml", canBeModified: true);
```

If the system is used, then, it will be applied if the first line of the GML code being imported is:
`/// MODIFIED

/// REPLACE 
if (quicksaved != 2)
/// CODE
if (quicksaved != 3) // now quit_timer's value has changed
/// END

/// AFTER
draw_set_color(c_red)
/// CODE
testing_after = "after the line `draw_set_color(c_red)`, this code will be there"
/// END

/// APPEND
testing_an_append = "this will be at the end of the file"
/// END

/// PREPEND
testing_a_prepend = "this will be at the start of the file"
/// END

/// INSERT 7
test_insert = "this is after line 7, so it will be line 8"
/// END
```
Consider the original code was

```gml
if scr_debug()
{
    if (quicksaved != 2)
        scr_84_debug(false)
    if gif_recording
    {
        draw_set_color(c_red)
        draw_set_font(fnt_main)
        draw_text(0, 440, ("GIF FRAME:" + string(gif_timer)))
    }
}
if (quit_timer >= 1)
    draw_sprite_ext(scr_84_get_sprite("spr_quitmessage"), (quit_timer / 7), 4, 4, 2, 2, 0, c_white, (quit_timer / 15))
```

Then, the GML file from above would make the code be:

```gml
testing_a_prepend = "this will be at the start of the file"
if scr_debug()
{
    if (quicksaved != 3)
        scr_84_debug(false)
    if gif_recording
    {
        test_insert = "this is after line 7, so it will be line 8"
        draw_set_color(c_red)
        testing_after = "after the line `draw_set_color(c_red)`, this code will be there"
        draw_set_font(fnt_main)
        draw_text(0, 440, ("GIF FRAME:" + string(gif_timer)))
    }
}
if (quit_timer >= 1)
    draw_sprite_ext(scr_84_get_sprite("spr_quitmessage"), (quit_timer / 7), 4, 4, 2, 2, 0, c_white, (quit_timer / 15))
testing_an_append = "this will be at the end of the file"
```

### Caveats
<!-- Any caveats, side effects or regressions of this PR -->
* I don't believe this could cause any unintended side effects. The system is restricted to a case that must be explicitly used, so it won't interfere with any other part of the code, nor will it create compatibility issues with any past scripts.
* I believe the biggest caveat with this system is of it possibly becoming an obscure and undocummented feature. But I believe it's a very useful one for those who want to use it.