### PR TITLE
Change some lists to have a public setter

### DIFF
--- a/UndertaleModLib/Models/UndertaleFont.cs
+++ b/UndertaleModLib/Models/UndertaleFont.cs
@@ -100,7 +100,7 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
     /// <summary>
     /// The glyphs that this font uses.
     /// </summary>
-    public UndertalePointerList<Glyph> Glyphs { get; private set; } = new UndertalePointerList<Glyph>();
+    public UndertalePointerList<Glyph> Glyphs { get; set; } = new UndertalePointerList<Glyph>();
 
     /// <summary>
     /// The maximum offset from the baseline to the top of the font

--- a/UndertaleModLib/Models/UndertaleGameObject.cs
+++ b/UndertaleModLib/Models/UndertaleGameObject.cs
@@ -139,14 +139,14 @@ public class UndertaleGameObject : UndertaleNamedResource, INotifyPropertyChange
     /// <summary>
     /// The vertices used for a <see cref="CollisionShape"/> of type <see cref="CollisionShapeFlags.Custom"/>.
     /// </summary>
-    public List<UndertalePhysicsVertex> PhysicsVertices { get; private set; } = new List<UndertalePhysicsVertex>();
+    public List<UndertalePhysicsVertex> PhysicsVertices { get; set; } = new List<UndertalePhysicsVertex>();
 
     #endregion
 
     /// <summary>
     /// All the events that this game object has.
     /// </summary>
-    public UndertalePointerList<UndertalePointerList<Event>> Events { get; private set; } = new();
+    public UndertalePointerList<UndertalePointerList<Event>> Events { get; set; } = new();
 
     /// <inheritdoc />
     public event PropertyChangedEventHandler PropertyChanged;
@@ -432,7 +432,7 @@ public class UndertaleGameObject : UndertaleNamedResource, INotifyPropertyChange
         /// The available actions that will be performed for this event.
         /// </summary>
         /// <remarks>This seems to always have 1 entry, it would need testing if maybe the games using drag-and-drop code are different</remarks>
-        public UndertalePointerList<EventAction> Actions { get; private set; } = new UndertalePointerList<EventAction>();
+        public UndertalePointerList<EventAction> Actions { get; set; } = new UndertalePointerList<EventAction>();
 
         //TODO: not used, condense. Also UMT specific.
         public EventSubtypeKey EventSubtypeKey

--- a/UndertaleModLib/Models/UndertaleGeneralInfo.cs
+++ b/UndertaleModLib/Models/UndertaleGeneralInfo.cs
@@ -282,7 +282,7 @@ public class UndertaleGeneralInfo : UndertaleObject, IDisposable
     /// <summary>
     /// The room order of the data file.
     /// </summary>
-    public UndertaleSimpleResourcesList<UndertaleRoom, UndertaleChunkROOM> RoomOrder { get; private set; } = new();
+    public UndertaleSimpleResourcesList<UndertaleRoom, UndertaleChunkROOM> RoomOrder { get; set; } = new();
 
     /// <summary>
     /// TODO: unknown, some sort of checksum.
@@ -768,7 +768,7 @@ public class UndertaleOptions : UndertaleObject, IDisposable
     /// <summary>
     /// A list of Constants that the game uses.
     /// </summary>
-    public UndertaleSimpleList<Constant> Constants { get; private set; } = new UndertaleSimpleList<Constant>();
+    public UndertaleSimpleList<Constant> Constants { get; set; } = new UndertaleSimpleList<Constant>();
 
     //TODO: not shown in GUI right now!!!
     public bool NewFormat { get; set; } = true;

--- a/UndertaleModLib/Models/UndertaleParticleSystem.cs
+++ b/UndertaleModLib/Models/UndertaleParticleSystem.cs
@@ -15,7 +15,7 @@ public class UndertaleParticleSystem : UndertaleNamedResource, IDisposable
 
     public int DrawOrder { get; set; }
 
-    public UndertaleSimpleResourcesList<UndertaleParticleSystemEmitter, UndertaleChunkPSEM> Emitters { get; private set; } = new();
+    public UndertaleSimpleResourcesList<UndertaleParticleSystemEmitter, UndertaleChunkPSEM> Emitters { get; set; } = new();
 
     /// <inheritdoc />
     public void Serialize(UndertaleWriter writer)

--- a/UndertaleModLib/Models/UndertalePath.cs
+++ b/UndertaleModLib/Models/UndertalePath.cs
@@ -33,7 +33,7 @@ public class UndertalePath : UndertaleNamedResource, IDisposable
     /// <summary>
     /// The amount of <see cref="PathPoint"/>s this <see cref="UndertalePath"/> has.
     /// </summary>
-    public UndertaleSimpleList<PathPoint> Points { get; private set; } = new UndertaleSimpleList<PathPoint>();
+    public UndertaleSimpleList<PathPoint> Points { get; set; } = new UndertaleSimpleList<PathPoint>();
 
     /// <summary>
     /// A point in a <see cref="UndertalePath"/>.

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -139,32 +139,32 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
     /// <summary>
     /// The list of backgrounds this room uses.
     /// </summary>
-    public UndertalePointerList<Background> Backgrounds { get; private set; } = new UndertalePointerList<Background>();
+    public UndertalePointerList<Background> Backgrounds { get; set; } = new UndertalePointerList<Background>();
 
     /// <summary>
     /// The list of views this room uses.
     /// </summary>
-    public UndertalePointerList<View> Views { get; private set; } = new UndertalePointerList<View>();
+    public UndertalePointerList<View> Views { get; set; } = new UndertalePointerList<View>();
 
     /// <summary>
     /// The list of game objects this room uses.
     /// </summary>
-    public UndertalePointerList<GameObject> GameObjects { get; private set; } = new UndertalePointerList<GameObject>();
+    public UndertalePointerList<GameObject> GameObjects { get; set; } = new UndertalePointerList<GameObject>();
 
     /// <summary>
     /// The list of tiles this room uses.
     /// </summary>
-    public UndertalePointerList<Tile> Tiles { get; private set; } = new UndertalePointerList<Tile>();
+    public UndertalePointerList<Tile> Tiles { get; set; } = new UndertalePointerList<Tile>();
 
     /// <summary>
     /// The list of layers this room uses. Used in Game Maker Studio: 2 only, as <see cref="Backgrounds"/> and <see cref="Tiles"/> are empty there.
     /// </summary>
-    public UndertalePointerList<Layer> Layers { get => _layers; private set { _layers = value; UpdateBGColorLayer(); OnPropertyChanged(); } }
+    public UndertalePointerList<Layer> Layers { get => _layers; set { _layers = value; UpdateBGColorLayer(); OnPropertyChanged(); } }
 
     /// <summary>
     /// The list of sequences this room uses.
     /// </summary>
-    public UndertaleSimpleList<UndertaleResourceById<UndertaleSequence, UndertaleChunkSEQN>> Sequences { get; private set; } = new UndertaleSimpleList<UndertaleResourceById<UndertaleSequence, UndertaleChunkSEQN>>();
+    public UndertaleSimpleList<UndertaleResourceById<UndertaleSequence, UndertaleChunkSEQN>> Sequences { get; set; } = new UndertaleSimpleList<UndertaleResourceById<UndertaleSequence, UndertaleChunkSEQN>>();
 
     public static bool CheckedForGMS2_2_2_302;
 
@@ -1583,8 +1583,8 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
 
         public class LayerInstancesData : LayerData
         {
-            internal uint[] InstanceIds { get; private set; } // 100000, 100001, 100002, 100003 - instance ids from GameObjects list in the room
-            public ObservableCollection<GameObject> Instances { get; private set; } = new();
+            internal uint[] InstanceIds { get; set; } // 100000, 100001, 100002, 100003 - instance ids from GameObjects list in the room
+            public ObservableCollection<GameObject> Instances { get; set; } = new();
 
             public bool AreInstancesUnresolved()
             {

--- a/UndertaleModLib/Models/UndertaleSprite.cs
+++ b/UndertaleModLib/Models/UndertaleSprite.cs
@@ -193,12 +193,12 @@ public class UndertaleSprite : UndertaleNamedResource, PrePaddedObject, INotifyP
     /// <summary>
     /// The frames of the sprite.
     /// </summary>
-    public UndertaleSimpleList<TextureEntry> Textures { get; private set; } = new UndertaleSimpleList<TextureEntry>();
+    public UndertaleSimpleList<TextureEntry> Textures { get; set; } = new UndertaleSimpleList<TextureEntry>();
 
     /// <summary>
     /// The collision masks of the sprite.
     /// </summary>
-    public ObservableCollection<MaskEntry> CollisionMasks { get; private set; } = new ObservableCollection<MaskEntry>();
+    public ObservableCollection<MaskEntry> CollisionMasks { get; set; } = new ObservableCollection<MaskEntry>();
 
     // Special sprite types (always used in GMS2)
     public uint SVersion { get; set; } = 1;


### PR DESCRIPTION
## Description
Change some lists to have a public setter.
AFAIK all of these have no reason to have a private setter. They make some code considerably more complicated, cause sometimes it is wished for to prepare some list in advance, and then just set it. Which is impossible with the private setter. E.g, I was unable to do `mySprite.Textures = GetAllTexturesForMySprite();`

