### PR TITLE
Fix GMS2 runner discovery

### DIFF
--- a/UndertaleModTool/Settings.cs
+++ b/UndertaleModTool/Settings.cs
@@ -17,7 +17,7 @@ namespace UndertaleModTool
 
         public string Version { get; set; } = MainWindow.Version;
         public string GameMakerStudioPath { get; set; } = "%appdata%\\GameMaker-Studio";
-        public string GameMakerStudio2RuntimesPath { get; set; } = "%systemdrive%\\ProgramData\\GameMakerStudio2\\Cache\\runtimes"; /* Using %systemdrive% here fixes the runtimes not being found when the system drive is not C:\\ */
+        public string GameMakerStudio2RuntimesPath { get; set; } = "%ProgramData%\\GameMakerStudio2\\Cache\\runtimes";
         public bool AssetOrderSwappingEnabled { get; set; } = false;
         public bool ProfileModeEnabled { get; set; } = false;
         public bool UseGMLCache { get; set; } = false;

--- a/UndertaleModTool/Windows/RuntimePicker.xaml.cs
+++ b/UndertaleModTool/Windows/RuntimePicker.xaml.cs
@@ -102,6 +102,9 @@ namespace UndertaleModTool
                     continue;
 
                 string runtimeRunner = System.IO.Path.Combine(runtimePath, @"windows\Runner.exe");
+                string runtimeRunnerX64 = System.IO.Path.Combine(runtimePath, @"windows\x64\Runner.exe");
+                if (Environment.Is64BitOperatingSystem && File.Exists(runtimeRunnerX64))
+                    runtimeRunner = runtimeRunnerX64;
                 if (!File.Exists(runtimeRunner))
                     continue;
 


### PR DESCRIPTION
## Description
Current 2.3 runtimes seems to only provide x64 runners and under the `x64` subfolder, this makes the picker account for that subfolder.

Testcase:
- Install 2023.4 runtime through GM
- Open (for example) UTY v1.1.0
- Select File -> Run game with other runner
- Say "no" to saving

Before: UMT simply starts the game's EXE

After: You get to choose
![image](https://github.com/krzys-h/UndertaleModTool/assets/28653235/f2ccafef-9476-424e-a1fd-4b83f0bb243a)

The %systemdrive%\ProgramData (which looks weird) -> %ProgramData% is simply a by-the-way thing. Windows does have a environment variable for it so why?

### Notes
In accordance to https://discord.com/channels/566861759210586112/586954521880690690/1191016299829133342