### PR TITLE
More robust GMS 2.2.2.302 and PSEM checks

### DIFF
--- a/UndertaleModLib/Models/UndertaleParticleSystem.cs
+++ b/UndertaleModLib/Models/UndertaleParticleSystem.cs
@@ -80,9 +80,21 @@ public class UndertaleParticleSystemEmitter : UndertaleNamedResource, INotifyPro
 
     public UndertaleString Name { get; set; }
 
+    // 2023.6
+    public bool Enabled { get; set; } = true;
+
     public EmitMode Mode { get; set; }
 
-    public int EmitCount { get; set; } = 1;
+    public int EmitCount { get; set; } = 1; // Note: technically single in 2023.8
+
+    // 2023.8
+    public bool EmitRelative { get; set; }
+    public float DelayMin { get; set; }
+    public float DelayMax { get; set; }
+    public TimeUnitEnum DelayUnit { get; set; }
+    public float IntervalMin { get; set; }
+    public float IntervalMax { get; set; }
+    public TimeUnitEnum IntervalUnit { get; set; }
 
     public DistributionEnum Distribution { get; set; }
 
@@ -104,6 +116,11 @@ public class UndertaleParticleSystemEmitter : UndertaleNamedResource, INotifyPro
 
     public float FrameIndex { get; set; }
 
+    // 2023.4
+    public bool Animate { get; set; }
+    public bool Stretch { get; set; }
+    public bool IsRandom { get; set; }
+
     public uint StartColor { get; set; } = 0xFFFFFFFF;
 
     public uint MidColor { get; set; } = 0xFFFFFFFF;
@@ -120,13 +137,23 @@ public class UndertaleParticleSystemEmitter : UndertaleNamedResource, INotifyPro
 
     public float ScaleY { get; set; } = 1;
 
-    public float SizeMin { get; set; } = 1;
+    // 2023.8
+    public float SizeMinX { get; set; } = 1;
+    public float SizeMaxX { get; set; } = 1;
+    public float SizeIncreaseX { get; set; }
+    public float SizeWiggleX { get; set; }
+    public float SizeMinY { get; set; } = 1;
+    public float SizeMaxY { get; set; } = 1;
+    public float SizeIncreaseY { get; set; }
+    public float SizeWiggleY { get; set; }
 
-    public float SizeMax { get; set; } = 1;
+    public float SizeMin { get => (SizeMinX + SizeMinY) / 2; set { SizeMinX = value; SizeMinY = value; } }
 
-    public float SizeIncrease { get; set; }
+    public float SizeMax { get => (SizeMaxX + SizeMaxY) / 2; set { SizeMaxX = value; SizeMaxY = value; } }
 
-    public float SizeWiggle { get; set; }
+    public float SizeIncrease { get => (SizeIncreaseX + SizeIncreaseY) / 2; set { SizeIncreaseX = value; SizeIncreaseY = value; } }
+
+    public float SizeWiggle { get => (SizeWiggleX + SizeWiggleY) / 2; set { SizeWiggleX = value; SizeWiggleY = value; } }
 
     public float SpeedMin { get; set; } = 5;
 
@@ -170,8 +197,22 @@ public class UndertaleParticleSystemEmitter : UndertaleNamedResource, INotifyPro
     public void Serialize(UndertaleWriter writer)
     {
         writer.WriteUndertaleString(Name);
+        if (writer.undertaleData.IsVersionAtLeast(2023, 6))
+            writer.Write(Enabled);
         writer.Write((int)Mode);
-        writer.Write(EmitCount);
+        if (writer.undertaleData.IsVersionAtLeast(2023, 8))
+        {
+            writer.Write((float)EmitCount);
+            writer.Write(EmitRelative);
+            writer.Write(DelayMin);
+            writer.Write(DelayMax);
+            writer.Write((int)DelayUnit);
+            writer.Write(IntervalMin);
+            writer.Write(IntervalMax);
+            writer.Write((int)IntervalUnit);
+        }
+        else
+            writer.Write(EmitCount);
         writer.Write((int)Distribution);
         writer.Write((int)Shape);
         writer.Write(RegionX);
@@ -182,6 +223,12 @@ public class UndertaleParticleSystemEmitter : UndertaleNamedResource, INotifyPro
         writer.Write(_sprite.SerializeById(writer));
         writer.Write((int)Texture);
         writer.Write(FrameIndex);
+        if (writer.undertaleData.IsVersionAtLeast(2023, 4))
+        {
+            writer.Write(Animate);
+            writer.Write(Stretch);
+            writer.Write(IsRandom);
+        }
         writer.Write(StartColor);
         writer.Write(MidColor);
         writer.Write(EndColor);
@@ -190,10 +237,24 @@ public class UndertaleParticleSystemEmitter : UndertaleNamedResource, INotifyPro
         writer.Write(LifetimeMax);
         writer.Write(ScaleX);
         writer.Write(ScaleY);
-        writer.Write(SizeMin);
-        writer.Write(SizeMax);
-        writer.Write(SizeIncrease);
-        writer.Write(SizeWiggle);
+        if (writer.undertaleData.IsVersionAtLeast(2023, 8))
+        {
+            writer.Write(SizeMinX);
+            writer.Write(SizeMaxX);
+            writer.Write(SizeMinY);
+            writer.Write(SizeMaxY);
+            writer.Write(SizeIncreaseX);
+            writer.Write(SizeIncreaseY);
+            writer.Write(SizeWiggleX);
+            writer.Write(SizeWiggleY);
+        }
+        else
+        {
+            writer.Write(SizeMin);
+            writer.Write(SizeMax);
+            writer.Write(SizeIncrease);
+            writer.Write(SizeWiggle);
+        }
         writer.Write(SpeedMin);
         writer.Write(SpeedMax);
         writer.Write(SpeedIncrease);
@@ -220,8 +281,22 @@ public class UndertaleParticleSystemEmitter : UndertaleNamedResource, INotifyPro
     public void Unserialize(UndertaleReader reader)
     {
         Name = reader.ReadUndertaleString();
+        if (reader.undertaleData.IsVersionAtLeast(2023, 6))
+            Enabled = reader.ReadBoolean();
         Mode = (EmitMode)reader.ReadInt32();
-        EmitCount = reader.ReadInt32();
+        if (reader.undertaleData.IsVersionAtLeast(2023, 8))
+        {
+            EmitCount = (int)reader.ReadSingle(); // The GUI still only allows integer input...
+            EmitRelative = reader.ReadBoolean(); // Always 0
+            DelayMin = reader.ReadSingle();
+            DelayMax = reader.ReadSingle();
+            DelayUnit = (TimeUnitEnum)reader.ReadInt32();
+            IntervalMin = reader.ReadSingle();
+            IntervalMax = reader.ReadSingle();
+            IntervalUnit = (TimeUnitEnum)reader.ReadInt32();
+        }
+        else
+            EmitCount = reader.ReadInt32();
         Distribution = (DistributionEnum)reader.ReadInt32();
         Shape = (EmitterShape)reader.ReadInt32();
         RegionX = reader.ReadSingle();
@@ -233,6 +308,12 @@ public class UndertaleParticleSystemEmitter : UndertaleNamedResource, INotifyPro
         _sprite.Unserialize(reader);
         Texture = (TextureEnum)reader.ReadInt32();
         FrameIndex = reader.ReadSingle();
+        if (reader.undertaleData.IsVersionAtLeast(2023, 4))
+        {
+            Animate = reader.ReadBoolean();
+            Stretch = reader.ReadBoolean();
+            IsRandom = reader.ReadBoolean();
+        }
         StartColor = reader.ReadUInt32();
         MidColor = reader.ReadUInt32();
         EndColor = reader.ReadUInt32();
@@ -241,10 +322,24 @@ public class UndertaleParticleSystemEmitter : UndertaleNamedResource, INotifyPro
         LifetimeMax = reader.ReadSingle();
         ScaleX = reader.ReadSingle();
         ScaleY = reader.ReadSingle();
-        SizeMin = reader.ReadSingle();
-        SizeMax = reader.ReadSingle();
-        SizeIncrease = reader.ReadSingle();
-        SizeWiggle = reader.ReadSingle();
+        if (reader.undertaleData.IsVersionAtLeast(2023, 8))
+        {
+            SizeMinX = reader.ReadSingle();
+            SizeMaxX = reader.ReadSingle();
+            SizeMinY = reader.ReadSingle();
+            SizeMaxY = reader.ReadSingle();
+            SizeIncreaseX = reader.ReadSingle();
+            SizeIncreaseY = reader.ReadSingle();
+            SizeWiggleX = reader.ReadSingle();
+            SizeWiggleY = reader.ReadSingle();
+        }
+        else
+        {
+            SizeMin = reader.ReadSingle();
+            SizeMax = reader.ReadSingle();
+            SizeIncrease = reader.ReadSingle();
+            SizeWiggle = reader.ReadSingle();
+        }
         SpeedMin = reader.ReadSingle();
         SpeedMax = reader.ReadSingle();
         SpeedIncrease = reader.ReadSingle();
@@ -322,5 +417,10 @@ public class UndertaleParticleSystemEmitter : UndertaleNamedResource, INotifyPro
         Cloud = 11,
         Smoke = 12,
         Snow = 13
+    }
+    public enum TimeUnitEnum
+    {
+        Seconds,
+        Frames
     }
 }

--- a/UndertaleModLib/Models/UndertaleParticleSystem.cs
+++ b/UndertaleModLib/Models/UndertaleParticleSystem.cs
@@ -7,6 +7,7 @@ namespace UndertaleModLib.Models;
 [PropertyChanged.AddINotifyPropertyChangedInterface]
 public class UndertaleParticleSystem : UndertaleNamedResource, IDisposable
 {
+    // TODO: Documentation on these values.
     public UndertaleString Name { get; set; }
 
     public int OriginX { get; set; }
@@ -78,6 +79,8 @@ public class UndertaleParticleSystemEmitter : UndertaleNamedResource, INotifyPro
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
     }
 
+    // TODO: Documentation on these values
+
     public UndertaleString Name { get; set; }
 
     // 2023.6
@@ -85,7 +88,7 @@ public class UndertaleParticleSystemEmitter : UndertaleNamedResource, INotifyPro
 
     public EmitMode Mode { get; set; }
 
-    public int EmitCount { get; set; } = 1; // Note: technically single in 2023.8
+    public int EmitCount { get; set; } = 1; // Note: technically float in 2023.8
 
     // 2023.8
     public bool EmitRelative { get; set; }
@@ -147,8 +150,8 @@ public class UndertaleParticleSystemEmitter : UndertaleNamedResource, INotifyPro
     public float SizeIncreaseY { get; set; }
     public float SizeWiggleY { get; set; }
 
+    // These two are used and serialized prior to 2023.8, retained for compatibility.
     public float SizeMin { get => (SizeMinX + SizeMinY) / 2; set { SizeMinX = value; SizeMinY = value; } }
-
     public float SizeMax { get => (SizeMaxX + SizeMaxY) / 2; set { SizeMaxX = value; SizeMaxY = value; } }
 
     public float SizeIncrease { get => (SizeIncreaseX + SizeIncreaseY) / 2; set { SizeIncreaseX = value; SizeIncreaseY = value; } }
@@ -381,7 +384,7 @@ public class UndertaleParticleSystemEmitter : UndertaleNamedResource, INotifyPro
         _spawnOnUpdate.Dispose();
     }
 
-
+    // TODO: More documentation needed
     public enum EmitMode
     {
         Stream,

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -166,8 +166,6 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
     /// </summary>
     public UndertaleSimpleList<UndertaleResourceById<UndertaleSequence, UndertaleChunkSEQN>> Sequences { get; private set; } = new UndertaleSimpleList<UndertaleResourceById<UndertaleSequence, UndertaleChunkSEQN>>();
 
-    public static bool CheckedForGMS2_2_2_302;
-
     /// <summary>
     /// Calls <see cref="OnPropertyChanged(string)"/> for <see cref="BGColorLayer"/> in order to update the room background color.<br/>
     /// Only used for GameMaker: Studio 2 rooms.
@@ -268,50 +266,6 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
             Views[0].Enabled = true;
     }
 
-    private static void CheckForGMS2_2_2_302(UndertaleReader reader)
-    {
-        if (reader.undertaleData.IsVersionAtLeast(2, 2, 2, 302))
-        {
-            CheckedForGMS2_2_2_302 = true;
-
-            uint newSize = GameObject.ChildObjectsSize + 8;
-            reader.SetStaticChildObjectsSize(typeof(GameObject), newSize);
-
-            return;
-        }
-
-        long returnTo = reader.Position;
-        reader.Position -= 4;
-
-        uint gameObjPtr = reader.ReadUInt32();
-        uint tilePtr = reader.ReadUInt32();
-
-        reader.AbsPosition = gameObjPtr; // "GameObjects"
-        uint objCount = reader.ReadUInt32();
-        if (objCount > 0)
-        {
-            uint firstPtr = reader.ReadUInt32();
-            uint secondPtr;
-            if (objCount == 1)
-                secondPtr = tilePtr;
-            else
-                secondPtr = reader.ReadUInt32();
-
-            if (secondPtr - firstPtr == 48)
-            {
-                reader.undertaleData.SetGMS2Version(2, 2, 2, 302);
-
-                //"GameObject.ImageSpeed" + "...ImageIndex"
-                uint newSize = GameObject.ChildObjectsSize + 8;
-                reader.SetStaticChildObjectsSize(typeof(GameObject), newSize);
-            }
-        }
-
-        reader.Position = returnTo;
-
-        CheckedForGMS2_2_2_302 = true;
-    }
-
     /// <inheritdoc />
     public void Serialize(UndertaleWriter writer)
     {
@@ -388,10 +342,6 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
         Backgrounds = reader.ReadUndertaleObjectPointer<UndertalePointerList<Background>>();
         Views = reader.ReadUndertaleObjectPointer<UndertalePointerList<View>>();
         GameObjects = reader.ReadUndertaleObjectPointer<UndertalePointerList<GameObject>>();
-
-        if (!CheckedForGMS2_2_2_302)
-            CheckForGMS2_2_2_302(reader);
-        
         Tiles = reader.ReadUndertaleObjectPointer<UndertalePointerList<Tile>>();
         World = reader.ReadBoolean();
         Top = reader.ReadUInt32();
@@ -479,8 +429,6 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
         uint backgroundPtr = reader.ReadUInt32();
         uint viewsPtr = reader.ReadUInt32();
         uint gameObjsPtr = reader.ReadUInt32();
-        if (!CheckedForGMS2_2_2_302)
-            CheckForGMS2_2_2_302(reader);
         uint tilesPtr = reader.ReadUInt32();
         uint layersPtr = 0;
         uint sequencesPtr = 0;

--- a/UndertaleModLib/UndertaleChunks.cs
+++ b/UndertaleModLib/UndertaleChunks.cs
@@ -718,81 +718,88 @@ namespace UndertaleModLib
         private void CheckForEffectData(UndertaleReader reader)
         {
             // Do a length check on room layers to see if this is 2022.1 or higher
-            if (reader.undertaleData.IsVersionAtLeast(2, 3) && !reader.undertaleData.IsVersionAtLeast(2022, 1))
+            if (!reader.undertaleData.IsVersionAtLeast(2, 3) || reader.undertaleData.IsVersionAtLeast(2022, 1))
             {
-                long returnTo = reader.Position;
-
-                // Iterate over all rooms until a length check is performed
-                int roomCount = reader.ReadInt32();
-                bool finished = false;
-                for (uint roomIndex = 0; roomIndex < roomCount && !finished; roomIndex++)
-                {
-                    // Advance to room data we're interested in (and grab pointer for next room)
-                    reader.Position = returnTo + 4 + (4 * roomIndex);
-                    uint roomPtr = (uint)reader.ReadInt32();
-                    reader.AbsPosition = roomPtr + (22 * 4);
-
-                    // Get the pointer for this room's layer list, as well as pointer to sequence list
-                    uint layerListPtr = (uint)reader.ReadInt32();
-                    int seqnPtr = reader.ReadInt32();
-                    reader.AbsPosition = layerListPtr;
-                    int layerCount = reader.ReadInt32();
-                    if (layerCount >= 1)
-                    {
-                        // Get pointer into the individual layer data (plus 8 bytes) for the first layer in the room
-                        int jumpOffset = reader.ReadInt32() + 8;
-
-                        // Find the offset for the end of this layer
-                        int nextOffset;
-                        if (layerCount == 1)
-                            nextOffset = seqnPtr;
-                        else
-                            nextOffset = reader.ReadInt32(); // (pointer to next element in the layer list)
-
-                        // Actually perform the length checks, depending on layer data
-                        reader.AbsPosition = jumpOffset;
-                        switch ((LayerType)reader.ReadInt32())
-                        {
-                            case LayerType.Background:
-                                if (nextOffset - reader.AbsPosition > 16 * 4)
-                                    reader.undertaleData.SetGMS2Version(2022, 1);
-                                finished = true;
-                                break;
-                            case LayerType.Instances:
-                                reader.Position += 6 * 4;
-                                int instanceCount = reader.ReadInt32();
-                                if (nextOffset - reader.AbsPosition != (instanceCount * 4))
-                                    reader.undertaleData.SetGMS2Version(2022, 1);
-                                finished = true;
-                                break;
-                            case LayerType.Assets:
-                                reader.Position += 6 * 4;
-                                int tileOffset = reader.ReadInt32();
-                                if (tileOffset != reader.AbsPosition + 8)
-                                    reader.undertaleData.SetGMS2Version(2022, 1);
-                                finished = true;
-                                break;
-                            case LayerType.Tiles:
-                                reader.Position += 7 * 4;
-                                int tileMapWidth = reader.ReadInt32();
-                                int tileMapHeight = reader.ReadInt32();
-                                if (nextOffset - reader.AbsPosition != (tileMapWidth * tileMapHeight * 4))
-                                    reader.undertaleData.SetGMS2Version(2022, 1);
-                                finished = true;
-                                break;
-                            case LayerType.Effect:
-                                reader.Position += 7 * 4;
-                                int propertyCount = reader.ReadInt32();
-                                if (nextOffset - reader.AbsPosition != (propertyCount * 3 * 4))
-                                    reader.undertaleData.SetGMS2Version(2022, 1);
-                                finished = true;
-                                break;
-                        }
-                    }
-                }
-
-                reader.Position = returnTo;
+                checkedFor2022_1 = true;
+                return;
             }
+            long returnTo = reader.Position;
+
+            // Iterate over all rooms until a length check is performed
+            int roomCount = reader.ReadInt32();
+            for (uint roomIndex = 0; roomIndex < roomCount; roomIndex++)
+            {
+                // Advance to room data we're interested in (and grab pointer for next room)
+                reader.Position = returnTo + 4 + (4 * roomIndex);
+                uint roomPtr = (uint)reader.ReadInt32();
+                reader.AbsPosition = roomPtr + (22 * 4);
+
+                // Get the pointer for this room's layer list, as well as pointer to sequence list
+                uint layerListPtr = (uint)reader.ReadInt32();
+                int seqnPtr = reader.ReadInt32();
+                reader.AbsPosition = layerListPtr;
+                int layerCount = reader.ReadInt32();
+                if (layerCount <= 0)
+                {
+                    // No layers, try the next room
+                    continue;
+                }
+                // Get pointer into the individual layer data (plus 8 bytes) for the first layer in the room
+                int jumpOffset = reader.ReadInt32() + 8;
+
+                // Find the offset for the end of this layer
+                int nextOffset;
+                if (layerCount == 1)
+                    nextOffset = seqnPtr;
+                else
+                    nextOffset = reader.ReadInt32(); // (pointer to next element in the layer list)
+
+                // Actually perform the length checks, depending on layer data
+                reader.AbsPosition = jumpOffset;
+
+                LayerType layerType = (LayerType)reader.ReadInt32();
+                // Basically the switch's default, as each successful switch case terminates the loop
+                if (!Enum.IsDefined(layerType) || layerType == LayerType.Path)
+                    continue;
+
+                switch (layerType)
+                {
+                    case LayerType.Background:
+                        if (nextOffset - reader.AbsPosition > 16 * 4)
+                            reader.undertaleData.SetGMS2Version(2022, 1);
+                        break;
+                    case LayerType.Instances:
+                        reader.Position += 6 * 4;
+                        int instanceCount = reader.ReadInt32();
+                        if (nextOffset - reader.AbsPosition != (instanceCount * 4))
+                            reader.undertaleData.SetGMS2Version(2022, 1);
+                        break;
+                    case LayerType.Assets:
+                        reader.Position += 6 * 4;
+                        int tileOffset = reader.ReadInt32();
+                        if (tileOffset != reader.AbsPosition + 8)
+                            reader.undertaleData.SetGMS2Version(2022, 1);
+                        break;
+                    case LayerType.Tiles:
+                        reader.Position += 7 * 4;
+                        int tileMapWidth = reader.ReadInt32();
+                        int tileMapHeight = reader.ReadInt32();
+                        if (nextOffset - reader.AbsPosition != (tileMapWidth * tileMapHeight * 4))
+                            reader.undertaleData.SetGMS2Version(2022, 1);
+                        break;
+                    case LayerType.Effect:
+                        reader.Position += 7 * 4;
+                        int propertyCount = reader.ReadInt32();
+                        if (nextOffset - reader.AbsPosition != (propertyCount * 3 * 4))
+                            reader.undertaleData.SetGMS2Version(2022, 1);
+                        break;
+                }
+                // Check complete, found and tested a layer.
+                break;
+            }
+
+            reader.Position = returnTo;
+
 
             checkedFor2022_1 = true;
         }
@@ -801,50 +808,52 @@ namespace UndertaleModLib
         private void CheckForImageSpeed(UndertaleReader reader)
         {
             // Check the size of the first GameObject in a room
-            if (reader.undertaleData.IsGameMaker2() && !reader.undertaleData.IsVersionAtLeast(2, 2, 2, 302))
+            if (!reader.undertaleData.IsGameMaker2() || reader.undertaleData.IsVersionAtLeast(2, 2, 2, 302))
             {
-                long returnTo = reader.Position;
-
-                // Iterate over all rooms until a length check is performed
-                int roomCount = reader.ReadInt32();
-                for (uint roomIndex = 0; roomIndex < roomCount; roomIndex++)
-                {
-                    // Advance to room data we're interested in (and grab pointer for next room)
-                    reader.Position = returnTo + 4 + (4 * roomIndex);
-                    uint roomPtr = (uint)reader.ReadInt32();
-                    reader.AbsPosition = roomPtr + (12 * 4);
-
-                    // Get the pointer for this room's object list, as well as pointer to tile list
-                    uint objectListPtr = (uint)reader.ReadInt32();
-                    int tileListPtr = reader.ReadInt32();
-                    reader.AbsPosition = objectListPtr;
-                    int objectCount = reader.ReadInt32();
-                    if (objectCount >= 1)
-                    {
-                        // compare position of first object to second
-                        int firstPtr = reader.ReadInt32();
-                        int secondPtr;
-                        if (objectCount == 1) // tile list starts right after, so it works as an alternate
-                            secondPtr = tileListPtr;
-                        else
-                            secondPtr = reader.ReadInt32();
-
-                        if (secondPtr - firstPtr == 48)
-                        {
-                            reader.undertaleData.SetGMS2Version(2, 2, 2, 302);
-
-                            //"GameObject.ImageSpeed" + "...ImageIndex"
-                            uint newSize = GameObject.ChildObjectsSize + 8;
-                            reader.SetStaticChildObjectsSize(typeof(GameObject), newSize);
-                        }
-                        // Check performed, one way or the other
-                        break;
-                    }
-                    // continue to next room if there are no objects
-                }
-
-                reader.Position = returnTo;
+                checkedForGMS2_2_2_302 = true;
+                return;
             }
+            long returnTo = reader.Position;
+
+            // Iterate over all rooms until a length check is performed
+            int roomCount = reader.ReadInt32();
+            for (uint roomIndex = 0; roomIndex < roomCount; roomIndex++)
+            {
+                // Advance to room data we're interested in (and grab pointer for next room)
+                reader.Position = returnTo + 4 + (4 * roomIndex);
+                uint roomPtr = (uint)reader.ReadInt32();
+                reader.AbsPosition = roomPtr + (12 * 4);
+
+                // Get the pointer for this room's object list, as well as pointer to tile list
+                uint objectListPtr = (uint)reader.ReadInt32();
+                int tileListPtr = reader.ReadInt32();
+                reader.AbsPosition = objectListPtr;
+                int objectCount = reader.ReadInt32();
+                if (objectCount <= 0)
+                {
+                    // No objects, try the next room
+                    continue;
+                }
+                // Compare position of first object to second
+                int firstPtr = reader.ReadInt32();
+                int secondPtr;
+                if (objectCount == 1) // Tile list starts right after, so it works as an alternate
+                    secondPtr = tileListPtr;
+                else
+                    secondPtr = reader.ReadInt32();
+
+                if (secondPtr - firstPtr == 48)
+                {
+                    reader.undertaleData.SetGMS2Version(2, 2, 2, 302);
+
+                    uint newSize = GameObject.ChildObjectsSize + 8;
+                    reader.SetStaticChildObjectsSize(typeof(GameObject), newSize);
+                }
+                // Check performed, one way or the other
+                break;
+            }
+
+            reader.Position = returnTo;
 
             checkedForGMS2_2_2_302 = true;
         }
@@ -1122,68 +1131,74 @@ namespace UndertaleModLib
         private void CheckFor2022_3And5(UndertaleReader reader)
         {
             // Detect GM2022.3
-            if (reader.undertaleData.IsVersionAtLeast(2, 3) && !reader.undertaleData.IsVersionAtLeast(2022, 3))
+            if (!reader.undertaleData.IsVersionAtLeast(2, 3) || reader.undertaleData.IsVersionAtLeast(2022, 3))
             {
-                long positionToReturn = reader.Position;
-
-                // Check for 2022.3 format
-                uint texCount = reader.ReadUInt32();
-                if (texCount == 1) // If no textures exist, this could false positive.
-                {
-                    reader.Position += 16; // Jump to either padding or length, depending on version
-                    if (reader.ReadUInt32() > 0) // Check whether it's padding or length
-                        reader.undertaleData.SetGMS2Version(2022, 3);
-                }
-                else if (texCount > 1)
-                {
-                    uint firstTex = reader.ReadUInt32();
-                    uint secondTex = reader.ReadUInt32();
-                    if (firstTex + 16 == secondTex)
-                        reader.undertaleData.SetGMS2Version(2022, 3);
-                }
-
-                if (reader.undertaleData.IsVersionAtLeast(2022, 3))
-                {
-                    // Also check for 2022.5 format
-                    reader.Position = positionToReturn + 4;
-                    for (uint i = 0; i < texCount; i++)
-                    {
-                        // Go to each texture, and then to each texture's data
-                        reader.Position = positionToReturn + 4 + (i * 4);
-                        reader.AbsPosition = reader.ReadUInt32() + 12; // go to texture, at an offset
-                        reader.AbsPosition = reader.ReadUInt32(); // go to texture data
-                        byte[] header = reader.ReadBytes(4);
-                        if (header.SequenceEqual(UndertaleEmbeddedTexture.TexData.QOIAndBZip2Header))
-                        {
-                            reader.Position += 4; // skip width/height
-                            bool is2022_5 = false;
-                            // Now check the actual BZ2 headers
-                            if (reader.ReadByte() != (byte)'B')
-                                is2022_5 = true;
-                            else if (reader.ReadByte() != (byte)'Z')
-                                is2022_5 = true;
-                            else if (reader.ReadByte() != (byte)'h')
-                                is2022_5 = true;
-                            else
-                            {
-                                reader.Position++;
-                                if (reader.ReadUInt24() != 0x594131) // digits of pi... (block header)
-                                    is2022_5 = true;
-                                else if (reader.ReadUInt24() != 0x595326)
-                                    is2022_5 = true;
-                            }
-
-                            if (is2022_5)
-                                reader.undertaleData.SetGMS2Version(2022, 5);
-
-                            // Checked one QOI+BZ2 texture. No need to check any more
-                            break;
-                        }
-                    }
-                }
-
-                reader.Position = positionToReturn;
+                checkedFor2022_3 = true;
+                return;
             }
+            long positionToReturn = reader.Position;
+
+            // Check for 2022.3 format
+            bool isGM2022_3 = false;
+            uint texCount = reader.ReadUInt32();
+            if (texCount == 1) // If no textures exist, this could false positive.
+            {
+                reader.Position += 16; // Jump to either padding or length, depending on version
+                if (reader.ReadUInt32() > 0) // Check whether it's padding or length
+                    isGM2022_3 = true;
+            }
+            else if (texCount > 1)
+            {
+                uint firstTex = reader.ReadUInt32();
+                uint secondTex = reader.ReadUInt32();
+                if (firstTex + 16 == secondTex)
+                    isGM2022_3 = true;
+            }
+
+            if (isGM2022_3)
+            {
+                reader.undertaleData.SetGMS2Version(2022, 3);
+                // Also check for 2022.5 format
+                reader.Position = positionToReturn + 4;
+                for (uint i = 0; i < texCount; i++)
+                {
+                    // Go to each texture, and then to each texture's data
+                    reader.Position = positionToReturn + 4 + (i * 4);
+                    reader.AbsPosition = reader.ReadUInt32() + 12; // go to texture, at an offset
+                    reader.AbsPosition = reader.ReadUInt32(); // go to texture data
+                    byte[] header = reader.ReadBytes(4);
+                    if (!header.SequenceEqual(UndertaleEmbeddedTexture.TexData.QOIAndBZip2Header))
+                    {
+                        // Nothing useful, check the next texture
+                        continue;
+                    }
+                    reader.Position += 4; // Skip width/height
+                    bool is2022_5 = false;
+                    // Now check the actual BZ2 headers
+                    if (reader.ReadByte() != (byte)'B')
+                        is2022_5 = true;
+                    else if (reader.ReadByte() != (byte)'Z')
+                        is2022_5 = true;
+                    else if (reader.ReadByte() != (byte)'h')
+                        is2022_5 = true;
+                    else
+                    {
+                        reader.Position++;
+                        if (reader.ReadUInt24() != 0x594131) // Digits of pi... (block header)
+                            is2022_5 = true;
+                        else if (reader.ReadUInt24() != 0x595326)
+                            is2022_5 = true;
+                    }
+
+                    if (is2022_5)
+                        reader.undertaleData.SetGMS2Version(2022, 5);
+
+                    // Checked one QOI+BZ2 texture. No need to check any more
+                    break;
+                }
+            }
+
+            reader.Position = positionToReturn;
 
             checkedFor2022_3 = true;
         }
@@ -1233,8 +1248,7 @@ namespace UndertaleModLib
         private void CheckForGMS2_0_6(UndertaleReader reader)
         {
             bool atLeastGMS2_0 = reader.undertaleData.IsGameMaker2();
-            bool atLeastGMS2_2 = reader.undertaleData.IsVersionAtLeast(2, 2);
-            if (!atLeastGMS2_0 || atLeastGMS2_2 || reader.undertaleData.IsVersionAtLeast(2, 0, 6))
+            if (!atLeastGMS2_0 || reader.undertaleData.IsVersionAtLeast(2, 0, 6))
                 return;
 
             long returnPos = reader.Position;
@@ -1252,7 +1266,7 @@ namespace UndertaleModLib
                 uint firstPtr = reader.ReadUInt32();
                 uint secondPtr = reader.ReadUInt32();
 
-                if (atLeastGMS2_0 && !atLeastGMS2_2) // 2 < version < 2.2
+                if (atLeastGMS2_0) // 2 < version < 2.2
                 {
                     if (secondPtr - firstPtr == 8) // "Scaled" + "_textureData" -> 8
                         noGeneratedMips = true;
@@ -1392,7 +1406,7 @@ namespace UndertaleModLib
         private void CheckFor2022_9And2023(UndertaleReader reader)
         {
             if (!reader.undertaleData.IsVersionAtLeast(2, 3)
-                || reader.undertaleData.IsVersionAtLeast(2022, 9) || reader.undertaleData.IsVersionAtLeast(2023, 1))
+                || reader.undertaleData.IsVersionAtLeast(2022, 9))
             {
                 checkedFor2022_9 = true;
                 return;
@@ -1514,13 +1528,12 @@ namespace UndertaleModLib
             if (reader.ReadUInt32() != 0) // in 2.3 a int with the value of 0 would be set here,
             {                             // it cannot be version 2.3 if this value isn't 0
                 reader.undertaleData.SetGMS2Version(2, 3, 1);
-                reader.Position -= 4;
             }
             else
             {
                 if (reader.ReadUInt32() == 0)                      // At all points (besides the first one)
                     reader.undertaleData.SetGMS2Version(2, 3, 1);  // if BezierX0 equals to 0 (the above check)
-                reader.Position -= 8;                              // then BezierY0 equals to 0 as well (the current check)
+                                                                   // then BezierY0 equals to 0 as well (the current check)
             }
 
             reader.Position = returnTo;

--- a/UndertaleModLib/UndertaleChunks.cs
+++ b/UndertaleModLib/UndertaleChunks.cs
@@ -758,7 +758,7 @@ namespace UndertaleModLib
                 reader.AbsPosition = jumpOffset;
 
                 LayerType layerType = (LayerType)reader.ReadInt32();
-                // Basically the switch's default, as each successful switch case terminates the loop
+                // This is the only way to repeat the loop, because each successful switch case terminates the loop
                 if (!Enum.IsDefined(layerType) || layerType == LayerType.Path)
                     continue;
 
@@ -1164,8 +1164,8 @@ namespace UndertaleModLib
                 {
                     // Go to each texture, and then to each texture's data
                     reader.Position = positionToReturn + 4 + (i * 4);
-                    reader.AbsPosition = reader.ReadUInt32() + 12; // go to texture, at an offset
-                    reader.AbsPosition = reader.ReadUInt32(); // go to texture data
+                    reader.AbsPosition = reader.ReadUInt32() + 12; // Go to texture, at an offset
+                    reader.AbsPosition = reader.ReadUInt32(); // Go to texture data
                     byte[] header = reader.ReadBytes(4);
                     if (!header.SequenceEqual(UndertaleEmbeddedTexture.TexData.QOIAndBZip2Header))
                     {
@@ -1831,7 +1831,6 @@ namespace UndertaleModLib
                 checkedPsemVersion = true;
                 return;
             }
-
             else if (count == 1) // Special case
             {
                 // Fortunately, consistent padding means we need no parsing here
@@ -1882,7 +1881,7 @@ namespace UndertaleModLib
             else if (secondPtr - firstPtr != 0xB0) // 2023.2
             {
                 reader.AbsPosition = positionToReturn;
-                throw new IOException("Unrecognized PSEM size with " + count.ToString() + " elements");
+                throw new IOException("Unrecognized PSEM size with " + count + " elements");
             }
             
 

--- a/UndertaleModTool/Editors/UndertaleParticleSystemEmitterEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleParticleSystemEmitterEditor.xaml
@@ -7,8 +7,9 @@
                        xmlns:undertale="clr-namespace:UndertaleModLib.Models;assembly=UndertaleModLib"
                        xmlns:sys="clr-namespace:System;assembly=mscorlib"
                        mc:Ignorable="d" 
-                       d:DesignHeight="450" d:DesignWidth="800" d:DataContext="{d:DesignInstance undertale:UndertaleParticleSystemEmitter}">
+                       d:DesignHeight="4500" d:DesignWidth="800" d:DataContext="{d:DesignInstance undertale:UndertaleParticleSystemEmitter}">
     <UserControl.Resources>
+        <local:IsVersionAtLeastConverter x:Key="IsVersionAtLeastConverter"/>
         <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="EmitMode">
             <ObjectDataProvider.MethodParameters>
                 <x:Type TypeName="undertale:UndertaleParticleSystemEmitter+EmitMode" />
@@ -29,8 +30,13 @@
                 <x:Type TypeName="undertale:UndertaleParticleSystemEmitter+TextureEnum" />
             </ObjectDataProvider.MethodParameters>
         </ObjectDataProvider>
+        <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="TimeUnitEnum">
+            <ObjectDataProvider.MethodParameters>
+                <x:Type TypeName="undertale:UndertaleParticleSystemEmitter+TimeUnitEnum" />
+            </ObjectDataProvider.MethodParameters>
+        </ObjectDataProvider>
     </UserControl.Resources>
-    
+
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="1*"/>
@@ -68,28 +74,85 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <TextBlock Grid.Row="0" Grid.Column="0" Margin="3">Name</TextBlock>
         <local:UndertaleStringReference Grid.Row="0" Grid.Column="1" Margin="3" ObjectReference="{Binding Name}"/>
 
-        <TextBlock Grid.Row="1" Grid.Column="0" Margin="3">Emit mode</TextBlock>
-        <local:ComboBoxDark Grid.Row="1" Grid.Column="1" Margin="3"
+        <TextBlock Grid.Row="1" Grid.Column="0" Margin="3"
+                   Visibility="{Binding Mode=OneTime, Converter={StaticResource IsVersionAtLeastConverter},ConverterParameter=2023.6}"
+                   >Enabled</TextBlock>
+        <CheckBox Grid.Row="1" Grid.Column="1" Margin="3" IsChecked="{Binding Enabled}"
+                   Visibility="{Binding Mode=OneTime, Converter={StaticResource IsVersionAtLeastConverter},ConverterParameter=2023.6}"/>
+
+        <TextBlock Grid.Row="2" Grid.Column="0" Margin="3">Emit mode</TextBlock>
+        <local:ComboBoxDark Grid.Row="2" Grid.Column="1" Margin="3"
                             ItemsSource="{Binding Source={StaticResource EmitMode}}" SelectedItem="{Binding Mode}"/>
 
-        <TextBlock Grid.Row="2" Grid.Column="0" Margin="3">Emit count</TextBlock>
-        <local:TextBoxDark Grid.Row="2" Grid.Column="1" Margin="3" Text="{Binding EmitCount}"/>
+        <TextBlock Grid.Row="3" Grid.Column="0" Margin="3">Emit count</TextBlock>
+        <local:TextBoxDark Grid.Row="3" Grid.Column="1" Margin="3" Text="{Binding EmitCount}"/>
 
-        <TextBlock Grid.Row="3" Grid.Column="0" Margin="3">Distribution</TextBlock>
-        <local:ComboBoxDark Grid.Row="3" Grid.Column="1" Margin="3"
+        <Grid Grid.Row="4" Grid.ColumnSpan="2" Visibility="{Binding Mode=OneTime, Converter={StaticResource IsVersionAtLeastConverter},ConverterParameter=2023.8}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="1*"/>
+                <ColumnDefinition Width="3*"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <TextBlock Grid.Row="0" Grid.Column="0" Margin="3">Emit relative</TextBlock>
+            <CheckBox Grid.Row="0" Grid.Column="1" Margin="3" IsChecked="{Binding EmitRelative}"/>
+
+            <TextBlock Grid.Row="1" Grid.Column="0" Margin="3">Delay min|max</TextBlock>
+            <Grid Grid.Row="1" Grid.Column="1">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <local:TextBoxDark Grid.Column="0" Margin="3" Text="{Binding DelayMin}"/>
+                <local:TextBoxDark Grid.Column="1" Margin="3" Text="{Binding DelayMax}"/>
+            </Grid>
+
+            <TextBlock Grid.Row="2" Grid.Column="0" Margin="3">Delay measured in:</TextBlock>
+            <local:ComboBoxDark Grid.Row="2" Grid.Column="1" Margin="3"
+                    ItemsSource="{Binding Source={StaticResource TimeUnitEnum}}" SelectedItem="{Binding DelayUnit}"/>
+
+            <TextBlock Grid.Row="3" Grid.Column="0" Margin="3">Interval min|max</TextBlock>
+            <Grid Grid.Row="3" Grid.Column="1">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <local:TextBoxDark Grid.Column="0" Margin="3" Text="{Binding IntervalMin}"/>
+                <local:TextBoxDark Grid.Column="1" Margin="3" Text="{Binding IntervalMax}"/>
+            </Grid>
+
+            <TextBlock Grid.Row="4" Grid.Column="0" Margin="3">Interval measured in:</TextBlock>
+            <local:ComboBoxDark Grid.Row="4" Grid.Column="1" Margin="3"
+                    ItemsSource="{Binding Source={StaticResource TimeUnitEnum}}" SelectedItem="{Binding IntervalUnit}"/>
+        </Grid>
+
+        <TextBlock Grid.Row="5" Grid.Column="0" Margin="3">Distribution</TextBlock>
+        <local:ComboBoxDark Grid.Row="5" Grid.Column="1" Margin="3"
                             ItemsSource="{Binding Source={StaticResource DistributionEnum}}" SelectedItem="{Binding Distribution}"/>
 
-        <TextBlock Grid.Row="4" Grid.Column="0" Margin="3">Shape</TextBlock>
-        <local:ComboBoxDark Grid.Row="4" Grid.Column="1" Margin="3"
+        <TextBlock Grid.Row="6" Grid.Column="0" Margin="3">Shape</TextBlock>
+        <local:ComboBoxDark Grid.Row="6" Grid.Column="1" Margin="3"
                             ItemsSource="{Binding Source={StaticResource EmitterShape}}" SelectedItem="{Binding Shape}"/>
 
-        <TextBlock Grid.Row="5" Grid.Column="0" Margin="3">Region X|Y|Width|Height</TextBlock>
-        <Grid Grid.Row="5" Grid.Column="1">
+        <TextBlock Grid.Row="7" Grid.Column="0" Margin="3">Region X|Y|Width|Height</TextBlock>
+        <Grid Grid.Row="7" Grid.Column="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
@@ -102,13 +165,13 @@
             <local:TextBoxDark Grid.Column="3" Margin="3" Text="{Binding RegionHeight}"/>
         </Grid>
 
-        <TextBlock Grid.Row="6" Grid.Column="0" Margin="3">Rotation</TextBlock>
-        <local:TextBoxDark Grid.Row="6" Grid.Column="1" Margin="3" Text="{Binding Rotation}"/>
+        <TextBlock Grid.Row="8" Grid.Column="0" Margin="3">Rotation</TextBlock>
+        <local:TextBoxDark Grid.Row="8" Grid.Column="1" Margin="3" Text="{Binding Rotation}"/>
 
-        <TextBlock Grid.Row="7" Grid.Column="0" Margin="3">Sprite</TextBlock>
-        <local:UndertaleObjectReference Grid.Row="7" Grid.Column="1" Margin="3" ObjectReference="{Binding Sprite}" ObjectType="{x:Type undertale:UndertaleSprite}"/>
+        <TextBlock Grid.Row="9" Grid.Column="0" Margin="3">Sprite</TextBlock>
+        <local:UndertaleObjectReference Grid.Row="9" Grid.Column="1" Margin="3" ObjectReference="{Binding Sprite}" ObjectType="{x:Type undertale:UndertaleSprite}"/>
 
-        <ListView Grid.Row="8" Grid.Column="1" ItemsSource="{Binding Sprite.Textures, Mode=OneWay}" Background="Transparent" BorderThickness="0">
+        <ListView Grid.Row="10" Grid.Column="1" ItemsSource="{Binding Sprite.Textures, Mode=OneWay}" Background="Transparent" BorderThickness="0">
             <ListView.ItemsPanel>
                 <ItemsPanelTemplate>
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center"/>
@@ -135,27 +198,48 @@
             </ListView.ItemTemplate>
         </ListView>
 
-        <TextBlock Grid.Row="9" Grid.Column="0" Margin="3">Sprite frame index</TextBlock>
-        <local:TextBoxDark Grid.Row="9" Grid.Column="1" Margin="3" Text="{Binding FrameIndex}"/>
+        <TextBlock Grid.Row="11" Grid.Column="0" Margin="3">Sprite frame index</TextBlock>
+        <local:TextBoxDark Grid.Row="11" Grid.Column="1" Margin="3" Text="{Binding FrameIndex}"/>
 
-        <TextBlock Grid.Row="10" Grid.Column="0" Margin="3">Texture</TextBlock>
-        <local:ComboBoxDark Grid.Row="10" Grid.Column="1" Margin="3"
+        <Grid Grid.Row="12" Grid.ColumnSpan="2" Visibility="{Binding Mode=OneTime, Converter={StaticResource IsVersionAtLeastConverter},ConverterParameter=2023.4}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="1*"/>
+                <ColumnDefinition Width="3*"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <TextBlock Grid.Row="0" Grid.Column="0" Margin="3">Animate sprite</TextBlock>
+            <CheckBox Grid.Row="0" Grid.Column="1" Margin="3" IsChecked="{Binding Animate}"/>
+
+            <TextBlock Grid.Row="1" Grid.Column="0" Margin="3">Stretch sprite</TextBlock>
+            <CheckBox Grid.Row="1" Grid.Column="1" Margin="3" IsChecked="{Binding Stretch}"/>
+
+            <TextBlock Grid.Row="2" Grid.Column="0" Margin="3">Random</TextBlock>
+            <CheckBox Grid.Row="2" Grid.Column="1" Margin="3" IsChecked="{Binding IsRandom}"/>
+        </Grid>
+
+        <TextBlock Grid.Row="13" Grid.Column="0" Margin="3">Texture</TextBlock>
+        <local:ComboBoxDark Grid.Row="13" Grid.Column="1" Margin="3"
                             ItemsSource="{Binding Source={StaticResource TextureEnum}}" SelectedItem="{Binding Texture}"/>
 
-        <TextBlock Grid.Row="11" Grid.Column="0" Margin="3">Start color</TextBlock>
-        <local:ColorPicker Grid.Row="11" Grid.Column="2" Margin="3" Color="{Binding StartColor}"/>
+        <TextBlock Grid.Row="14" Grid.Column="0" Margin="3">Start color</TextBlock>
+        <local:ColorPicker Grid.Row="14" Grid.Column="2" Margin="3" Color="{Binding StartColor}"/>
 
-        <TextBlock Grid.Row="12" Grid.Column="0" Margin="3">Middle color</TextBlock>
-        <local:ColorPicker Grid.Row="12" Grid.Column="2" Margin="3" Color="{Binding MidColor}"/>
+        <TextBlock Grid.Row="15" Grid.Column="0" Margin="3">Middle color</TextBlock>
+        <local:ColorPicker Grid.Row="15" Grid.Column="2" Margin="3" Color="{Binding MidColor}"/>
 
-        <TextBlock Grid.Row="13" Grid.Column="0" Margin="3">End color</TextBlock>
-        <local:ColorPicker Grid.Row="13" Grid.Column="2" Margin="3" Color="{Binding EndColor}"/>
+        <TextBlock Grid.Row="16" Grid.Column="0" Margin="3">End color</TextBlock>
+        <local:ColorPicker Grid.Row="16" Grid.Column="2" Margin="3" Color="{Binding EndColor}"/>
 
-        <TextBlock Grid.Row="14" Grid.Column="0" Margin="3">Additive color blend</TextBlock>
-        <CheckBox Grid.Row="14" Grid.Column="1" Margin="3" IsChecked="{Binding AdditiveBlend}"/>
+        <TextBlock Grid.Row="17" Grid.Column="0" Margin="3">Additive color blend</TextBlock>
+        <CheckBox Grid.Row="17" Grid.Column="1" Margin="3" IsChecked="{Binding AdditiveBlend}"/>
 
-        <TextBlock Grid.Row="15" Grid.Column="0" Margin="3">Lifetime min|max</TextBlock>
-        <Grid Grid.Row="15" Grid.Column="1">
+        <TextBlock Grid.Row="18" Grid.Column="0" Margin="3">Lifetime min|max</TextBlock>
+        <Grid Grid.Row="18" Grid.Column="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
@@ -164,8 +248,8 @@
             <local:TextBoxDark Grid.Column="1" Margin="3" Text="{Binding LifetimeMax}"/>
         </Grid>
 
-        <TextBlock Grid.Row="16" Grid.Column="0" Margin="3">Scale X|Y</TextBlock>
-        <Grid Grid.Row="16" Grid.Column="1">
+        <TextBlock Grid.Row="19" Grid.Column="0" Margin="3">Scale X|Y</TextBlock>
+        <Grid Grid.Row="19" Grid.Column="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
@@ -174,28 +258,54 @@
             <local:TextBoxDark Grid.Column="1" Margin="3" Text="{Binding ScaleY}"/>
         </Grid>
 
-        <TextBlock Grid.Row="17" Grid.Column="0" Margin="3">Size min|max</TextBlock>
-        <Grid Grid.Row="17" Grid.Column="1">
+        <TextBlock Grid.Row="20" Grid.Column="1" Margin="3" HorizontalAlignment="Center" Foreground="DarkGray" FontStyle="Italic" TextWrapping="Wrap">
+            Hint: Prior to GM 2023.8, these "Size" values were not split by x and y.<LineBreak />
+            UndertaleModTool represents this by averaging the values.<LineBreak />
+            For best results, enter the same value in both fields.
+        </TextBlock>
+
+        <TextBlock Grid.Row="21" Grid.Column="0" Margin="3">Size min</TextBlock>
+        <Grid Grid.Row="21" Grid.Column="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
-            <local:TextBoxDark Grid.Column="0" Margin="3" Text="{Binding SizeMin}"/>
-            <local:TextBoxDark Grid.Column="1" Margin="3" Text="{Binding SizeMax}"/>
+            <local:TextBoxDark Grid.Column="0" Margin="3" Text="{Binding SizeMinX}"/>
+            <local:TextBoxDark Grid.Column="1" Margin="3" Text="{Binding SizeMinY}"/>
         </Grid>
 
-        <TextBlock Grid.Row="18" Grid.Column="0" Margin="3">Size increase|wiggle</TextBlock>
-        <Grid Grid.Row="18" Grid.Column="1">
+        <TextBlock Grid.Row="22" Grid.Column="0" Margin="3">Size max</TextBlock>
+        <Grid Grid.Row="22" Grid.Column="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
-            <local:TextBoxDark Grid.Column="0" Margin="3" Text="{Binding SizeIncrease}"/>
-            <local:TextBoxDark Grid.Column="1" Margin="3" Text="{Binding SizeWiggle}"/>
+            <local:TextBoxDark Grid.Column="0" Margin="3" Text="{Binding SizeMaxX}"/>
+            <local:TextBoxDark Grid.Column="1" Margin="3" Text="{Binding SizeMaxY}"/>
         </Grid>
 
-        <TextBlock Grid.Row="19" Grid.Column="0" Margin="3">Speed min|max</TextBlock>
-        <Grid Grid.Row="19" Grid.Column="1">
+        <TextBlock Grid.Row="23" Grid.Column="0" Margin="3">Size increase</TextBlock>
+        <Grid Grid.Row="23" Grid.Column="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <local:TextBoxDark Grid.Column="0" Margin="3" Text="{Binding SizeIncreaseX}"/>
+            <local:TextBoxDark Grid.Column="1" Margin="3" Text="{Binding SizeIncreaseY}"/>
+        </Grid>
+
+        <TextBlock Grid.Row="24" Grid.Column="0" Margin="3">Size wiggle</TextBlock>
+        <Grid Grid.Row="24" Grid.Column="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <local:TextBoxDark Grid.Column="0" Margin="3" Text="{Binding SizeWiggleX}"/>
+            <local:TextBoxDark Grid.Column="1" Margin="3" Text="{Binding SizeWiggleY}"/>
+        </Grid>
+
+        <TextBlock Grid.Row="25" Grid.Column="0" Margin="3">Speed min|max</TextBlock>
+        <Grid Grid.Row="25" Grid.Column="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
@@ -204,8 +314,8 @@
             <local:TextBoxDark Grid.Column="1" Margin="3" Text="{Binding SpeedMax}"/>
         </Grid>
 
-        <TextBlock Grid.Row="20" Grid.Column="0" Margin="3">Speed increase|wiggle</TextBlock>
-        <Grid Grid.Row="20" Grid.Column="1">
+        <TextBlock Grid.Row="26" Grid.Column="0" Margin="3">Speed increase|wiggle</TextBlock>
+        <Grid Grid.Row="26" Grid.Column="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
@@ -214,8 +324,8 @@
             <local:TextBoxDark Grid.Column="1" Margin="3" Text="{Binding SpeedWiggle}"/>
         </Grid>
 
-        <TextBlock Grid.Row="21" Grid.Column="0" Margin="3">Gravity force|direction</TextBlock>
-        <Grid Grid.Row="21" Grid.Column="1">
+        <TextBlock Grid.Row="27" Grid.Column="0" Margin="3">Gravity force|direction</TextBlock>
+        <Grid Grid.Row="27" Grid.Column="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
@@ -224,8 +334,8 @@
             <local:TextBoxDark Grid.Column="1" Margin="3" Text="{Binding GravityDirection}"/>
         </Grid>
 
-        <TextBlock Grid.Row="22" Grid.Column="0" Margin="3">Direction min|max</TextBlock>
-        <Grid Grid.Row="22" Grid.Column="1">
+        <TextBlock Grid.Row="28" Grid.Column="0" Margin="3">Direction min|max</TextBlock>
+        <Grid Grid.Row="28" Grid.Column="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
@@ -234,8 +344,8 @@
             <local:TextBoxDark Grid.Column="1" Margin="3" Text="{Binding DirectionMax}"/>
         </Grid>
 
-        <TextBlock Grid.Row="23" Grid.Column="0" Margin="3">Direction increase|wiggle</TextBlock>
-        <Grid Grid.Row="23" Grid.Column="1">
+        <TextBlock Grid.Row="29" Grid.Column="0" Margin="3">Direction increase|wiggle</TextBlock>
+        <Grid Grid.Row="29" Grid.Column="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
@@ -244,8 +354,8 @@
             <local:TextBoxDark Grid.Column="1" Margin="3" Text="{Binding DirectionWiggle}"/>
         </Grid>
 
-        <TextBlock Grid.Row="24" Grid.Column="0" Margin="3">Orientation min|max</TextBlock>
-        <Grid Grid.Row="24" Grid.Column="1">
+        <TextBlock Grid.Row="30" Grid.Column="0" Margin="3">Orientation min|max</TextBlock>
+        <Grid Grid.Row="30" Grid.Column="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
@@ -254,8 +364,8 @@
             <local:TextBoxDark Grid.Column="1" Margin="3" Text="{Binding OrientationMax}"/>
         </Grid>
 
-        <TextBlock Grid.Row="25" Grid.Column="0" Margin="3">Orientation increase|wiggle</TextBlock>
-        <Grid Grid.Row="25" Grid.Column="1">
+        <TextBlock Grid.Row="31" Grid.Column="0" Margin="3">Orientation increase|wiggle</TextBlock>
+        <Grid Grid.Row="31" Grid.Column="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
@@ -264,19 +374,19 @@
             <local:TextBoxDark Grid.Column="1" Margin="3" Text="{Binding OrientationWiggle}"/>
         </Grid>
 
-        <TextBlock Grid.Row="26" Grid.Column="0" Margin="3">Is orientation relative</TextBlock>
-        <CheckBox Grid.Row="26" Grid.Column="1" Margin="3" IsChecked="{Binding OrientationRelative}"/>
+        <TextBlock Grid.Row="32" Grid.Column="0" Margin="3">Is orientation relative</TextBlock>
+        <CheckBox Grid.Row="32" Grid.Column="1" Margin="3" IsChecked="{Binding OrientationRelative}"/>
 
-        <TextBlock Grid.Row="27" Grid.Column="0" Margin="3">Spawn on death</TextBlock>
-        <local:UndertaleObjectReference Grid.Row="27" Grid.Column="1" Margin="3" ObjectReference="{Binding SpawnOnDeath}" ObjectType="{x:Type undertale:UndertaleParticleSystemEmitter}"/>
+        <TextBlock Grid.Row="33" Grid.Column="0" Margin="3">Spawn on death</TextBlock>
+        <local:UndertaleObjectReference Grid.Row="33" Grid.Column="1" Margin="3" ObjectReference="{Binding SpawnOnDeath}" ObjectType="{x:Type undertale:UndertaleParticleSystemEmitter}"/>
 
-        <TextBlock Grid.Row="28" Grid.Column="0" Margin="3">Spawn on death count</TextBlock>
-        <local:TextBoxDark Grid.Row="28" Grid.Column="1" Margin="3" Text="{Binding SpawnOnDeathCount}"/>
+        <TextBlock Grid.Row="34" Grid.Column="0" Margin="3">Spawn on death count</TextBlock>
+        <local:TextBoxDark Grid.Row="34" Grid.Column="1" Margin="3" Text="{Binding SpawnOnDeathCount}"/>
 
-        <TextBlock Grid.Row="29" Grid.Column="0" Margin="3">Spawn on update</TextBlock>
-        <local:UndertaleObjectReference Grid.Row="29" Grid.Column="1" Margin="3" ObjectReference="{Binding SpawnOnUpdate}" ObjectType="{x:Type undertale:UndertaleParticleSystemEmitter}"/>
+        <TextBlock Grid.Row="35" Grid.Column="0" Margin="3">Spawn on update</TextBlock>
+        <local:UndertaleObjectReference Grid.Row="35" Grid.Column="1" Margin="3" ObjectReference="{Binding SpawnOnUpdate}" ObjectType="{x:Type undertale:UndertaleParticleSystemEmitter}"/>
 
-        <TextBlock Grid.Row="30" Grid.Column="0" Margin="3">Spawn on update count</TextBlock>
-        <local:TextBoxDark Grid.Row="30" Grid.Column="1" Margin="3" Text="{Binding SpawnOnUpdateCount}"/>
+        <TextBlock Grid.Row="36" Grid.Column="0" Margin="3">Spawn on update count</TextBlock>
+        <local:TextBoxDark Grid.Row="36" Grid.Column="1" Margin="3" Text="{Binding SpawnOnUpdateCount}"/>
     </Grid>
 </local:DataUserControl>


### PR DESCRIPTION
## Description
Changes the GMS 2.2.2.302 check to iterate over all rooms, thus not failing on "Destructivator 2 Demo" (which has no objects in the first room and thus passes over the old check without detecting the version). Closes #1381.

Additionally, implements new PSEM (Particle System EMitter) checks to identify GM2023.4, GM2023.6, and GM2023.8, as well as adding the new values to both UndertaleParticleSystemEmitter and its corresponding editor in the GUI. Closes #1554.

### Caveats
Limited testing. I still don't fully understand the point of UnserializeObjectCount.

### Notes
2.2.2.302 seems like it would be a needlessly precise version, but if we're internally consistent it doesn't look like a problem.