### PR TITLE
Fixes build errors originating from ModLibTests

### DIFF
--- a/UndertaleModTests/GameScriptTests.cs
+++ b/UndertaleModTests/GameScriptTests.cs
@@ -36,7 +36,7 @@ namespace UndertaleModTests
 
         public bool IsAppClosed => throw new NotImplementedException();
 
-        public void ChangeSelection(object newSelection)
+        public void ChangeSelection(object newSelection, bool inNewTab)
         {
         }
 


### PR DESCRIPTION
Fixed definition of ```GameScriptTestBase.ChangeSelection``` to include overload for optional argument ```inNewTab```

## Description
When trying to build **UndertaleModTool.sln** in Visual Studio 2022, the following error occurs:

```
CS0535	'GameScriptTestBase' does not implement interface member 'IScriptInterface.ChangeSelection(object, bool)'
```

This occurs because ModToolTests declares ```GameScriptTestBase.ChangeSelection``` with the optional argument ```inNewTab``` but the definition doesn't include this overload.

This change fixes the definition without changing functionality so **UndertaleModTool.sln** can be built without having to remove ModToolTests.

### Notes
Since ModToolTests isn't a necessary part of the core build and can contribute its own issues, it may be a better solution long term for it to be part of a separate **.sln** file, but this is a minimally-invasive fix that allow **UndertaleModTool.sln** to build as-is without errors for now,