### PR TITLE
Fix brackets not being placed in some conditions

### DIFF
--- a/UndertaleModLib/Decompiler/Instructions/Decompiler.ExpressionCompare.cs
+++ b/UndertaleModLib/Decompiler/Instructions/Decompiler.ExpressionCompare.cs
@@ -29,12 +29,7 @@ public static partial class Decompiler
         {
             string arg1 = Argument1.ToString(context);
             string arg2 = Argument2.ToString(context);
-            return String.Format("({0} {1} {2})", arg1, OperationToPrintableString(Opcode), arg2);
-        }
-
-        public string ToStringWithParen(DecompileContext context)
-        {
-            return "(" + ToString(context) + ")";
+            return $"({arg1} {OperationToPrintableString(Opcode)} {arg2})";
         }
 
         public override Statement CleanStatement(DecompileContext context, BlockHLStatement block)

--- a/UndertaleModLib/Decompiler/Instructions/Decompiler.IfHLStatement.cs
+++ b/UndertaleModLib/Decompiler/Instructions/Decompiler.IfHLStatement.cs
@@ -145,20 +145,13 @@ public static partial class Decompiler
         public override string ToString(DecompileContext context)
         {
             StringBuilder sb = new StringBuilder();
-            string cond;
-            if (condition is ExpressionCompare)
-                cond = (condition as ExpressionCompare).ToStringWithParen(context);
-            else
-                cond = condition.ToString(context);
+            string cond = condition.ToString(context);
             sb.Append("if " + cond + "\n");
             sb.Append(context.Indentation + trueBlock.ToString(context));
 
             foreach (ValueTuple<Expression, BlockHLStatement> tuple in elseConditions)
             {
-                if (tuple.Item1 is ExpressionCompare)
-                    cond = (tuple.Item1 as ExpressionCompare).ToStringWithParen(context);
-                else
-                    cond = tuple.Item1.ToString(context);
+                cond = tuple.Item1.ToString(context);
                 sb.Append("\n" + context.Indentation + "else if " + cond + "\n");
                 sb.Append(context.Indentation + tuple.Item2.ToString(context));
             }

--- a/UndertaleModLib/Decompiler/Instructions/Decompiler.LoopHLStatement.cs
+++ b/UndertaleModLib/Decompiler/Instructions/Decompiler.LoopHLStatement.cs
@@ -130,12 +130,12 @@ public static partial class Decompiler
             }
 
             string cond;
-            if (Condition is ExpressionCompare)
-                cond = (Condition as ExpressionCompare).ToStringWithParen(context);
+            if (Condition is ExpressionCompare compare)
+                cond = compare.ToString(context);
             else if (IsDoUntilLoop)
                 cond = Condition?.ToString(context) ?? "(false)";
             else
-                cond = Condition != null ? Condition.ToString(context) : "(true)";
+                cond = Condition is not null ? Condition.ToString(context) : "(true)";
 
             if (IsDoUntilLoop)
                 return "do\n" + context.Indentation + Block.ToString(context, false) + " until " + cond + ";";


### PR DESCRIPTION
## Description
This fixes the decompiler not placing brackets in some conditions, thus leading to inaccurate results when recompiling back. Fixes #1032

### Caveats
None to my knowledge

### Notes
I only tested this with AM2R.