### PR TITLE
Create ParticleSystems list on asset layers

### DIFF
--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -1363,6 +1363,9 @@ namespace UndertaleModTool
                 // if it's needed to set "NineSlices"
                 if (!data.IsVersionAtLeast(2, 3, 2))
                     layer.AssetsData.NineSlices ??= new UndertalePointerList<SpriteInstance>();
+                // likewise
+                if (data.IsVersionAtLeast(2023, 2))
+                    layer.AssetsData.ParticleSystems ??= new UndertalePointerList<ParticleSystemInstance>();
             }
             else if (layer.LayerType == LayerType.Tiles)
             {


### PR DESCRIPTION
## Description
Closes #1523 by creating the ParticleSystems asset list on making a new Assets Layer in GM2023.2+.

### Caveats
As far as I can tell, ParticleSystems aren't actually in the UI. Then again, that was the case prior to this pull.

### Notes
N/A