### PR TITLE
Clean up Double<->String Round trip

### DIFF
--- a/UndertaleModLib/Decompiler/Instructions/Decompiler.ExpressionConstant.cs
+++ b/UndertaleModLib/Decompiler/Instructions/Decompiler.ExpressionConstant.cs
@@ -74,7 +74,7 @@ public static partial class Decompiler
         public override string ToString(DecompileContext context)
         {
             if (Value is float f) // More accurate, larger range, double to string.
-                return RoundTrip.ToRoundTrip(f);
+                return DoubleToString.StringOf(f);
 
             if (Value is Int64 i && i <= int.MaxValue && i >= int.MinValue) // Decompiler accuracy improvement.
             {
@@ -82,7 +82,7 @@ public static partial class Decompiler
             }
 
             if (Value is double d) // More accurate, larger range, double to string.
-                return RoundTrip.ToRoundTrip(d);
+                return DoubleToString.StringOf(d);
 
             if (Value is Statement statement)
                 return statement.ToString(context);


### PR DESCRIPTION
## Description
This cleans up the Double<->String round trip to be more readable, less memory consuming and more performant.

### Notes
I haven't actually ran any benchmarks cause lazy. Originally wanted to do something else, but got sniped by this instead.

Code should be self explanatory with the comments. The only thing that might be unexplained is:
- We don't need to check for a lowercase 'e'. As per MSDN: 
  > If scientific notation is used, the exponent in the result is prefixed with "E" if the format specifier is "G", or "e" if the format specifier is "g"
- We use G17 instead of R because MSDN recommends it and it's supposedly faster.

I did test this against the original unit test from that stackoverflow post, my reimplementation passed.